### PR TITLE
fix(ecovent): address issue 35 follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Version 1.2.7
   schedule editor approach.
 
 Version 1.2.8
+* Restore `alarm_status` as a Home Assistant `problem` binary sensor while
+  keeping the enum alarm sensor for `no` / `warning` / `alarm` detail.
 * Expose manual speed as a visible configuration number so it can be adjusted
   without using the live fan speed control.
 * Add disabled-by-default configuration numbers for preset supply/exhaust speed

--- a/README.md
+++ b/README.md
@@ -273,6 +273,32 @@ Version 1.2.5
   the PDF-documented current schedule speed; writable beeper control remains
   exposed only for profiles with a documented sound-emitter parameter.
 
+Version 1.2.6
+* Harden the vendored protocol client with better transport error handling,
+  bulk-read fallback, missing-battery tolerance, and four-byte filter countdown
+  parsing.
+* Split protocol maps, device profiles, model metadata, sensor specs, and tests
+  out of the monolithic client for easier review and maintenance.
+* Add profile-aware support for Smart Wi-Fi/iFan extract fans, Breezy/Freshpoint,
+  Freshbox/Micra, and Arc Smart/O2 Supreme devices.
+* Expand PDF-backed model aliases and README discovery keywords for Blauberg,
+  VENTS, OXXIFY, SIKU, Flexit, DUKA, RL, Winzel, and NIBE labels.
+* Keep Home Assistant fan direction values separate from EcoVent protocol airflow
+  values, and expose optional entities only when the active profile supports
+  them.
+
+Version 1.2.7
+* Add the built-in weekly schedule editor and expose the full weekly schedule
+  through a single schedule summary entity.
+* Register the custom schedule frontend with a content-hashed module URL and add
+  localized schedule editor strings.
+* Make schedule writes bounded by sending only changed days/periods and writing
+  only changed records to the device.
+* Correct VENTO/TwinFresh `0x0306` to schedule speed, remove false VENTO beeper
+  exposure, and keep unknown enum sensor values stable.
+* Add device clock sync support and clean stale helper entities from the previous
+  schedule editor approach.
+
 Version 1.2.8
 * Expose manual speed as a visible configuration number so it can be adjusted
   without using the live fan speed control.

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ Version 1.2.7
 Version 1.2.8
 * Restore the visible weekly schedule switch and keep the schedule frontend file
   digest out of the Home Assistant event loop.
-* Restore `alarm_status` as a Home Assistant `Alarm problem` binary sensor
+* Restore `alarm_status` as a Home Assistant `Device problem` binary sensor
   while keeping the enum alarm sensor for `no` / `warning` / `alarm` detail.
 * Expose manual speed as a visible configuration number so it can be adjusted
   without using the live fan speed control.

--- a/README.md
+++ b/README.md
@@ -300,6 +300,8 @@ Version 1.2.7
   schedule editor approach.
 
 Version 1.2.8
+* Restore the visible weekly schedule switch and keep the schedule frontend file
+  digest out of the Home Assistant event loop.
 * Restore `alarm_status` as a Home Assistant `problem` binary sensor while
   keeping the enum alarm sensor for `no` / `warning` / `alarm` detail.
 * Expose manual speed as a visible configuration number so it can be adjusted

--- a/README.md
+++ b/README.md
@@ -272,3 +272,11 @@ Version 1.2.5
 * Correct the VENTO/TwinFresh Expert `0x0306` interpretation from beeper state to
   the PDF-documented current schedule speed; writable beeper control remains
   exposed only for profiles with a documented sound-emitter parameter.
+
+Version 1.2.8
+* Expose manual speed as a visible configuration number so it can be adjusted
+  without using the live fan speed control.
+* Add disabled-by-default configuration numbers for preset supply/exhaust speed
+  setpoints on VENTO/TwinFresh, Breezy/Freshpoint, and Freshbox/Micra profiles.
+* Encode speed setpoint writes with the active protocol profile's percent scale,
+  while keeping live fan percentage control Home Assistant-native.

--- a/README.md
+++ b/README.md
@@ -302,8 +302,8 @@ Version 1.2.7
 Version 1.2.8
 * Restore the visible weekly schedule switch and keep the schedule frontend file
   digest out of the Home Assistant event loop.
