### PR TITLE
fix(ecovent): turn on before airflow mode changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,3 +310,6 @@ Version 1.2.8
   setpoints on VENTO/TwinFresh, Breezy/Freshpoint, and Freshbox/Micra profiles.
 * Encode speed setpoint writes with the active protocol profile's percent scale,
   while keeping live fan percentage control Home Assistant-native.
+* Turn the unit on before applying Home Assistant airflow direction or heat
+  recovery changes, so Freshpoint/Breezy ventilation mode starts reliably from
+  an off state.

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -278,6 +278,12 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         self._set_param_if_changed("speed", "manual")
         self._set_manual_percentage_if_changed(percentage)
 
+    def set_airflow_mode(self, airflow: str, turn_on: bool = True) -> None:
+        """Set airflow mode, optionally turning the fan on first."""
+        if turn_on:
+            self._set_param_if_changed("state", "on")
+        self._set_param_if_changed("airflow", airflow)
+
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
         await self.hass.async_add_executor_job(self.set_percentage, percentage, True)
@@ -287,15 +293,15 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         """Set the direction of the fan."""
         if direction == "forward":
             await self.hass.async_add_executor_job(
-                self._set_param_if_changed,
-                "airflow",
+                self.set_airflow_mode,
                 "ventilation",
+                True,
             )
         elif direction == "reverse":
             await self.hass.async_add_executor_job(
-                self._set_param_if_changed,
-                "airflow",
+                self.set_airflow_mode,
                 "air_supply",
+                True,
             )
         else:
             raise ValueError(f"Invalid direction: {direction}")
@@ -305,9 +311,9 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         """Set oscillation."""
         target_airflow = "heat_recovery" if oscillating else "ventilation"
         await self.hass.async_add_executor_job(
-            self._set_param_if_changed,
-            "airflow",
+            self.set_airflow_mode,
             target_airflow,
+            True,
         )
         await self.coordinator.async_refresh()
         # self.schedule_update_ha_state()

--- a/tests/test_fan_direction.py
+++ b/tests/test_fan_direction.py
@@ -63,14 +63,40 @@ class FanDirectionTest(unittest.TestCase):
         tree = _fan_tree()
         current_direction = _class_method(tree, "VentoExpertFan", "current_direction")
         set_direction = _class_method(tree, "VentoExpertFan", "async_set_direction")
+        set_airflow_mode = _class_method(tree, "VentoExpertFan", "set_airflow_mode")
 
         current_constants = _string_constants(current_direction)
         set_constants = _string_constants(set_direction)
+        set_airflow_constants = _string_constants(set_airflow_mode)
 
         self.assertIn("air_supply", current_constants)
         self.assertIn("reverse", current_constants)
         self.assertIn("ventilation", set_constants)
         self.assertIn("air_supply", set_constants)
+        self.assertIn("state", set_airflow_constants)
+        self.assertIn("on", set_airflow_constants)
+        self.assertIn("airflow", set_airflow_constants)
+
+    def test_direction_and_oscillation_turn_on_before_airflow_change(self):
+        tree = _fan_tree()
+        set_direction = _class_method(tree, "VentoExpertFan", "async_set_direction")
+        oscillate = _class_method(tree, "VentoExpertFan", "async_oscillate")
+
+        for method in (set_direction, oscillate):
+            with self.subTest(method=method.name):
+                calls = [
+                    call
+                    for call in ast.walk(method)
+                    if isinstance(call, ast.Call)
+                    and isinstance(call.func, ast.Attribute)
+                    and call.func.attr == "async_add_executor_job"
+                    and len(call.args) >= 3
+                    and isinstance(call.args[0], ast.Attribute)
+                    and call.args[0].attr == "set_airflow_mode"
+                    and isinstance(call.args[-1], ast.Constant)
+                    and call.args[-1].value is True
+                ]
+                self.assertTrue(calls)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- turn the fan on before applying Home Assistant airflow direction or heat recovery mode changes
- keep Freshpoint/Breezy ventilation mode from becoming a no-op when the device is currently off
- add regression coverage for direction/oscillation mode controls

## Tests
- PYTHONPATH=tests python3 -m unittest discover -s tests -v
- ruff check custom_components tests
- git diff --check