### PR TITLE
fix(ecovent_v2): register startup migration listener safely

### DIFF
--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -176,10 +176,7 @@ async def _async_migrate_statistics_metadata_on_start(
     async def _async_run_at_start(_event) -> None:
         await _async_migrate_statistics_metadata(hass, coordinator)
 
-    hass.bus.async_listen_once(
-        EVENT_HOMEASSISTANT_STARTED,
-        lambda event: hass.async_create_task(_async_run_at_start(event)),
-    )
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STARTED, _async_run_at_start)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:


### PR DESCRIPTION
## Summary
- register the Home Assistant started callback as an async listener directly
- avoid calling `hass.async_create_task` from a synchronous event-bus lambda
- fixes the Home Assistant 2026.4 thread-safety warning/error observed at startup after installing 1.2.5

## Details
Home Assistant reports this as unsafe because the sync lambda passed to `hass.bus.async_listen_once()` may run outside the event loop and then calls `hass.async_create_task(...)`:

```text
Detected that custom integration ecovent_v2 calls hass.async_create_task from a thread other than the event loop ... custom_components/ecovent_v2/__init__.py, line 181
```

`async_listen_once` accepts coroutine callbacks, so the startup migration callback can be passed directly. The existing immediate migration still runs before the listener is registered.

## Validation
- `python3 -m py_compile custom_components/ecovent_v2/__init__.py custom_components/ecovent_v2/*.py`
- `python3 -m compileall -q custom_components/ecovent_v2`
- live Home Assistant 2026.4 check with this one-line patch: EcoVent entities load and no `ecovent_v2` thread-safety warning/error remains after restart