-* Restore `alarm_status` as a Home Assistant `problem` binary sensor while
-  keeping the enum alarm sensor for `no` / `warning` / `alarm` detail.
+* Restore `alarm_status` as a Home Assistant `Alarm problem` binary sensor
+  while keeping the enum alarm sensor for `no` / `warning` / `alarm` detail.
 * Expose manual speed as a visible configuration number so it can be adjusted
   without using the live fan speed control.
 * Add disabled-by-default configuration numbers for preset supply/exhaust speed

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -55,7 +55,6 @@ def _async_migrate_entity_registry(
     stale_binary_unique_ids = (
         fan.id + "_boost_status",
         fan.id + "_timer_mode",
-        fan.id + "_alarm_status",
     )
     for unique_id in stale_binary_unique_ids:
         entity_id = registry.async_get_entity_id(

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -123,6 +123,23 @@ def _async_migrate_entity_registry(
         _LOGGER.info("Migrated EcoVent V2 entity id %s to %s", entity_id, new_entity_id)
 
     if fan.supports_parameter("weekly_schedule_setup"):
+        schedule_switch_entity_id = registry.async_get_entity_id(
+            Platform.SWITCH,
+            DOMAIN,
+            fan.id + "_weekly_schedule_state",
+        )
+        if schedule_switch_entity_id is not None:
+            schedule_switch_entry = registry.async_get(schedule_switch_entity_id)
+            if schedule_switch_entry.hidden_by is not None:
+                registry.async_update_entity(
+                    schedule_switch_entity_id,
+                    hidden_by=None,
+                )
+                _LOGGER.info(
+                    "Restored visible EcoVent V2 weekly schedule switch %s",
+                    schedule_switch_entity_id,
+                )
+
         schedule_helper_entity_ids = (
             f"select.{device_slug}_schedule_day",
             *[

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -125,7 +125,6 @@ def _async_migrate_entity_registry(
 
     if fan.supports_parameter("weekly_schedule_setup"):
         schedule_helper_entity_ids = (
-            f"switch.{device_slug}_weekly_schedule",
             f"select.{device_slug}_schedule_day",
             *[
                 f"select.{device_slug}_schedule_period_{period}_speed"

--- a/custom_components/ecovent_v2/binary_sensor.py
+++ b/custom_components/ecovent_v2/binary_sensor.py
@@ -58,7 +58,7 @@ BINARY_SENSOR_SPECS = (
     ),
     BinarySensorSpec(
         "_alarm_status",
-        "Alarm problem",
+        "Device problem",
         "alarm_status",
         True,
         "mdi:alert-outline",

--- a/custom_components/ecovent_v2/binary_sensor.py
+++ b/custom_components/ecovent_v2/binary_sensor.py
@@ -37,6 +37,7 @@ class BinarySensorSpec:
     icon: str
     device_class: BinarySensorDeviceClass | None = None
     required_capabilities: tuple[str, ...] = ("binary_diagnostics",)
+    on_values: tuple[str, ...] = ("on",)
 
 
 BINARY_SENSOR_SPECS = (
@@ -54,6 +55,16 @@ BINARY_SENSOR_SPECS = (
         True,
         "mdi:air-filter",
         BinarySensorDeviceClass.PROBLEM,
+    ),
+    BinarySensorSpec(
+        "_alarm_status",
+        "Alarm status",
+        "alarm_status",
+        True,
+        "mdi:alert-outline",
+        BinarySensorDeviceClass.PROBLEM,
+        required_capabilities=(),
+        on_values=("alarm", "warning"),
     ),
     BinarySensorSpec(
         "_cloud_server_state",
@@ -146,6 +157,7 @@ async def async_setup_entry(
                 spec.enable_by_default,
                 spec.icon,
                 spec.device_class,
+                spec.on_values,
             )
             for spec in BINARY_SENSOR_SPECS
             if coordinator._fan.supports_entity(
@@ -173,6 +185,7 @@ class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEn
         enable_by_default: bool = False,
         icon: str | None = "",
         device_class: BinarySensorDeviceClass | None = None,
+        on_values: tuple[str, ...] = ("on",),
     ) -> None:
         """Initialize fan binary sensors."""
         coordinator: EcoVentCoordinator = hass.data[DOMAIN][config.entry_id]
@@ -184,6 +197,7 @@ class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEn
         self._attr_device_class = device_class
         self._attr_entity_registry_enabled_default = enable_by_default
         self._method = method
+        self._on_values = on_values
         self._attr_icon = icon
 
         self._attr_device_info = DeviceInfo(
@@ -193,7 +207,8 @@ class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEn
     @property
     def is_on(self):
         """Is on."""
-        self._state = getattr(self._fan, self._method) == "on"
+        value = getattr(self._fan, self._method)
+        self._state = None if value is None else value in self._on_values
         # self.async_write_ha_state() dangerous not allowed
         # self.schedule_update_ha_state() # not needed
         # _LOGGER.debug(f"VentoBinarySensor: {self._attr_name} state updated to {self._state}")

--- a/custom_components/ecovent_v2/binary_sensor.py
+++ b/custom_components/ecovent_v2/binary_sensor.py
@@ -58,7 +58,7 @@ BINARY_SENSOR_SPECS = (
     ),
     BinarySensorSpec(
         "_alarm_status",
-        "Alarm status",
+        "Alarm problem",
         "alarm_status",
         True,
         "mdi:alert-outline",

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -112,7 +112,7 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     def percentage(self) -> int | None:
         """Return the current speed."""
         if self._fan.state == "off":
-            return None
+            return 0
         return self._fan.preset_speed_percent(self._fan.speed)
 
     @property
@@ -235,7 +235,7 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         )
         await self.coordinator.async_refresh()
 
-    def set_preset_mode(self, preset_mode: str, turn_on: bool = False) -> None:
+    def set_preset_mode(self, preset_mode: str, turn_on: bool = True) -> None:
         """Set the preset mode of the fan."""
         if preset_mode == "off":
             self._set_param_if_changed("state", "off")
@@ -259,10 +259,10 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
-        await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode)
+        await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode, True)
         await self.coordinator.async_refresh()
 
-    def set_percentage(self, percentage: int, turn_on: bool = False) -> None:
+    def set_percentage(self, percentage: int, turn_on: bool = True) -> None:
         """Set the speed of the fan, as a percentage."""
         if percentage <= 0:
             self._set_param_if_changed("state", "off")
@@ -270,12 +270,6 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
         if turn_on:
             self._set_param_if_changed("state", "on")
-        elif self._fan.state == "off":
-            _LOGGER.debug(
-                "Skipping manual speed command for %s while fan is off",
-                self._fan.name,
-            )
-            return
 
         if self._fan.uses_operating_mode_presets:
             self._fan.set_speed_setpoint_percent(percentage)
@@ -286,7 +280,7 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        await self.hass.async_add_executor_job(self.set_percentage, percentage)
+        await self.hass.async_add_executor_job(self.set_percentage, percentage, True)
         await self.coordinator.async_refresh()
 
     async def async_set_direction(self, direction: str) -> None:

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -210,9 +210,17 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             preset_mode = speed
 
         if preset_mode is not None:
-            await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode)
+            await self.hass.async_add_executor_job(
+                self.set_preset_mode,
+                preset_mode,
+                True,
+            )
         if percentage is not None:
-            await self.hass.async_add_executor_job(self.set_percentage, percentage)
+            await self.hass.async_add_executor_job(
+                self.set_percentage,
+                percentage,
+                True,
+            )
 
         if preset_mode is None and percentage is None:
             await self.hass.async_add_executor_job(
@@ -227,19 +235,22 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         )
         await self.coordinator.async_refresh()
 
-    def set_preset_mode(self, preset_mode: str) -> None:
+    def set_preset_mode(self, preset_mode: str, turn_on: bool = False) -> None:
         """Set the preset mode of the fan."""
         if preset_mode == "off":
             self._set_param_if_changed("state", "off")
             return
 
         if self._fan.uses_operating_mode_presets:
-            self._set_param_if_changed("state", "on")
+            if turn_on:
+                self._set_param_if_changed("state", "on")
             self._fan.set_operating_mode_preset(preset_mode)
             return
 
         if preset_mode in self.preset_modes:
-            state_changed = self._set_param_if_changed("state", "on")
+            state_changed = False
+            if turn_on:
+                state_changed = self._set_param_if_changed("state", "on")
             speed_changed = self._set_param_if_changed("speed", preset_mode)
             if preset_mode != "manual" and (state_changed or speed_changed):
                 self._fan.update_preset_speed_settings()
@@ -251,13 +262,21 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode)
         await self.coordinator.async_refresh()
 
-    def set_percentage(self, percentage: int) -> None:
+    def set_percentage(self, percentage: int, turn_on: bool = False) -> None:
         """Set the speed of the fan, as a percentage."""
         if percentage <= 0:
             self._set_param_if_changed("state", "off")
             return
 
-        self._set_param_if_changed("state", "on")
+        if turn_on:
+            self._set_param_if_changed("state", "on")
+        elif self._fan.state == "off":
+            _LOGGER.debug(
+                "Skipping manual speed command for %s while fan is off",
+                self._fan.name,
+            )
+            return
+
         if self._fan.uses_operating_mode_presets:
             self._fan.set_speed_setpoint_percent(percentage)
             return

--- a/custom_components/ecovent_v2/frontend.py
+++ b/custom_components/ecovent_v2/frontend.py
@@ -37,5 +37,6 @@ async def async_register_frontend(hass: HomeAssistant) -> None:
             )
         ]
     )
-    add_extra_js_url(hass, _frontend_module_url(frontend_dir))
+    module_url = await hass.async_add_executor_job(_frontend_module_url, frontend_dir)
+    add_extra_js_url(hass, module_url)
     hass.data[_REGISTERED_KEY] = True

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.7",
+  "version": "1.2.8",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/number.py
+++ b/custom_components/ecovent_v2/number.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import logging
 import re
 
 from .ecoventv2 import Fan
@@ -17,7 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
-import logging
+from .number_helpers import encode_raw_number, encode_speed_percent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -39,9 +40,213 @@ class NumberSpec:
     device_class: NumberDeviceClass | None = None
     required_capabilities: tuple[str, ...] = ()
     value_bytes: int = 1
+    write_mode: str = "raw"
 
 
 NUMBER_SPECS = (
+    NumberSpec(
+        "Manual speed",
+        "man_speed",
+        "mdi:fan",
+        True,
+        native_min_value=2.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        write_mode="manual_speed_percent",
+    ),
+    NumberSpec(
+        "Low supply speed",
+        "supply_speed_low",
+        "mdi:fan-speed-1",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Low exhaust speed",
+        "exhaust_speed_low",
+        "mdi:fan-speed-1",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Medium supply speed",
+        "supply_speed_medium",
+        "mdi:fan-speed-2",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Medium exhaust speed",
+        "exhaust_speed_medium",
+        "mdi:fan-speed-2",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "High supply speed",
+        "supply_speed_high",
+        "mdi:fan-speed-3",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "High exhaust speed",
+        "exhaust_speed_high",
+        "mdi:fan-speed-3",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("three_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 1 supply speed",
+        "supply_speed_low",
+        "mdi:fan-speed-1",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 1 exhaust speed",
+        "exhaust_speed_low",
+        "mdi:fan-speed-1",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 2 supply speed",
+        "supply_speed_medium",
+        "mdi:fan-speed-2",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 2 exhaust speed",
+        "exhaust_speed_medium",
+        "mdi:fan-speed-2",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 3 supply speed",
+        "supply_speed_high",
+        "mdi:fan-speed-3",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 3 exhaust speed",
+        "exhaust_speed_high",
+        "mdi:fan-speed-3",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 4 supply speed",
+        "supply_speed_4",
+        "mdi:fan-plus",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 4 exhaust speed",
+        "exhaust_speed_4",
+        "mdi:fan-plus",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 5 supply speed",
+        "supply_speed_5",
+        "mdi:fan-plus",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
+    NumberSpec(
+        "Speed 5 exhaust speed",
+        "exhaust_speed_5",
+        "mdi:fan-plus",
+        False,
+        native_min_value=1.0,
+        native_max_value=100.0,
+        native_step=1,
+        unit_of_measurement=PERCENTAGE,
+        required_capabilities=("five_speed_setpoints",),
+        write_mode="speed_percent",
+    ),
     NumberSpec(
         "Humidity threshold",
         "humidity_treshold",
@@ -216,6 +421,7 @@ async def async_setup_entry(
                 native_step=spec.native_step,
                 unit_of_measurement=spec.unit_of_measurement,
                 value_bytes=spec.value_bytes,
+                write_mode=spec.write_mode,
             )
             for spec in NUMBER_SPECS
             if coordinator._fan.supports_entity(
@@ -251,6 +457,7 @@ class VentoNumber(CoordinatorEntity, NumberEntity):
         native_step: float | None = None,
         unit_of_measurement: str | None = None,
         value_bytes: int = 1,
+        write_mode: str = "raw",
     ) -> None:
         """Initialize the Vento Number entity."""
 
@@ -269,6 +476,7 @@ class VentoNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_value = getattr(self._fan, method)
         self._func = method
         self._value_bytes = value_bytes
+        self._write_mode = write_mode
 
         if native_min_value is not None:
             self._attr_native_min_value = native_min_value
@@ -299,11 +507,24 @@ class VentoNumber(CoordinatorEntity, NumberEntity):
     async def async_set_native_value(self, value: float) -> None:
         """Update the current value."""
         self._attr_native_value = value
-        intval = int(value)
-        if self._value_bytes > 1:
-            value_hex = intval.to_bytes(self._value_bytes, "little").hex()
+
+        if self._write_mode == "manual_speed_percent":
+            await self.hass.async_add_executor_job(
+                self._fan.set_man_speed_percent,
+                int(value),
+            )
+            self.async_write_ha_state()
+            await self.coordinator.async_refresh()
+            return
+
+        if self._write_mode == "speed_percent":
+            value_hex = encode_speed_percent(
+                value,
+                self._fan.device_profile.speed_percent_scale,
+            )
         else:
-            value_hex = hex(intval).replace("0x", "").zfill(2)
+            value_hex = encode_raw_number(value, self._value_bytes)
+
         await self.hass.async_add_executor_job(
             self._fan.set_param,
             self._func,

--- a/custom_components/ecovent_v2/number_helpers.py
+++ b/custom_components/ecovent_v2/number_helpers.py
@@ -1,0 +1,23 @@
+"""Helpers for EcoVent number entities."""
+
+from __future__ import annotations
+
+import math
+
+
+def encode_raw_number(value: float, value_bytes: int = 1) -> str:
+    """Encode a plain numeric value for a protocol write."""
+    intval = int(value)
+    if value_bytes > 1:
+        return intval.to_bytes(value_bytes, "little").hex()
+    return hex(intval).replace("0x", "").zfill(2)
+
+
+def encode_speed_percent(value: float, speed_percent_scale: str) -> str:
+    """Encode a Home Assistant percent value for a speed setpoint row."""
+    target = max(0, min(100, int(value)))
+    if speed_percent_scale == "percent":
+        encoded = target
+    else:
+        encoded = math.ceil(255 / 100 * target)
+    return hex(encoded).replace("0x", "").zfill(2)

--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -26,6 +26,7 @@ DEVICE_PROFILES = {
                 "filter_maintenance",
                 "night_party_timers",
                 "sensor_switches",
+                "three_speed_setpoints",
                 "timer_mode",
             }
         ),
@@ -73,6 +74,7 @@ DEVICE_PROFILES = {
                 "night_party_timers",
                 "sensor_switches",
                 "temperature_probes",
+                "three_speed_setpoints",
                 "timer_mode",
                 "voc",
             }
@@ -93,6 +95,7 @@ DEVICE_PROFILES = {
         schedule_speed_modes=("speed_1", "speed_2", "speed_3", "speed_4", "speed_5"),
         capabilities=frozenset(
             {
+                "five_speed_setpoints",
                 "filter_maintenance",
                 "timer_mode",
             }

--- a/custom_components/ecovent_v2/switch.py
+++ b/custom_components/ecovent_v2/switch.py
@@ -317,6 +317,10 @@ class VentoSwitch(CoordinatorEntity, SwitchEntity):
         # _LOGGER.debug(f"Attribute2 value: {self._attribute2}")
         return self._fan.analogV_sensor_state
 
+    def weekly_schedule_state(self):
+        """Weekly schedule state."""
+        return self._fan.weekly_schedule_state
+
     def light_sensor_state(self):
         """Light sensor state."""
         return self._fan.light_sensor_state

--- a/custom_components/ecovent_v2/switch.py
+++ b/custom_components/ecovent_v2/switch.py
@@ -72,6 +72,17 @@ SWITCH_SPECS = (
         False,
     ),
     SwitchSpec(
+        "_weekly_schedule_state",
+        "Weekly schedule",
+        "weekly_schedule_state",
+        SwitchDeviceClass.SWITCH,
+        False,
+        EntityCategory.CONFIG,
+        True,
+        "mdi:calendar-clock",
+        False,
+    ),
+    SwitchSpec(
         "_light_sensor_state",
         "Light sensor",
         "light_sensor_state",

--- a/tests/test_ecovent_number_helpers.py
+++ b/tests/test_ecovent_number_helpers.py
@@ -1,0 +1,110 @@
+"""Regression tests for EcoVent number setpoint helpers."""
+
+import ast
+import unittest
+
+from ecovent_test_helpers import COMPONENT_PATH, Fan  # noqa: F401  Sets module path.
+from number_helpers import encode_raw_number, encode_speed_percent
+
+
+NUMBER_PATH = COMPONENT_PATH / "number.py"
+
+
+def _number_spec_calls():
+    tree = ast.parse(NUMBER_PATH.read_text())
+    return [
+        node
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == "NumberSpec"
+    ]
+
+
+def _constant_arg(call, index):
+    return call.args[index].value
+
+
+def _keyword_value(call, name):
+    for keyword in call.keywords:
+        if keyword.arg == name:
+            return ast.literal_eval(keyword.value)
+    return None
+
+
+class NumberHelperTest(unittest.TestCase):
+    def test_speed_percent_encoder_respects_profile_scale(self):
+        self.assertEqual(encode_speed_percent(50, "byte"), "80")
+        self.assertEqual(encode_speed_percent(50, "percent"), "32")
+
+    def test_raw_number_encoder_keeps_little_endian_multibyte_values(self):
+        self.assertEqual(encode_raw_number(45), "2d")
+        self.assertEqual(encode_raw_number(365, 2), "6d01")
+
+    def test_manual_speed_number_is_visible_configuration_entity(self):
+        manual_specs = [
+            call
+            for call in _number_spec_calls()
+            if _constant_arg(call, 1) == "man_speed"
+        ]
+
+        self.assertEqual(len(manual_specs), 1)
+        self.assertEqual(_constant_arg(manual_specs[0], 0), "Manual speed")
+        self.assertIs(_constant_arg(manual_specs[0], 3), True)
+        self.assertEqual(
+            _keyword_value(manual_specs[0], "write_mode"),
+            "manual_speed_percent",
+        )
+
+    def test_preset_speed_numbers_are_disabled_by_default(self):
+        speed_specs = [
+            call
+            for call in _number_spec_calls()
+            if _constant_arg(call, 1).startswith(("supply_speed", "exhaust_speed"))
+        ]
+
+        self.assertEqual(len(speed_specs), 16)
+        self.assertTrue(all(_constant_arg(call, 3) is False for call in speed_specs))
+        self.assertTrue(
+            all(
+                _keyword_value(call, "write_mode") == "speed_percent"
+                for call in speed_specs
+            )
+        )
+
+    def test_speed_setpoint_capabilities_split_three_and_five_speed_profiles(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(fan.supports_capability("three_speed_setpoints"))
+        self.assertFalse(fan.supports_capability("five_speed_setpoints"))
+        self.assertTrue(
+            fan.supports_entity(
+                required_params=("supply_speed_low",),
+                required_capabilities=("three_speed_setpoints",),
+            )
+        )
+
+        fan.unit_type = "0200"
+        self.assertEqual(fan.profile_key, "freshbox")
+        self.assertFalse(fan.supports_capability("three_speed_setpoints"))
+        self.assertTrue(fan.supports_capability("five_speed_setpoints"))
+        self.assertTrue(
+            fan.supports_entity(
+                required_params=("supply_speed_5",),
+                required_capabilities=("five_speed_setpoints",),
+            )
+        )
+
+        fan.unit_type = "0600"
+        self.assertEqual(fan.profile_key, "extract_fan")
+        self.assertFalse(fan.supports_capability("three_speed_setpoints"))
+        self.assertFalse(fan.supports_capability("five_speed_setpoints"))
+        self.assertTrue(
+            fan.supports_entity(
+                required_params=("max_speed_setpoint",),
+                required_capabilities=("speed_setpoints",),
+            )
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -101,9 +101,13 @@ class Issue35RegressionTest(unittest.TestCase):
     def test_weekly_schedule_switch_stays_visible(self):
         switch_source = SWITCH_PATH.read_text()
         init_source = INIT_PATH.read_text()
+        tree = _tree(SWITCH_PATH)
 
         self.assertIn('"_weekly_schedule_state"', switch_source)
         self.assertIn('"weekly_schedule_state"', switch_source)
+        self.assertIsNotNone(
+            _class_method(tree, "VentoSwitch", "weekly_schedule_state")
+        )
         self.assertNotIn('f"switch.{device_slug}_weekly_schedule"', init_source)
 
     def test_reported_legacy_entity_migrations_are_listed(self):

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -12,6 +12,7 @@ FAN_PATH = COMPONENT_PATH / "fan.py"
 FRONTEND_PATH = COMPONENT_PATH / "frontend.py"
 INIT_PATH = COMPONENT_PATH / "__init__.py"
 SWITCH_PATH = COMPONENT_PATH / "switch.py"
+BINARY_SENSOR_PATH = COMPONENT_PATH / "binary_sensor.py"
 
 
 def _tree(path):
@@ -108,9 +109,18 @@ class Issue35RegressionTest(unittest.TestCase):
     def test_reported_legacy_entity_migrations_are_listed(self):
         init_source = INIT_PATH.read_text()
 
-        self.assertIn('fan.id + "_alarm_status"', init_source)
         self.assertIn('fan.id + "_speed1"', init_source)
         self.assertIn('f"sensor.{device_slug}_fan_1_speed"', init_source)
+
+    def test_alarm_status_keeps_problem_binary_sensor(self):
+        binary_sensor_source = BINARY_SENSOR_PATH.read_text()
+        init_source = INIT_PATH.read_text()
+
+        self.assertIn('"_alarm_status"', binary_sensor_source)
+        self.assertIn('"alarm_status"', binary_sensor_source)
+        self.assertIn("BinarySensorDeviceClass.PROBLEM", binary_sensor_source)
+        self.assertIn('on_values=("alarm", "warning")', binary_sensor_source)
+        self.assertNotIn('fan.id + "_alarm_status"', init_source)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -123,7 +123,7 @@ class Issue35RegressionTest(unittest.TestCase):
         init_source = INIT_PATH.read_text()
 
         self.assertIn('"_alarm_status"', binary_sensor_source)
-        self.assertIn('"Alarm problem"', binary_sensor_source)
+        self.assertIn('"Device problem"', binary_sensor_source)
         self.assertIn('"alarm_status"', binary_sensor_source)
         self.assertIn("BinarySensorDeviceClass.PROBLEM", binary_sensor_source)
         self.assertIn('on_values=("alarm", "warning")', binary_sensor_source)

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -1,0 +1,117 @@
+"""Static regressions for issue #35 follow-ups."""
+
+from pathlib import Path
+import ast
+import unittest
+
+
+COMPONENT_PATH = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"
+)
+FAN_PATH = COMPONENT_PATH / "fan.py"
+FRONTEND_PATH = COMPONENT_PATH / "frontend.py"
+INIT_PATH = COMPONENT_PATH / "__init__.py"
+SWITCH_PATH = COMPONENT_PATH / "switch.py"
+
+
+def _tree(path):
+    return ast.parse(path.read_text())
+
+
+def _module_function(tree, method_name):
+    for node in tree.body:
+        if isinstance(node, (ast.AsyncFunctionDef, ast.FunctionDef)):
+            if node.name == method_name:
+                return node
+    raise AssertionError(f"{method_name} not found")
+
+
+def _class_method(tree, class_name, method_name):
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == class_name:
+            for item in node.body:
+                if isinstance(item, (ast.AsyncFunctionDef, ast.FunctionDef)):
+                    if item.name == method_name:
+                        return item
+    raise AssertionError(f"{class_name}.{method_name} not found")
+
+
+def _executor_calls(node, target_attr):
+    for call in ast.walk(node):
+        if not isinstance(call, ast.Call):
+            continue
+        func = call.func
+        if not isinstance(func, ast.Attribute) or func.attr != "async_add_executor_job":
+            continue
+        if not call.args:
+            continue
+        callback = call.args[0]
+        if isinstance(callback, ast.Attribute) and callback.attr == target_attr:
+            yield call
+
+
+class Issue35RegressionTest(unittest.TestCase):
+    def test_frontend_digest_file_io_runs_in_executor(self):
+        tree = _tree(FRONTEND_PATH)
+        register = _module_function(tree, "async_register_frontend")
+
+        read_bytes_calls = [
+            node
+            for node in ast.walk(register)
+            if isinstance(node, ast.Attribute) and node.attr == "read_bytes"
+        ]
+        executor_calls = [
+            node
+            for node in ast.walk(register)
+            if isinstance(node, ast.Attribute) and node.attr == "async_add_executor_job"
+        ]
+
+        self.assertEqual(read_bytes_calls, [])
+        self.assertTrue(executor_calls)
+
+    def test_direct_speed_change_does_not_turn_on_off_fan(self):
+        tree = _tree(FAN_PATH)
+        turn_on = _class_method(tree, "VentoExpertFan", "async_turn_on")
+        set_percentage = _class_method(tree, "VentoExpertFan", "async_set_percentage")
+        set_preset = _class_method(tree, "VentoExpertFan", "async_set_preset_mode")
+
+        self.assertTrue(
+            any(
+                len(call.args) >= 3 and isinstance(call.args[2], ast.Constant)
+                and call.args[2].value is True
+                for call in _executor_calls(turn_on, "set_percentage")
+            )
+        )
+        self.assertFalse(
+            any(
+                len(call.args) >= 3 and isinstance(call.args[2], ast.Constant)
+                and call.args[2].value is True
+                for call in _executor_calls(set_percentage, "set_percentage")
+            )
+        )
+        self.assertFalse(
+            any(
+                len(call.args) >= 3 and isinstance(call.args[2], ast.Constant)
+                and call.args[2].value is True
+                for call in _executor_calls(set_preset, "set_preset_mode")
+            )
+        )
+
+    def test_weekly_schedule_switch_stays_visible(self):
+        switch_source = SWITCH_PATH.read_text()
+        init_source = INIT_PATH.read_text()
+
+        self.assertIn('"_weekly_schedule_state"', switch_source)
+        self.assertIn('"weekly_schedule_state"', switch_source)
+        self.assertNotIn('f"switch.{device_slug}_weekly_schedule"', init_source)
+
+    def test_reported_legacy_entity_migrations_are_listed(self):
+        init_source = INIT_PATH.read_text()
+
+        self.assertIn('fan.id + "_alarm_status"', init_source)
+        self.assertIn('fan.id + "_speed1"', init_source)
+        self.assertIn('f"sensor.{device_slug}_fan_1_speed"', init_source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -108,6 +108,8 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertIsNotNone(
             _class_method(tree, "VentoSwitch", "weekly_schedule_state")
         )
+        self.assertIn('fan.id + "_weekly_schedule_state"', init_source)
+        self.assertIn("hidden_by=None", init_source)
         self.assertNotIn('f"switch.{device_slug}_weekly_schedule"', init_source)
 
     def test_reported_legacy_entity_migrations_are_listed(self):

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -123,6 +123,7 @@ class Issue35RegressionTest(unittest.TestCase):
         init_source = INIT_PATH.read_text()
 
         self.assertIn('"_alarm_status"', binary_sensor_source)
+        self.assertIn('"Alarm problem"', binary_sensor_source)
         self.assertIn('"alarm_status"', binary_sensor_source)
         self.assertIn("BinarySensorDeviceClass.PROBLEM", binary_sensor_source)
         self.assertIn('on_values=("alarm", "warning")', binary_sensor_source)

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -69,7 +69,7 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertEqual(read_bytes_calls, [])
         self.assertTrue(executor_calls)
 
-    def test_direct_speed_change_does_not_turn_on_off_fan(self):
+    def test_direct_speed_change_is_live_fan_control(self):
         tree = _tree(FAN_PATH)
         turn_on = _class_method(tree, "VentoExpertFan", "async_turn_on")
         set_percentage = _class_method(tree, "VentoExpertFan", "async_set_percentage")
@@ -82,14 +82,14 @@ class Issue35RegressionTest(unittest.TestCase):
                 for call in _executor_calls(turn_on, "set_percentage")
             )
         )
-        self.assertFalse(
+        self.assertTrue(
             any(
                 len(call.args) >= 3 and isinstance(call.args[2], ast.Constant)
                 and call.args[2].value is True
                 for call in _executor_calls(set_percentage, "set_percentage")
             )
         )
-        self.assertFalse(
+        self.assertTrue(
             any(
                 len(call.args) >= 3 and isinstance(call.args[2], ast.Constant)
                 and call.args[2].value is True


### PR DESCRIPTION
## Summary
- Move the schedule frontend content hash file read into Home Assistant executor work so startup no longer reports blocking `read_bytes` / `open`.
- Restore the weekly schedule switch as a visible control, including migration cleanup for entries hidden by the previous helper model.
- Restore `alarm_status` as a Home Assistant `Device problem` binary sensor while keeping the enum `Alarm status` sensor for `no` / `warning` / `alarm` detail.
- Add a visible manual speed number and profile-aware preset supply/exhaust speed setpoint numbers for VENTO/TwinFresh, Breezy/Freshpoint, and Freshbox/Micra profiles.
- Fill the missing 1.2.6 / 1.2.7 changelog entries and document the 1.2.8 follow-ups.

## Notes
- Protocol register `0x0083` is an alarm/warning indicator, so the enum keeps the exact protocol detail while the binary entity uses HA's `problem` semantics.
- Live `fan.set_percentage` remains Home Assistant-native: setting a non-zero fan percentage is a live fan control and turns the fan on.
- The old “adjust manual speed without using live fan speed control” workflow is now covered by the `Manual speed` number entity.

## Validation
- `PYTHONPATH=tests python3 -m unittest discover -s tests` (78 tests)
- `ruff check .`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `node --check custom_components/ecovent_v2/frontend/ecovent-schedule-dialog.js`
- `git diff --check`
- Deployed to live Home Assistant 2026.4.4, ran `ha core check`, restarted Core, and verified:
  - `fan.living_room_vent` loads
  - `sensor.living_room_vent_fan_1_speed` exists
  - `sensor.living_room_vent_alarm_status` is enum `no` and displays as `Alarm status`
  - `binary_sensor.living_room_vent_alarm_status` is visible `problem` / `off` and displays as `Device problem`
  - `switch.living_room_vent_weekly_schedule` is visible with `hidden_by=null`
  - `number.living_room_vent_manual_speed` and preset speed setpoint numbers exist
  - schedule frontend route returns HTTP 200
  - recent Core logs contain no EcoVent blocking-call warnings

Refs #35
