### PR TITLE
fix: clean up EcoVent entities and fan controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,3 +190,21 @@ Version 1.2.4
 * Merge pull request #40 from AndyNew2
 ** added weekly_schedule_state on request
 ** Add weekly schedule state to VentoSwitch
+
+Version 1.2.5
+* Clean up Home Assistant entity names and categories
+* Move multi-state statuses from binary sensors to enum sensors
+* Expose observed beeper flag as a read-only diagnostic sensor
+* Add Airflow enum state translations for cleaner UI labels
+* Add fan attribute translations so the built-in direction/oscillation controls
+  read as Airflow and Heat recovery
+* Add Off as a Home Assistant pseudo preset mode that turns the fan off
+* Skip unchanged fan commands so automations can set desired final states
+  without re-sending already-active state, preset, direction, heat recovery, or
+  manual percentage writes
+* Switch to manual speed automatically when setting the fan percentage directly
+* Keep preset percentage synchronized from the device-reported low/medium/high
+  supply/exhaust setpoints instead of hiding it outside manual mode
+* Document live TwinFresh V.2 beeper testing: writing `0x0306=00` or `0x0306=02`
+  did not disable command beeps reliably on the tested device, so the integration
+  does not expose a writable beeper control.

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -4,21 +4,24 @@
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import (
+    CONF_IP_ADDRESS,
+    CONF_NAME,
+    CONF_PASSWORD,
+    CONF_PORT,
+    EVENT_HOMEASSISTANT_STARTED,
+    PERCENTAGE,
+    Platform,
+    REVOLUTIONS_PER_MINUTE,
+)
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
+from homeassistant.util import slugify
 
 from .const import DOMAIN, UPDATE_INTERVAL
 from .coordinator import EcoVentCoordinator
 
 _LOGGER = logging.getLogger(__name__)
-
-from homeassistant.const import (
-    CONF_DEVICE_ID,
-    CONF_IP_ADDRESS,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-)
 
 _PLATFORMS: list[Platform] = [
     Platform.SENSOR,
@@ -27,6 +30,156 @@ _PLATFORMS: list[Platform] = [
     Platform.NUMBER,
     Platform.FAN,
 ]
+
+_STATISTICS_UNIT_MIGRATIONS = {
+    "fan_1_speed": REVOLUTIONS_PER_MINUTE,
+    "fan_2_speed": REVOLUTIONS_PER_MINUTE,
+    "timer_counter": "h",
+    "battery": PERCENTAGE,
+    "filter_change_in": "h",
+    "machine_hours": "h",
+}
+
+
+def _async_migrate_entity_registry(
+    hass: HomeAssistant, coordinator: EcoVentCoordinator
+) -> None:
+    """Move legacy entities to clearer domains and ids."""
+    registry = er.async_get(hass)
+    fan = coordinator._fan
+    device_slug = slugify(fan.name)
+
+    stale_binary_unique_ids = (
+        fan.id + "_boost_status",
+        fan.id + "_timer_mode",
+        fan.id + "_alarm_status",
+    )
+    for unique_id in stale_binary_unique_ids:
+        entity_id = registry.async_get_entity_id(
+            Platform.BINARY_SENSOR, DOMAIN, unique_id
+        )
+        if entity_id is not None:
+            registry.async_remove(entity_id)
+            _LOGGER.info("Removed legacy EcoVent V2 binary sensor %s", entity_id)
+
+    beeper_select_entity_id = registry.async_get_entity_id(
+        Platform.SELECT, DOMAIN, fan.id + "_beeper"
+    )
+    if beeper_select_entity_id is not None:
+        registry.async_remove(beeper_select_entity_id)
+        _LOGGER.info(
+            "Removed writable EcoVent V2 beeper select %s", beeper_select_entity_id
+        )
+
+    entity_id_migrations = {
+        (Platform.SENSOR, fan.id + "_speed1"): f"sensor.{device_slug}_fan_1_speed",
+        (Platform.SENSOR, fan.id + "_speed2"): f"sensor.{device_slug}_fan_2_speed",
+        (
+            Platform.SENSOR,
+            fan.id + "_filter_change_in",
+        ): f"sensor.{device_slug}_filter_change_in",
+        (
+            Platform.SWITCH,
+            fan.id + "_humidity_sensor_state",
+        ): f"switch.{device_slug}_humidity_sensor",
+        (
+            Platform.SWITCH,
+            fan.id + "_relay_sensor_state",
+        ): f"switch.{device_slug}_relay_sensor",
+        (
+            Platform.SWITCH,
+            fan.id + "_analogV_sensor_state",
+        ): f"switch.{device_slug}_analog_voltage_sensor",
+        (
+            Platform.NUMBER,
+            fan.id + "humidity_treshold",
+        ): f"number.{device_slug}_humidity_threshold",
+        (
+            Platform.NUMBER,
+            fan.id + "analogV_treshold",
+        ): f"number.{device_slug}_analog_voltage_threshold",
+    }
+    for (domain, unique_id), new_entity_id in entity_id_migrations.items():
+        entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
+        if entity_id is None or entity_id == new_entity_id:
+            continue
+
+        existing = registry.async_get(new_entity_id)
+        if existing is not None and existing.unique_id != unique_id:
+            _LOGGER.debug(
+                "Skipping EcoVent V2 entity id migration for %s: %s already exists",
+                entity_id,
+                new_entity_id,
+            )
+            continue
+
+        registry.async_update_entity(entity_id, new_entity_id=new_entity_id)
+        _LOGGER.info("Migrated EcoVent V2 entity id %s to %s", entity_id, new_entity_id)
+
+
+async def _async_migrate_statistics_metadata(
+    hass: HomeAssistant, coordinator: EcoVentCoordinator
+) -> None:
+    """Update historic statistics units after adding explicit sensor units."""
+    try:
+        from homeassistant.components.recorder.statistics import (
+            async_list_statistic_ids,
+            async_update_statistics_metadata,
+        )
+    except ImportError:
+        _LOGGER.debug("Recorder statistics unavailable; skipping EcoVent V2 migration")
+        return
+
+    fan = coordinator._fan
+    device_slug = slugify(fan.name)
+    statistic_units = {
+        f"sensor.{device_slug}_{suffix}": unit
+        for suffix, unit in _STATISTICS_UNIT_MIGRATIONS.items()
+    }
+
+    try:
+        statistics = await async_list_statistic_ids(hass, set(statistic_units))
+    except Exception as err:  # noqa: BLE001
+        _LOGGER.debug("Unable to inspect EcoVent V2 statistics metadata: %s", err)
+        return
+
+    for statistic in statistics:
+        statistic_id = statistic.get("statistic_id")
+        new_unit = statistic_units.get(statistic_id)
+        if new_unit is None:
+            continue
+
+        old_unit = statistic.get("unit_of_measurement")
+        if old_unit == new_unit:
+            continue
+
+        async_update_statistics_metadata(
+            hass,
+            statistic_id,
+            new_unit_class=None,
+            new_unit_of_measurement=new_unit,
+        )
+        _LOGGER.info(
+            "Migrated EcoVent V2 statistics unit for %s from %s to %s",
+            statistic_id,
+            old_unit,
+            new_unit,
+        )
+
+
+async def _async_migrate_statistics_metadata_on_start(
+    hass: HomeAssistant, coordinator: EcoVentCoordinator
+) -> None:
+    """Run statistics migration now and again after recorder startup."""
+    await _async_migrate_statistics_metadata(hass, coordinator)
+
+    async def _async_run_at_start(_event) -> None:
+        await _async_migrate_statistics_metadata(hass, coordinator)
+
+    hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STARTED,
+        lambda event: hass.async_create_task(_async_run_at_start(event)),
+    )
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -41,12 +194,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         UPDATE_INTERVAL: entry.data.get(UPDATE_INTERVAL, 30),
     }
 
-    coordinator = EcoVentCoordinator(hass, entry, update_seconds=entry.runtime_data[UPDATE_INTERVAL])
+    coordinator = EcoVentCoordinator(
+        hass, entry, update_seconds=entry.runtime_data[UPDATE_INTERVAL]
+    )
 
     await coordinator.async_config_entry_first_refresh()
 
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coordinator
+    _async_migrate_entity_registry(hass, coordinator)
+    await _async_migrate_statistics_metadata_on_start(hass, coordinator)
     await hass.config_entries.async_forward_entry_setups(entry, _PLATFORMS)
     return True
 

--- a/custom_components/ecovent_v2/binary_sensor.py
+++ b/custom_components/ecovent_v2/binary_sensor.py
@@ -9,6 +9,7 @@ from homeassistant.components.binary_sensor import (
     BinarySensorEntity,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -32,36 +33,50 @@ async def async_setup_entry(
     async_add_entities(
         [
             VentoBinarySensor(
-                hass, config, "_boost_status", "boost_status", False, None
-            ),
-            VentoBinarySensor(hass, config, "_timer_mode", "timer_mode", False, None),
-            VentoBinarySensor(
-                hass, config, "_relay_status", "relay_status", False, None
+                hass,
+                config,
+                "_relay_status",
+                "Relay status",
+                "relay_status",
+                False,
+                "mdi:electric-switch",
             ),
             VentoBinarySensor(
                 hass,
                 config,
                 "_filter_replacement_status",
+                "Filter replacement required",
                 "filter_replacement_status",
                 True,
-                None,
-            ),
-            VentoBinarySensor(
-                hass, config, "_alarm_status", "alarm_status", True, None
+                "mdi:air-filter",
+                BinarySensorDeviceClass.PROBLEM,
             ),
             VentoBinarySensor(
                 hass,
                 config,
                 "_cloud_server_state",
+                "Cloud server",
                 "cloud_server_state",
                 False,
-                None,
+                "mdi:cloud-check-outline",
             ),
             VentoBinarySensor(
-                hass, config, "_humidity_status", "humidity_status", False, None
+                hass,
+                config,
+                "_humidity_status",
+                "Humidity status",
+                "humidity_status",
+                False,
+                "mdi:water-alert-outline",
             ),
             VentoBinarySensor(
-                hass, config, "_analogV_status", "analogV_status", False, None
+                hass,
+                config,
+                "_analogV_status",
+                "Analog voltage status",
+                "analogV_status",
+                False,
+                "mdi:flash-alert-outline",
             ),
         ]
     )
@@ -70,26 +85,31 @@ async def async_setup_entry(
 class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEntity
     """Vento Binary Sensor class."""
 
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+
     def __init__(
         self,
         hass: HomeAssistant,
         config: ConfigEntry,
-        name="VentoBinarySensor",
+        key="VentoBinarySensor",
+        name=None,
         method=None,
         enable_by_default: bool = False,
         icon: str | None = "",
-        device_class=BinarySensorDeviceClass,
+        device_class: BinarySensorDeviceClass | None = None,
     ) -> None:
         """Initialize fan binary sensors."""
         coordinator: EcoVentCoordinator = hass.data[DOMAIN][config.entry_id]
         super().__init__(coordinator)
         self._fan: Fan = coordinator._fan
-        self._attr_unique_id = self._fan.id + name
-        self._attr_name = self._fan.name + name
+        self._attr_unique_id = self._fan.id + key
+        self._attr_name = name
         self._state = None
-        self._sensor_type = device_class
+        self._attr_device_class = device_class
         self._attr_entity_registry_enabled_default = enable_by_default
-        self._attribute = getattr(self._fan, method)
+        self._method = method
         self._attr_icon = icon
 
         self._attr_device_info = DeviceInfo(
@@ -99,7 +119,7 @@ class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEn
     @property
     def is_on(self):
         """Is on."""
-        self._state = self._attribute == "on"
+        self._state = getattr(self._fan, self._method) == "on"
         # self.async_write_ha_state() dangerous not allowed
         # self.schedule_update_ha_state() # not needed
         # _LOGGER.debug(f"VentoBinarySensor: {self._attr_name} state updated to {self._state}")

--- a/custom_components/ecovent_v2/config_flow.py
+++ b/custom_components/ecovent_v2/config_flow.py
@@ -10,7 +10,6 @@ import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
 from homeassistant.const import (
-    CONF_DEVICE_ID,
     CONF_IP_ADDRESS,
     CONF_NAME,
     CONF_PASSWORD,
@@ -53,7 +52,9 @@ class VentoHub:
         self.fan = Fan(self.host, password, self.fan_id, self.name, self.port)
         await hass.async_add_executor_job(self.fan.init_device)
         self.fan_id = self.fan.id
-        _LOGGER.info("Config Flow: Authenticated fan with name:%s ID: %s", self.name, self.fan_id)
+        _LOGGER.info(
+            "Config Flow: Authenticated fan with name:%s ID: %s", self.name, self.fan_id
+        )
         if self.fan_id is not None:
             self.name = self.name + " " + self.fan_id
         return (
@@ -78,7 +79,10 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
 
     hub = VentoHub(
         # data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_DEVICE_ID], data[CONF_NAME]
-        data[CONF_IP_ADDRESS], data[CONF_PORT], "DEFAULT_DEVICEID", data[CONF_NAME]
+        data[CONF_IP_ADDRESS],
+        data[CONF_PORT],
+        "DEFAULT_DEVICEID",
+        data[CONF_NAME],
     )
 
     if not await hub.authenticate(hass, data[CONF_PASSWORD]):
@@ -166,7 +170,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
-    ) -> ConfigFlowResult:
+    ) -> FlowResult:
         """Handle reconfigure step."""
         errors: dict[str, str] = {}
 

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -8,7 +8,6 @@ from .ecoventv2 import Fan
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
-    CONF_DEVICE_ID,
     CONF_IP_ADDRESS,
     CONF_NAME,
     CONF_PASSWORD,
@@ -81,4 +80,3 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         else:
             _LOGGER.debug("EcoVentCoordinator: Starting quick data update...")
             await self.hass.async_add_executor_job(self._fan.quick_update)
-

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -1,13 +1,12 @@
-"""Version"""
+"""Library to handle communication with Wifi ecofan from TwinFresh / Blauberg."""
 
-__version__ = "loc_0.9.29"
-
-"""Library to handle communication with Wifi ecofan from TwinFresh / Blauberg"""
+import logging
+import math
 import socket
 import sys
 import time
-import math
-import logging
+
+__version__ = "loc_0.9.29"
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -77,13 +76,10 @@ Sw used for switch
 """
 
 
-
-
-
 class Fan(object):
     """Class to communicate with the ecofan"""
 
-    HEADER = f"FDFD"
+    HEADER = "FDFD"
 
     func = {
         "read": "01",
@@ -102,7 +98,9 @@ class Fan(object):
 
     statuses = {0: "off", 1: "on"}
 
-    bstatuses = {0: "off", 1: "on", 2: "silent"}  # for beeper, values unknown
+    # Observed on a TwinFresh V.2 as a volatile command/status flag, not a stable
+    # beeper preference. Writing 0 or 2 did not disable command beeps reliably.
+    bstatuses = {0: "off", 1: "on", 2: "silent"}
 
     boost_statuses = {0: "off", 1: "on", 2: "delay"}
 
@@ -143,7 +141,7 @@ class Fan(object):
     params = {
         0x0001: ["state", states],
         0x0002: ["speed", speeds],
-        0x0006: ["boost_status", statuses],
+        0x0006: ["boost_status", boost_statuses],
         0x0007: ["timer_mode", timer_modes],
         0x000B: ["timer_counter", None],
         0x000F: ["humidity_sensor_state", states],
@@ -154,17 +152,24 @@ class Fan(object):
         0x0025: ["humidity", None],
         0x002D: ["analogV", None],
         0x0032: ["relay_status", statuses],
+        0x003A: ["supply_speed_low", None],
+        0x003B: ["exhaust_speed_low", None],
+        0x003C: ["supply_speed_medium", None],
+        0x003D: ["exhaust_speed_medium", None],
+        0x003E: ["supply_speed_high", None],
+        0x003F: ["exhaust_speed_high", None],
         0x0044: ["man_speed", None],
         0x004A: ["fan1_speed", None],
         0x004B: ["fan2_speed", None],
+        0x0063: ["filter_timer_setpoint", None],
         0x0064: ["filter_timer_countdown", None],
         0x0066: ["boost_time", None],
-     #   0x006F: ["rtc_time", None],  according stats not used in integration
-     #   0x0070: ["rtc_date", None],  according stats not used in integration
+        #   0x006F: ["rtc_time", None],  according stats not used in integration
+        #   0x0070: ["rtc_date", None],  according stats not used in integration
         0x007C: ["device_search", None],  # this is the fan serial number
-     #   0x007D: ["device_password", None],  according stats not used in integration
+        #   0x007D: ["device_password", None],  according stats not used in integration
         0x007E: ["machine_hours", None],
-     #   0x0081: ["heater_status", statuses], according stats not used in integration
+        #   0x0081: ["heater_status", statuses], according stats not used in integration
         0x0083: ["alarm_status", alarms],
         0x0085: ["cloud_server_state", states],
         0x0086: ["firmware", None],
@@ -173,29 +178,30 @@ class Fan(object):
         0x00B7: ["airflow", airflows],
         0x00B8: ["analogV_treshold", None],
         0x00B9: ["unit_type", unit_types],
-        # Write only parameters
-        0x0065: ["filter_timer_reset", None],  # WRITE ONLY
         0x0072: ["weekly_schedule_state", states],
-     #   0x0077: ["weekly_schedule_setup", None], according stats not used in integration
-        0x0080: ["reset_alarms", None],  # WRITE ONLY
+        #   0x0077: ["weekly_schedule_setup", None], according stats not used in integration
         #        0x0087: [ 'factory_reset', None ],
         #        0x00a0: [ 'wifi_apply_and_quit', None ],
         #        0x00a2: [ 'wifi_discard_and_quit', None ],
-      #  0x0094: ["wifi_operation_mode", wifi_operation_modes],  according stats not used in integration
-      #  # 0x0095: ["wifi_name", None],  # propose not to transfer this data over network   according stats not used in integration
-      #  # 0x0096: ["wifi_pasword", None], # propose not to transfer this data over network  according stats not used in integration
-      #  # 0x0099: ["wifi_enc_type", wifi_enc_types], # propose not to transfer this data over network  according stats not used in integration
-      #  0x009A: ["wifi_freq_channel", None],  according stats not used in integration
-      #  0x009B: ["wifi_dhcp", wifi_dhcps],  according stats not used in integration
+        #  0x0094: ["wifi_operation_mode", wifi_operation_modes],  according stats not used in integration
+        #  # 0x0095: ["wifi_name", None],  # propose not to transfer this data over network   according stats not used in integration
+        #  # 0x0096: ["wifi_pasword", None], # propose not to transfer this data over network  according stats not used in integration
+        #  # 0x0099: ["wifi_enc_type", wifi_enc_types], # propose not to transfer this data over network  according stats not used in integration
+        #  0x009A: ["wifi_freq_channel", None],  according stats not used in integration
+        #  0x009B: ["wifi_dhcp", wifi_dhcps],  according stats not used in integration
         0x009C: ["wifi_assigned_ip", None],
-      #  0x009D: ["wifi_assigned_netmask", None],  according stats not used in integration
-      #  0x009E: ["wifi_main_gateway", None],  according stats not used in integration
-      #  0x0302: ["night_mode_timer", None],  according stats not used in integration
-      #  0x0303: ["party_mode_timer", None],  according stats not used in integration
+        #  0x009D: ["wifi_assigned_netmask", None],  according stats not used in integration
+        #  0x009E: ["wifi_main_gateway", None],  according stats not used in integration
+        0x0302: ["night_mode_timer", None],
+        0x0303: ["party_mode_timer", None],
         0x0304: ["humidity_status", statuses],
         0x0305: ["analogV_status", statuses],
-      #  0x0306: ["beeper", bstatuses]        # beeper seems not to work on V2 eco vents, needs firmware 1.xxx or higher
-         #  beeper according stats not used in integration
+        0x0306: ["beeper", bstatuses],
+    }
+
+    write_params = {
+        0x0065: ["filter_timer_reset", None],
+        0x0080: ["reset_alarms", None],
     }
 
     _name = None
@@ -217,9 +223,16 @@ class Fan(object):
     _humidity = None
     _analogV = None
     _relay_status = None
+    _supply_speed_low = None
+    _exhaust_speed_low = None
+    _supply_speed_medium = None
+    _exhaust_speed_medium = None
+    _supply_speed_high = None
+    _exhaust_speed_high = None
     _man_speed = None
     _fan1_speed = None
     _fan2_speed = None
+    _filter_timer_setpoint = None
     _filter_timer_countdown = None
     _boost_time = None
     _rtc_time = None
@@ -251,6 +264,7 @@ class Fan(object):
     _humidity_status = None
     _analogV_status = None
     _beeper = None
+    _unknown_params = None
 
     def __init__(
         self,
@@ -267,6 +281,7 @@ class Fan(object):
         self._id = fan_id
         self._pwd_size = 0
         self._password = password
+        self._unknown_params = {}
 
     def init_device(self):
         if self._id == "DEFAULT_DEVICEID":
@@ -348,17 +363,19 @@ class Fan(object):
         return str
 
     def get_params_index(self, value):
-        for i in self.params:
-            if self.params[i][0] == value:
-                return i
+        for params in (self.params, self.write_params):
+            for i in params:
+                if params[i][0] == value:
+                    return i
 
     def get_params_values(self, idx, value):
         # print ( "EcoventV2: " + idx,  file = sys.stderr )
         index = self.get_params_index(idx)
-        if index != None:
-            if self.params[index][1] != None:
-                for i in self.params[index][1]:
-                    if self.params[index][1][i] == value:
+        if index is not None:
+            param = self.params.get(index) or self.write_params.get(index)
+            if param[1] is not None:
+                for i in param[1]:
+                    if param[1][i] == value:
                         return [index, i]
             return [index, None]
         else:
@@ -458,11 +475,15 @@ class Fan(object):
         # 0x0305: ["analogV_status", statuses],
         return self.do_func(self.func["read"], request)
 
+    def update_preset_speed_settings(self):
+        request = "003A003B003C003D003E003F"
+        return self.do_func(self.func["read"], request)
+
     def set_param(self, param, value):
         valpar = self.get_params_values(param, value)
         # print ( "EcoventV2: " + " " + param + "/" + value , file = sys.stderr )
-        if valpar[0] != None:
-            if valpar[1] != None:
+        if valpar[0] is not None:
+            if valpar[1] is not None:
                 self.do_func(
                     self.func["write_return"],
                     hex(valpar[0]).replace("0x", "").zfill(4),
@@ -477,7 +498,7 @@ class Fan(object):
 
     def get_param(self, param):
         idx = self.get_params_index(param)
-        if idx != None:
+        if idx is not None:
             #  _LOGGER.debug(f"Getting parameter {param} with index {idx}")
             self.do_func(self.func["read"], hex(idx).replace("0x", "").zfill(4))
 
@@ -527,6 +548,28 @@ class Fan(object):
             value = hex(val).replace("0x", "").zfill(2)
             self.do_func(self.func["write_return"], request, value)
 
+    def _handle_param_response(self, param_id, value):
+        param = self.params.get(param_id)
+        if param is None:
+            self.unknown_params[param_id] = value
+            _LOGGER.debug(
+                "EcoventV2: skipping unknown parameter 0x%04x=%s",
+                param_id,
+                value,
+            )
+            return
+
+        if value is None:
+            _LOGGER.debug(
+                "EcoventV2: skipping no-value parameter 0x%04x (%s)",
+                param_id,
+                param[0],
+            )
+            return
+
+        setattr(self, param[0], value)
+        # _LOGGER.debug(f"Updated parameter {param[0]} with value {value}")
+
     def parse_response(self, data):
         pointer = 20  # discard header bytes
         length = len(data) - 2
@@ -561,7 +604,12 @@ class Fan(object):
                     value_counter = p
                     ext_function = 2
                 elif ext_function == 0xFD:
-                    None
+                    self._handle_param_response(p, None)
+                    ext_function = 0
+                    parameter = 1
+                    value_counter = 1
+                    high_byte_value = 0
+                    response = bytearray()
                 else:
                     if parameter == 1:
                         # print ("appending: " + hex(high_byte_value))
@@ -575,8 +623,9 @@ class Fan(object):
                 parameter = 1
                 value_counter = 1
                 high_byte_value = 0
-                setattr(self, self.params[int(response[:2].hex(), 16)][0], response[2:].hex() )
-                # _LOGGER.debug(f"Updated parameter {self.params[int(response[:2].hex(), 16)][0]} with value {response[2:].hex()}")
+                param_id = int(response[:2].hex(), 16)
+                value = response[2:].hex()
+                self._handle_param_response(param_id, value)
                 response = bytearray()
 
     @property
@@ -629,7 +678,7 @@ class Fan(object):
 
     @state.setter
     def state(self, val):
-        self._state = self.states.get(int(val),"Unknown %s" % val)
+        self._state = self.states.get(int(val), "Unknown %s" % val)
 
     @property
     def speed(self):
@@ -638,7 +687,7 @@ class Fan(object):
     @speed.setter
     def speed(self, input):
         val = int(input, 16)
-        self._speed = self.speeds.get(val,"Unknown %s" % val)
+        self._speed = self.speeds.get(val, "Unknown %s" % val)
 
     @property
     def boost_status(self):
@@ -750,7 +799,84 @@ class Fan(object):
     @relay_status.setter
     def relay_status(self, input):
         val = int(input, 16)
-        self._relay_status = self.statuses.get(val,"Unknown %s" % val)
+        self._relay_status = self.statuses.get(val, "Unknown %s" % val)
+
+    def _preset_speed_percent(self, input):
+        val = int(input, 16)
+        if val >= 0 and val <= 255:
+            return int(val / 255 * 100)
+        return None
+
+    @property
+    def supply_speed_low(self):
+        return self._supply_speed_low
+
+    @supply_speed_low.setter
+    def supply_speed_low(self, input):
+        self._supply_speed_low = self._preset_speed_percent(input)
+
+    @property
+    def exhaust_speed_low(self):
+        return self._exhaust_speed_low
+
+    @exhaust_speed_low.setter
+    def exhaust_speed_low(self, input):
+        self._exhaust_speed_low = self._preset_speed_percent(input)
+
+    @property
+    def supply_speed_medium(self):
+        return self._supply_speed_medium
+
+    @supply_speed_medium.setter
+    def supply_speed_medium(self, input):
+        self._supply_speed_medium = self._preset_speed_percent(input)
+
+    @property
+    def exhaust_speed_medium(self):
+        return self._exhaust_speed_medium
+
+    @exhaust_speed_medium.setter
+    def exhaust_speed_medium(self, input):
+        self._exhaust_speed_medium = self._preset_speed_percent(input)
+
+    @property
+    def supply_speed_high(self):
+        return self._supply_speed_high
+
+    @supply_speed_high.setter
+    def supply_speed_high(self, input):
+        self._supply_speed_high = self._preset_speed_percent(input)
+
+    @property
+    def exhaust_speed_high(self):
+        return self._exhaust_speed_high
+
+    @exhaust_speed_high.setter
+    def exhaust_speed_high(self, input):
+        self._exhaust_speed_high = self._preset_speed_percent(input)
+
+    def preset_speed_percent(self, preset):
+        preset_speeds = {
+            "low": (self.supply_speed_low, self.exhaust_speed_low),
+            "medium": (self.supply_speed_medium, self.exhaust_speed_medium),
+            "high": (self.supply_speed_high, self.exhaust_speed_high),
+        }
+        preset_speed = preset_speeds.get(preset)
+        if preset_speed is None:
+            return self.man_speed
+
+        supply_speed, exhaust_speed = preset_speed
+        if self.airflow == "air_supply" and supply_speed is not None:
+            return supply_speed
+        if self.airflow == "ventilation" and exhaust_speed is not None:
+            return exhaust_speed
+
+        available_speeds = [
+            speed for speed in (supply_speed, exhaust_speed) if speed is not None
+        ]
+        if available_speeds:
+            return int(sum(available_speeds) / len(available_speeds))
+        return self.man_speed
 
     @property
     def man_speed(self):
@@ -783,6 +909,15 @@ class Fan(object):
             int(input, 16).to_bytes(2, "big"), byteorder="little", signed=False
         )
         self._fan2_speed = str(val)
+
+    @property
+    def filter_timer_setpoint(self):
+        return self._filter_timer_setpoint
+
+    @filter_timer_setpoint.setter
+    def filter_timer_setpoint(self, input):
+        val = int.from_bytes(bytes.fromhex(input), byteorder="little", signed=False)
+        self._filter_timer_setpoint = str(val) + " d"
 
     @property
     def filter_timer_countdown(self):
@@ -840,7 +975,7 @@ class Fan(object):
 
     @weekly_schedule_state.setter
     def weekly_schedule_state(self, val):
-        self._weekly_schedule_state = self.states.get(int(val),"Unknown %s" % val)
+        self._weekly_schedule_state = self.states.get(int(val), "Unknown %s" % val)
 
     @property
     def weekly_schedule_setup(self):
@@ -900,7 +1035,7 @@ class Fan(object):
     @alarm_status.setter
     def alarm_status(self, input):
         val = int(input, 16)
-        self._alarm_status = self.alarms.get(val,"Unknown %s" % val)
+        self._alarm_status = self.alarms.get(val, "Unknown %s" % val)
 
     @property
     def cloud_server_state(self):
@@ -909,7 +1044,7 @@ class Fan(object):
     @cloud_server_state.setter
     def cloud_server_state(self, input):
         val = int(input, 16)
-        self._cloud_server_state = self.states.get(val,"Unknown %s" % val)
+        self._cloud_server_state = self.states.get(val, "Unknown %s" % val)
 
     @property
     def firmware(self):
@@ -937,7 +1072,7 @@ class Fan(object):
     @filter_replacement_status.setter
     def filter_replacement_status(self, input):
         val = int(input, 16)
-        self._filter_replacement_status = self.statuses.get(val,"Unknown %s" % val)
+        self._filter_replacement_status = self.statuses.get(val, "Unknown %s" % val)
 
     @property
     def wifi_operation_mode(self):
@@ -946,7 +1081,9 @@ class Fan(object):
     @wifi_operation_mode.setter
     def wifi_operation_mode(self, input):
         val = int(input, 16)
-        self._wifi_operation_mode = self.wifi_operation_modes.get(val,"Unknown %s" % val)
+        self._wifi_operation_mode = self.wifi_operation_modes.get(
+            val, "Unknown %s" % val
+        )
 
     @property
     def wifi_name(self):
@@ -971,7 +1108,7 @@ class Fan(object):
     @wifi_enc_type.setter
     def wifi_enc_type(self, input):
         val = int(input, 16)
-        self._wifi_enc_type = self.wifi_enc_types.get(val,"Unknown %s" % val)
+        self._wifi_enc_type = self.wifi_enc_types.get(val, "Unknown %s" % val)
 
     @property
     def wifi_freq_channel(self):
@@ -989,7 +1126,7 @@ class Fan(object):
     @wifi_dhcp.setter
     def wifi_dhcp(self, input):
         val = int(input, 16)
-        self._wifi_dhcp = self.wifi_dhcps.get(val,"Unknown %s" % val)
+        self._wifi_dhcp = self.wifi_dhcps.get(val, "Unknown %s" % val)
 
     @property
     def wifi_assigned_ip(self):
@@ -1042,7 +1179,7 @@ class Fan(object):
     @airflow.setter
     def airflow(self, input):
         val = int(input, 16)
-        self._airflow = self.airflows.get(val,"Unknown %s" % val)
+        self._airflow = self.airflows.get(val, "Unknown %s" % val)
 
     @property
     def analogV_treshold(self):
@@ -1091,7 +1228,7 @@ class Fan(object):
     @humidity_status.setter
     def humidity_status(self, input):
         val = int(input, 16)
-        self._humidity_status = self.statuses.get(val,"Unknown %s" % val)
+        self._humidity_status = self.statuses.get(val, "Unknown %s" % val)
 
     @property
     def analogV_status(self):
@@ -1100,7 +1237,7 @@ class Fan(object):
     @analogV_status.setter
     def analogV_status(self, input):
         val = int(input, 16)
-        self._analogV_status = self.statuses.get(val,"Unknown %s" % val)
+        self._analogV_status = self.statuses.get(val, "Unknown %s" % val)
 
     @property
     def beeper(self):
@@ -1109,7 +1246,11 @@ class Fan(object):
     @beeper.setter
     def beeper(self, input):
         val = int(input, 16)
-        self._beeper = self.bstatuses.get(val,"Unknown %s" % val)
+        self._beeper = self.bstatuses.get(val, "Unknown %s" % val)
+
+    @property
+    def unknown_params(self):
+        return self._unknown_params
 
     def reset_filter_timer(self):
         self.set_param("filter_timer_reset", "")

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -9,6 +9,7 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_platform
 from homeassistant.helpers.device_registry import DeviceInfo
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import SERVICE_FILTER_TIMER_RESET
 from .const import SERVICE_RESET_ALARMS
 from .const import DOMAIN
@@ -35,7 +36,7 @@ FULL_SUPPORT = (
 )
 
 
-PRESET_MODES = ["low", "medium", "high", "manual"]
+PRESET_MODES = ["off", "low", "medium", "high", "manual"]
 DIRECTIONS = ["ventilation", "air_supply", "heat_recovery"]
 
 
@@ -72,6 +73,8 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         # self._percentage = self._fan.man_speed we use fan object directly otherwise we would miss changes from fan changes via remote or direct control
         self._attr_unique_id = self._fan.id
         self._attr_name = self._fan.name
+        self._attr_icon = "mdi:fan"
+        self._attr_translation_key = "vent"
         self._attr_extra_state_attributes = {"ipv4_address": self._fan.current_wifi_ip}
         self._attr_supported_features = FULL_SUPPORT
         self._attr_device_info = DeviceInfo(
@@ -105,9 +108,11 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         return self._fan.state == "on"
 
     @property
-    def percentage(self) -> int:
+    def percentage(self) -> int | None:
         """Return the current speed."""
-        return self._fan.man_speed
+        if self._fan.state == "off":
+            return None
+        return self._fan.preset_speed_percent(self._fan.speed)
 
     @property
     def preset_modes(self) -> list[str]:
@@ -122,12 +127,45 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     @property
     def preset_mode(self) -> str:
         """Return the current preset mode, e.g., auto, smart, interval, favorite."""
+        if self._fan.state == "off":
+            return "off"
         return self._fan.speed
+
+    def _set_param_if_changed(self, name: str, target: Any) -> bool:
+        """Write a device parameter only when it actually changes."""
+        current = getattr(self._fan, name)
+        if current == target:
+            _LOGGER.debug(
+                "Skipping unchanged %s command for %s: %s",
+                name,
+                self._fan.name,
+                target,
+            )
+            return False
+
+        self._fan.set_param(name, target)
+        return True
+
+    def _set_manual_percentage_if_changed(self, percentage: int) -> bool:
+        """Write manual speed percentage only when it actually changes."""
+        target_percentage = max(2, percentage)
+        if self._fan.man_speed == target_percentage:
+            _LOGGER.debug(
+                "Skipping unchanged manual speed command for %s: %s%%",
+                self._fan.name,
+                target_percentage,
+            )
+            return False
+
+        self._fan.set_man_speed_percent(target_percentage)
+        return True
 
     @property
     def current_direction(self) -> str:
         """Fan direction."""
-        return self._fan.airflow
+        if self._fan.airflow == "air_supply":
+            return "reverse"
+        return "forward"
 
     @property
     def oscillating(self) -> bool:
@@ -157,24 +195,34 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     ) -> None:
         """Turn on the entity."""
         if preset_mode is not None:
-            self.set_preset_mode(preset_mode)
+            await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode)
         if percentage is not None:
-            self.set_percentage(percentage)
+            await self.hass.async_add_executor_job(self.set_percentage, percentage)
 
-        await self.hass.async_add_executor_job(self._fan.set_param, "state", "on")
+        if preset_mode is None and percentage is None:
+            await self.hass.async_add_executor_job(
+                self._set_param_if_changed, "state", "on"
+            )
         await self.coordinator.async_refresh()
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the entity."""
-        await self.hass.async_add_executor_job(self._fan.set_param, "state", "off")
+        await self.hass.async_add_executor_job(
+            self._set_param_if_changed, "state", "off"
+        )
         await self.coordinator.async_refresh()
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
+        if preset_mode == "off":
+            self._set_param_if_changed("state", "off")
+            return
+
         if preset_mode in self.preset_modes:
-            self._fan.set_param("speed", preset_mode)
-            if preset_mode == "manual":
-                self._fan.set_man_speed_percent(self.percentage)
+            state_changed = self._set_param_if_changed("state", "on")
+            speed_changed = self._set_param_if_changed("speed", preset_mode)
+            if preset_mode != "manual" and (state_changed or speed_changed):
+                self._fan.update_preset_speed_settings()
         else:
             raise ValueError(f"Invalid preset mode: {preset_mode}")
 
@@ -185,9 +233,13 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     def set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        # self._percentage = percentage
-        if self._fan.speed == "manual":
-            self._fan.set_man_speed_percent(percentage)
+        if percentage <= 0:
+            self._set_param_if_changed("state", "off")
+            return
+
+        self._set_param_if_changed("state", "on")
+        self._set_param_if_changed("speed", "manual")
+        self._set_manual_percentage_if_changed(percentage)
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
@@ -196,22 +248,30 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
-        if direction == "forward" and self._fan.airflow != "ventilation":
+        if direction == "forward":
             await self.hass.async_add_executor_job(
-                self._fan.set_param, "airflow", "ventilation"
+                self._set_param_if_changed,
+                "airflow",
+                "ventilation",
             )
-        if direction == "reverse" and self._fan.airflow != "air_supply":
+        elif direction == "reverse":
             await self.hass.async_add_executor_job(
-                self._fan.set_param, "airflow", "air_supply"
+                self._set_param_if_changed,
+                "airflow",
+                "air_supply",
             )
+        else:
+            raise ValueError(f"Invalid direction: {direction}")
         await self.coordinator.async_refresh()
 
     async def async_oscillate(self, oscillating: bool) -> None:
         """Set oscillation."""
-        if oscillating:
-            await self.hass.async_add_executor_job( self._fan.set_param, "airflow", "heat_recovery" )
-        else:
-            await self.hass.async_add_executor_job( self._fan.set_param, "airflow", "ventilation" )
+        target_airflow = "heat_recovery" if oscillating else "ventilation"
+        await self.hass.async_add_executor_job(
+            self._set_param_if_changed,
+            "airflow",
+            target_airflow,
+        )
         await self.coordinator.async_refresh()
         # self.schedule_update_ha_state()
 
@@ -220,9 +280,9 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     # Reset filter timer
     async def async_reset_filter_timer(self, fan_target) -> None:
         """Reset Fan's filter timer."""
-        await self.hass.async_add_executor_job( self._fan.set_param, "filter_timer_reset", "" )
-        # await self.hass.async_add_executor_job(self._fan.set_param, "beeper", "silent")
-        # just for a tryal
+        await self.hass.async_add_executor_job(
+            self._fan.set_param, "filter_timer_reset", ""
+        )
 
     # Reset alarms
     async def async_reset_alarms(self, fan_target) -> None:

--- a/custom_components/ecovent_v2/icons.json
+++ b/custom_components/ecovent_v2/icons.json
@@ -1,4 +1,22 @@
 {
+  "entity": {
+    "fan": {
+      "vent": {
+        "state_attributes": {
+          "preset_mode": {
+            "default": "mdi:fan",
+            "state": {
+              "off": "mdi:fan-off",
+              "low": "mdi:fan-speed-1",
+              "medium": "mdi:fan-speed-2",
+              "high": "mdi:fan-speed-3",
+              "manual": "mdi:tune-variant"
+            }
+          }
+        }
+      }
+    }
+  },
   "services": {
     "filter_timer_reset": {
       "service": "mdi:air-filter"

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.4",
+  "version": "1.2.5",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/number.py
+++ b/custom_components/ecovent_v2/number.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import re
+
 from .ecoventv2 import Fan
 
 from homeassistant.components.number import NumberDeviceClass, NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import EntityCategory
+from homeassistant.const import EntityCategory, PERCENTAGE
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -40,11 +42,12 @@ async def async_setup_entry(
                 native_min_value=40.0,
                 native_max_value=80.0,
                 native_step=1,
+                unit_of_measurement=PERCENTAGE,
             ),
             VentoNumber(
                 hass,
                 config,
-                "Analog Voltage threshold",
+                "Analog voltage threshold",
                 "analogV_treshold",
                 None,
                 "mdi:flash-triangle-outline",
@@ -54,6 +57,7 @@ async def async_setup_entry(
                 native_min_value=0.0,
                 native_max_value=100.0,
                 native_step=1,
+                unit_of_measurement=PERCENTAGE,
             ),
             VentoNumber(
                 hass,
@@ -68,6 +72,22 @@ async def async_setup_entry(
                 native_min_value=0,
                 native_max_value=60,
                 native_step=1,
+                unit_of_measurement="min",
+            ),
+            VentoNumber(
+                hass,
+                config,
+                "Filter timer setpoint",
+                "filter_timer_setpoint",
+                None,
+                "mdi:air-filter",
+                False,
+                mode=NumberMode.AUTO,
+                entity_category=EntityCategory.CONFIG,
+                native_min_value=10,
+                native_max_value=999,
+                native_step=1,
+                unit_of_measurement="d",
             ),
         ]
     )
@@ -126,12 +146,33 @@ class VentoNumber(CoordinatorEntity, NumberEntity):
             name=self._fan.name,
         )
 
+    @property
+    def native_value(self) -> float | None:
+        """Return the numeric part of the current device value."""
+        value = getattr(self._fan, self._func)
+        if value is None:
+            return None
+        if isinstance(value, (int, float)):
+            return value
+
+        match = re.match(r"(?P<value>\d+(?:\.\d+)?)", str(value))
+        if match is None:
+            return None
+
+        return float(match.group("value"))
+
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._attr_native_value = value
         intval = int(value)
+        if self._func == "filter_timer_setpoint":
+            value_hex = intval.to_bytes(2, "little").hex()
+        else:
+            value_hex = hex(intval).replace("0x", "").zfill(2)
         await self.hass.async_add_executor_job(
-            self._fan.set_param, self._func, hex(intval).replace("0x", "").zfill(2)
+            self._fan.set_param,
+            self._func,
+            value_hex,
         )
         self.async_write_ha_state()
         await self.coordinator.async_refresh()

--- a/custom_components/ecovent_v2/sensor.py
+++ b/custom_components/ecovent_v2/sensor.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+import re
+
 from .ecoventv2 import Fan
 
 from homeassistant.components.sensor import (
@@ -18,11 +21,43 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
-import logging
 
 _LOGGER = logging.getLogger(__name__)
 
-import re
+
+def _parse_hours(
+    value: str | None, pattern: str, precision: int | None = None
+) -> float | None:
+    """Parse device duration strings and expose them as hours."""
+    if value is None:
+        return None
+
+    match = re.match(pattern, value)
+    if not match:
+        return None
+
+    parts = {key: int(val) for key, val in match.groupdict().items() if val is not None}
+    total_hours = (
+        parts.get("days", 0) * 24
+        + parts.get("hours", 0)
+        + parts.get("minutes", 0) / 60
+        + parts.get("seconds", 0) / 3600
+    )
+    if precision is not None:
+        return round(total_hours, precision)
+    return total_hours
+
+
+def _parse_days(value: str | None) -> int | None:
+    """Parse simple device duration strings formatted as days."""
+    if value is None:
+        return None
+
+    match = re.match(r"(?P<days>\d+) d", value)
+    if not match:
+        return None
+
+    return int(match.group("days"))
 
 
 async def async_setup_entry(
@@ -37,6 +72,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_humidity",
+                "Humidity",
                 "humidity",
                 PERCENTAGE,
                 SensorDeviceClass.HUMIDITY,
@@ -49,6 +85,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_speed1",
+                "Fan 1 speed",
                 "fan1_speed",
                 REVOLUTIONS_PER_MINUTE,
                 None,
@@ -61,6 +98,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_speed2",
+                "Fan 2 speed",
                 "fan2_speed",
                 REVOLUTIONS_PER_MINUTE,
                 None,
@@ -73,28 +111,95 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_airflow",
+                "Airflow",
                 "airflow",
                 None,
-                None,
+                SensorDeviceClass.ENUM,
                 None,
                 None,
                 True,
+                "mdi:hvac",
+                ["ventilation", "heat_recovery", "air_supply"],
+                translation_key="airflow",
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_beeper",
+                "Beeper",
+                "beeper",
+                None,
+                SensorDeviceClass.ENUM,
+                None,
+                EntityCategory.DIAGNOSTIC,
+                True,
+                "mdi:volume-high",
+                ["off", "on", "silent"],
+                translation_key="beeper",
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_boost_status",
+                "Boost status",
+                "boost_status",
+                None,
+                SensorDeviceClass.ENUM,
+                None,
+                EntityCategory.DIAGNOSTIC,
+                True,
+                "mdi:fan-chevron-up",
+                ["off", "on", "delay"],
+                translation_key="boost_status",
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_timer_mode",
+                "Timer mode",
+                "timer_mode",
+                None,
+                SensorDeviceClass.ENUM,
+                None,
+                EntityCategory.DIAGNOSTIC,
+                False,
+                "mdi:timer-cog-outline",
+                ["off", "night", "party"],
+                translation_key="timer_mode",
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_alarm_status",
+                "Alarm status",
+                "alarm_status",
+                None,
+                SensorDeviceClass.ENUM,
+                None,
+                EntityCategory.DIAGNOSTIC,
+                True,
+                "mdi:alert-outline",
+                ["no", "alarm", "warning"],
+                translation_key="alarm_status",
             ),
             VentoSensor(
                 hass,
                 config,
                 "_timer_counter",
+                "Timer counter",
                 "timer_counter",
                 "h",
                 SensorDeviceClass.DURATION,
                 SensorStateClass.MEASUREMENT,
                 EntityCategory.DIAGNOSTIC,
                 False,
+                "mdi:timer-play-outline",
             ),
             VentoSensor(
                 hass,
                 config,
                 "_battery",
+                "Battery",
                 "battery_voltage",
                 PERCENTAGE,
                 SensorDeviceClass.BATTERY,
@@ -107,6 +212,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_filter_change_in",
+                "Filter change in",
                 "filter_timer_countdown",
                 "h",
                 SensorDeviceClass.DURATION,
@@ -114,11 +220,55 @@ async def async_setup_entry(
                 EntityCategory.DIAGNOSTIC,
                 True,
                 "mdi:timer-sand",
+                suggested_display_precision=1,
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_filter_remaining",
+                "Filter remaining",
+                "filter_remaining",
+                PERCENTAGE,
+                None,
+                SensorStateClass.MEASUREMENT,
+                EntityCategory.DIAGNOSTIC,
+                True,
+                "mdi:air-filter",
+                suggested_display_precision=0,
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_night_mode_timer",
+                "Night mode timer",
+                "night_mode_timer",
+                "h",
+                SensorDeviceClass.DURATION,
+                SensorStateClass.MEASUREMENT,
+                EntityCategory.DIAGNOSTIC,
+                False,
+                "mdi:weather-night",
+                suggested_display_precision=2,
+            ),
+            VentoSensor(
+                hass,
+                config,
+                "_party_mode_timer",
+                "Party mode timer",
+                "party_mode_timer",
+                "h",
+                SensorDeviceClass.DURATION,
+                SensorStateClass.MEASUREMENT,
+                EntityCategory.DIAGNOSTIC,
+                False,
+                "mdi:party-popper",
+                suggested_display_precision=2,
             ),
             VentoSensor(
                 hass,
                 config,
                 "_analogv",
+                "Analog voltage",
                 "analogv",
                 None,
                 None,
@@ -131,6 +281,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_machine_hours",
+                "Machine hours",
                 "machine_hours",
                 "h",
                 SensorDeviceClass.DURATION,
@@ -143,6 +294,7 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_ip",
+                "IP address",
                 "current_wifi_ip",
                 None,
                 None,
@@ -159,13 +311,15 @@ async def async_setup_entry(
 class VentoSensor(CoordinatorEntity, SensorEntity):
     """Class for Vento Fan Sensors."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
         self,
         hass: HomeAssistant,
         config: ConfigEntry,
-        name="VentoSensor",
+        key="VentoSensor",
+        name=None,
         method=None,
         native_unit_of_measurement=None,
         device_class=None,
@@ -173,6 +327,10 @@ class VentoSensor(CoordinatorEntity, SensorEntity):
         entity_category=None,
         enable_by_default=True,
         icon=None,
+        options=None,
+        *,
+        suggested_display_precision: int | None = None,
+        translation_key: str | None = None,
     ) -> None:
         """Initialize fan sensors."""
         coordinator: EcoVentCoordinator = hass.data[DOMAIN][config.entry_id]
@@ -182,11 +340,15 @@ class VentoSensor(CoordinatorEntity, SensorEntity):
         self._attr_device_class = device_class
         self._attr_state_class = state_class
         self._attr_entity_category = entity_category
-        self._attr_name = self._fan.name + name
-        self._attr_unique_id = self._fan.id + name
+        self._attr_name = name
+        self._attr_unique_id = self._fan.id + key
         self._attr_entity_registry_enabled_default = enable_by_default
         self._method = getattr(self, method)
         self._attr_icon = icon
+        self._attr_options = options
+        self._attr_translation_key = translation_key
+        if suggested_display_precision is not None:
+            self._attr_suggested_display_precision = suggested_display_precision
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._fan.id)},
             name=self._fan.name,
@@ -219,64 +381,82 @@ class VentoSensor(CoordinatorEntity, SensorEntity):
         """Get airflow value."""
         return self._fan.airflow
 
+    def beeper(self):
+        """Get beeper command mode reported by the device."""
+        return self._fan.beeper
+
+    def boost_status(self):
+        """Get boost status."""
+        return self._fan.boost_status
+
+    def timer_mode(self):
+        """Get timer mode."""
+        return self._fan.timer_mode
+
+    def alarm_status(self):
+        """Get alarm status."""
+        return self._fan.alarm_status
+
     def battery_voltage(self):
         """Get battery used percentage."""
         high = 3300
         low = 2500
         if self._fan.battery_voltage is None:
-            voltage = 0
-        else:
-            voltage = int(self._fan.battery_voltage.split()[0])
-            voltage = round(((voltage - low) / (high - low)) * 100)
-        return voltage
+            return None
+
+        voltage = int(self._fan.battery_voltage.split()[0])
+        voltage = round(((voltage - low) / (high - low)) * 100)
+        return min(100, max(0, voltage))
 
     def timer_counter(self):
         """Get timer counter value as total hours."""
-        timer_counter_str = self._fan.timer_counter
-
-        # Use regex to extract days, hours, and minutes
-        match = re.match(r"(\d+)h (\d+)m (\d+)s", timer_counter_str)
-        if match:
-            hours = int(match.group(1))
-            minutes = int(match.group(2))
-            seconds = int(match.group(3))
-
-            # Convert everything to total hours
-            total_hours = hours + minutes / 60 + seconds / 3600
-            return total_hours
-        return None  # In case the string format is unexpected
+        return _parse_hours(
+            self._fan.timer_counter,
+            r"(?P<hours>\d+)h (?P<minutes>\d+)m (?P<seconds>\d+)s",
+            3,
+        )
 
     def filter_timer_countdown(self):
         """Get filter time countdown as total hours."""
-        remaining_time_str = self._fan.filter_timer_countdown
+        return _parse_hours(
+            self._fan.filter_timer_countdown,
+            r"(?P<days>\d+)d (?P<hours>\d+)h (?P<minutes>\d+)m",
+            1,
+        )
 
-        # Use regex to extract days, hours, and minutes
-        match = re.match(r"(\d+)d (\d+)h (\d+)m", remaining_time_str)
-        if match:
-            days = int(match.group(1))
-            hours = int(match.group(2))
-            minutes = int(match.group(3))
+    def filter_remaining(self):
+        """Get filter lifetime remaining as a percentage."""
+        remaining_hours = self.filter_timer_countdown()
+        setpoint_days = _parse_days(self._fan.filter_timer_setpoint)
+        if remaining_hours is None or not setpoint_days:
+            return None
 
-            # Convert everything to total hours
-            total_hours = days * 24 + hours + minutes / 60
-            return total_hours
-        return None  # In case the string format is unexpected
+        remaining = remaining_hours / (setpoint_days * 24) * 100
+        return min(100, max(0, round(remaining)))
+
+    def night_mode_timer(self):
+        """Get night mode timer value as total hours."""
+        return _parse_hours(
+            self._fan.night_mode_timer,
+            r"(?P<hours>\d+)h (?P<minutes>\d+)m",
+            2,
+        )
+
+    def party_mode_timer(self):
+        """Get party mode timer value as total hours."""
+        return _parse_hours(
+            self._fan.party_mode_timer,
+            r"(?P<hours>\d+)h (?P<minutes>\d+)m",
+            2,
+        )
 
     def machine_hours(self):
         """Get machine hours value as total hours."""
-        machine_hours_str = self._fan.machine_hours
-
-        # Use regex to extract days, hours, and minutes
-        match = re.match(r"(\d+)d (\d+)h (\d+)m", machine_hours_str)
-        if match:
-            days = int(match.group(1))
-            hours = int(match.group(2))
-            minutes = int(match.group(3))
-
-            # Convert everything to total hours
-            total_hours = days * 24 + hours + minutes / 60
-            return total_hours
-        return None  # In case the string format is unexpected
+        return _parse_hours(
+            self._fan.machine_hours,
+            r"(?P<days>\d+)d (?P<hours>\d+)h (?P<minutes>\d+)m",
+            1,
+        )
 
     def analogv(self):
         """Get analog Voltage value."""

--- a/custom_components/ecovent_v2/strings.json
+++ b/custom_components/ecovent_v2/strings.json
@@ -28,5 +28,74 @@
       "name": "Reset fan Vento alarms",
       "description": "Reset Vento alarms."
     }
+  },
+  "entity": {
+    "sensor": {
+      "airflow": {
+        "state": {
+          "ventilation": "Ventilation",
+          "heat_recovery": "Heat recovery",
+          "air_supply": "Air supply"
+        }
+      },
+      "beeper": {
+        "state": {
+          "off": "Off",
+          "on": "On",
+          "silent": "Silent"
+        }
+      },
+      "boost_status": {
+        "state": {
+          "off": "Off",
+          "on": "On",
+          "delay": "Delay"
+        }
+      },
+      "timer_mode": {
+        "state": {
+          "off": "Off",
+          "night": "Night",
+          "party": "Party"
+        }
+      },
+      "alarm_status": {
+        "state": {
+          "no": "No alarm",
+          "alarm": "Alarm",
+          "warning": "Warning"
+        }
+      }
+    },
+    "fan": {
+      "vent": {
+        "state_attributes": {
+          "direction": {
+            "name": "Airflow",
+            "state": {
+              "forward": "Ventilation",
+              "reverse": "Air supply"
+            }
+          },
+          "oscillating": {
+            "name": "Heat recovery",
+            "state": {
+              "false": "Off",
+              "true": "On"
+            }
+          },
+          "preset_mode": {
+            "name": "Preset mode",
+            "state": {
+              "off": "Off",
+              "low": "Low",
+              "medium": "Medium",
+              "high": "High",
+              "manual": "Manual"
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/custom_components/ecovent_v2/switch.py
+++ b/custom_components/ecovent_v2/switch.py
@@ -31,42 +31,46 @@ async def async_setup_entry(
                 hass,
                 config,
                 "_humidity_sensor_state",
+                "Humidity sensor",
                 "humidity_sensor_state",
                 SwitchDeviceClass.SWITCH,
                 False,
                 EntityCategory.CONFIG,
                 True,
-                "mdi:switch",
+                "mdi:water-percent-alert",
                 False,
             ),
             VentoSwitch(
                 hass,
                 config,
                 "_relay_sensor_state",
+                "Relay sensor",
                 "relay_sensor_state",
                 SwitchDeviceClass.SWITCH,
                 False,
                 EntityCategory.CONFIG,
                 True,
-                "mdi:switch",
+                "mdi:electric-switch",
                 False,
             ),
             VentoSwitch(
                 hass,
                 config,
                 "_analogV_sensor_state",
+                "Analog voltage sensor",
                 "analogV_sensor_state",
                 SwitchDeviceClass.SWITCH,
                 False,
                 EntityCategory.CONFIG,
                 True,
-                "mdi:switch",
+                "mdi:flash-alert-outline",
                 False,
             ),
             VentoSwitch(
                 hass,
                 config,
                 "_weekly_schedule_state",
+                "Weekly schedule",
                 "weekly_schedule_state",
                 SwitchDeviceClass.SWITCH,
                 False,
@@ -82,13 +86,15 @@ async def async_setup_entry(
 class VentoSwitch(CoordinatorEntity, SwitchEntity):
     """Class for Vento Fan Switches."""
 
+    _attr_has_entity_name = True
     _attr_should_poll = False
 
     def __init__(
         self,
         hass: HomeAssistant,
         config: ConfigEntry,
-        name="VentoSwitch",
+        key="VentoSwitch",
+        name=None,
         method=None,
         device_class: SwitchDeviceClass | None = None,
         state: bool = False,
@@ -103,8 +109,8 @@ class VentoSwitch(CoordinatorEntity, SwitchEntity):
         self._fan: Fan = coordinator._fan
         self._attr_device_class = device_class
         self._attr_entity_category = entity_category
-        self._attr_name = self._fan.name + name
-        self._attr_unique_id = self._fan.id + name
+        self._attr_name = name
+        self._attr_unique_id = self._fan.id + key
         self._attr_entity_registry_enabled_default = enable_by_default
         self._method = getattr(self, method)
         #  self._attribute2 = getattr(self._fan, method)  crazy cannot be done here, only works for binary sensor.

--- a/custom_components/ecovent_v2/translations/en.json
+++ b/custom_components/ecovent_v2/translations/en.json
@@ -28,5 +28,74 @@
             "description": "Reset Vento alarms.",
             "name": "Reset fan Vento alarms"
         }
+    },
+    "entity": {
+        "sensor": {
+            "airflow": {
+                "state": {
+                    "air_supply": "Air supply",
+                    "heat_recovery": "Heat recovery",
+                    "ventilation": "Ventilation"
+                }
+            },
+            "beeper": {
+                "state": {
+                    "off": "Off",
+                    "on": "On",
+                    "silent": "Silent"
+                }
+            },
+            "alarm_status": {
+                "state": {
+                    "alarm": "Alarm",
+                    "no": "No alarm",
+                    "warning": "Warning"
+                }
+            },
+            "boost_status": {
+                "state": {
+                    "delay": "Delay",
+                    "off": "Off",
+                    "on": "On"
+                }
+            },
+            "timer_mode": {
+                "state": {
+                    "night": "Night",
+                    "off": "Off",
+                    "party": "Party"
+                }
+            }
+        },
+        "fan": {
+            "vent": {
+                "state_attributes": {
+                    "direction": {
+                        "name": "Airflow",
+                        "state": {
+                            "forward": "Ventilation",
+                            "reverse": "Air supply"
+                        }
+                    },
+                    "oscillating": {
+                        "name": "Heat recovery",
+                        "state": {
+                            "false": "Off",
+                            "true": "On"
+                        }
+                    },
+                    "preset_mode": {
+                        "name": "Preset mode",
+                        "state": {
+                            "high": "High",
+                            "low": "Low",
+                            "manual": "Manual",
+                            "medium": "Medium",
+                            "off": "Off"
+                        }
+                    }
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary

This is a cleanup and robustness pass for the Home Assistant integration entity model and fan controls.

- Clean up entity naming/categories with `has_entity_name`, device classes, units, state classes, translations, focused MDI icons, and statistics unit metadata migration for upgraded sensors.
- Move multi-state values such as boost, timer, alarm, airflow, and beeper status to enum sensors instead of binary/select entities where a boolean model is wrong.
- Add missing protocol fields for filter timer setpoint, filter countdown, night/party timers, beeper status, and Low/Medium/High preset speed setpoints.
- Improve the fan entity: translated preset labels and preset icons, `Off` pseudo-preset, Airflow/Heat recovery labels in the built-in fan controls, direct percentage writes switch to Manual, and repeated desired-state commands skip unchanged device writes.
- Add filter timer setpoint and filter remaining entities, reduce recorder churn for duration sensors, and keep write-only reset commands out of regular polling.
- Harden response parsing so unknown, malformed, or no-value protocol parameters are retained/logged or skipped without crashing setup or losing the rest of the update.

## Protocol Notes

- `0x0044` is the Manual speed setting, not the active Low/Medium/High preset percentage.
- Low/Medium/High percentages come from the preset supply/exhaust setpoints at `0x003A..0x003F`.
- `0x0306` is exposed as read-only beeper status. Live TwinFresh V.2 testing showed writes to this value do not reliably disable command beeps, so this PR intentionally avoids a writable beeper control.

## Validation

- `python3 -m ruff check custom_components/ecovent_v2`
- `python3 -m ruff format --check custom_components/ecovent_v2`
- `python3 -m compileall -q custom_components/ecovent_v2`
- Focused parser test for `FD + param` no-value markers followed by normal parameters.
- Fake fan state-machine checks for preset, percentage, direction, oscillation, and unchanged-command no-op behavior.
- Live TwinFresh V.2 read-only protocol smoke for state, speed, airflow, beeper, preset setpoints, and manual speed.
- Live Home Assistant upgrade smoke verified historic statistics metadata update for `sensor.living_room_vent_fan_1_speed` from no unit to `rpm`.
- Live TwinFresh V.2 smoke test through Home Assistant, including all 25 preset transitions among `off/low/medium/high/manual` with expected percentages: `off=None`, `low=9`, `medium=44`, `high=80`, `manual=86` on the tested unit in Air supply mode.
