### PR TITLE
fix(ecovent): preserve stable entity ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,3 +354,12 @@ Version 1.2.9
   during setup migration.
 * Stop exposing the old `Airflow: something` placeholder for protocol airflow
   enum value `3`; unknown airflow values now use `Unknown airflow <value>`.
+
+Version 1.2.10
+* Preserve user-customized entity ids during legacy entity id migration, while
+  still repairing known intermediate integration-generated names so regenerated
+  names survive integration reloads and Home Assistant restarts, including
+  analog voltage sensor/status variants.
+* Use the same stable object-id suffixes for newly created entities and legacy
+  migrations, keeping readable UI labels without changing entity ids just
+  because labels gained clearer prefixes.

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -20,6 +20,7 @@ from homeassistant.util import slugify
 
 from .const import CONF_AUTO_CLOCK_SYNC, DOMAIN, UPDATE_INTERVAL
 from .coordinator import EcoVentCoordinator
+from .entity_naming import stable_entity_id
 from .frontend import async_register_frontend
 
 _LOGGER = logging.getLogger(__name__)
@@ -42,6 +43,83 @@ _STATISTICS_UNIT_MIGRATIONS = {
     "filter_change_in": "h",
     "machine_hours": "h",
 }
+
+
+def _entity_id_has_legacy_device_id(entity_id: str, fan_id: str | None) -> bool:
+    """Return whether an entity id still carries the old device-id suffix.
+
+    Legacy EcoVent entity ids were generated from device names like
+    ``Ventilator 5``. Only rewrite those one-shot legacy ids; if a user has
+    already renamed an entity id manually, do not keep forcing our preferred id
+    on every integration reload.
+    """
+    if fan_id is None:
+        return False
+
+    legacy_slug = slugify(fan_id)
+    if not legacy_slug:
+        return False
+
+    object_id = entity_id.split(".", 1)[-1]
+    object_tokens = object_id.split("_")
+    legacy_tokens = legacy_slug.split("_")
+    token_count = len(legacy_tokens)
+    return any(
+        object_tokens[index : index + token_count] == legacy_tokens
+        for index in range(0, len(object_tokens) - token_count + 1)
+    )
+
+
+def _entity_id_matches_generated_suffix(
+    entity_id: str,
+    fan_name: str,
+    fan_id: str | None,
+    suffixes: tuple[str, ...],
+) -> bool:
+    """Return whether an entity id matches a known integration-generated name.
+
+    EcoVent ids went through several naming schemes before the stable suffixes:
+    raw keys, friendly-label slugs, typo-preserving parameter names, and old
+    ``*_set`` number names. Migrate those known generated variants, but still
+    leave unrelated user-customized ids alone.
+    """
+    object_id = entity_id.split(".", 1)[-1]
+    device_slug = slugify(fan_name)
+    legacy_device_match = _entity_id_has_legacy_device_id(entity_id, fan_id)
+
+    for suffix in {slugify(suffix) for suffix in suffixes}:
+        if object_id == suffix:
+            return True
+
+        if not object_id.endswith(f"_{suffix}"):
+            continue
+
+        prefix = object_id[: -(len(suffix) + 1)]
+        if prefix == device_slug or legacy_device_match:
+            return True
+
+    return False
+
+
+def _known_generated_unique_ids(
+    fan_name: str,
+    fan_id: str | None,
+    suffixes: tuple[str, ...],
+) -> tuple[str, ...]:
+    """Return known unique ids emitted by older EcoVent naming schemes."""
+    prefixes = (fan_name,)
+    if fan_id:
+        prefixes = (fan_name, f"{fan_name} {fan_id}", fan_id)
+
+    unique_ids: list[str] = []
+    for suffix in suffixes:
+        suffix_variants = (suffix, f"_{suffix}")
+        for suffix_variant in suffix_variants:
+            unique_ids.append(suffix_variant)
+            for prefix in prefixes:
+                unique_ids.append(f"{prefix}{suffix_variant}")
+
+    return tuple(dict.fromkeys(unique_ids))
 
 
 def _async_migrate_entity_registry(
@@ -86,49 +164,172 @@ def _async_migrate_entity_registry(
             _LOGGER.info("Removed stale EcoVent V2 beeper entity %s", beeper_entity_id)
 
     entity_id_migrations = {
-        (Platform.SENSOR, fan.id + "_speed1"): f"sensor.{device_slug}_fan_1_speed",
-        (Platform.SENSOR, fan.id + "_speed2"): f"sensor.{device_slug}_fan_2_speed",
+        (Platform.SENSOR, fan.id + "_speed1"): (
+            stable_entity_id(Platform.SENSOR, fan.name, "fan1_speed"),
+            ("fan1_speed", "fan_1_speed", "speed1", "fan_speed"),
+        ),
+        (Platform.SENSOR, fan.id + "_speed2"): (
+            stable_entity_id(Platform.SENSOR, fan.name, "fan2_speed"),
+            ("fan2_speed", "fan_2_speed", "speed2"),
+        ),
         (
             Platform.SENSOR,
             fan.id + "_filter_change_in",
-        ): f"sensor.{device_slug}_filter_change_in",
+        ): (
+            stable_entity_id(Platform.SENSOR, fan.name, "filter_change_in"),
+            ("filter_change_in", "filter_remaining", "filter_timer_countdown"),
+        ),
+        (
+            Platform.SENSOR,
+            fan.id + "_analogv",
+        ): (
+            stable_entity_id(Platform.SENSOR, fan.name, "analogv"),
+            ("analogv", "analogV", "analog_v", "analog_voltage"),
+        ),
+        (
+            Platform.BINARY_SENSOR,
+            fan.id + "_analogV_status",
+        ): (
+            stable_entity_id(Platform.BINARY_SENSOR, fan.name, "analogV_status"),
+            (
+                "analogV_status",
+                "analogv_status",
+                "analog_v_status",
+                "analog_voltage_status",
+            ),
+        ),
         (
             Platform.SWITCH,
             fan.id + "_humidity_sensor_state",
-        ): f"switch.{device_slug}_humidity_sensor",
+        ): (
+            stable_entity_id(Platform.SWITCH, fan.name, "humidity_sensor_state"),
+            ("humidity_sensor_state", "humidity_sensor"),
+        ),
         (
             Platform.SWITCH,
             fan.id + "_relay_sensor_state",
-        ): f"switch.{device_slug}_relay_sensor",
+        ): (
+            stable_entity_id(Platform.SWITCH, fan.name, "relay_sensor_state"),
+            ("relay_sensor_state", "relay_sensor"),
+        ),
         (
             Platform.SWITCH,
             fan.id + "_analogV_sensor_state",
-        ): f"switch.{device_slug}_analog_voltage_sensor",
+        ): (
+            stable_entity_id(Platform.SWITCH, fan.name, "analogV_sensor_state"),
+            (
+                "analogV_sensor_state",
+                "analogv_sensor_state",
+                "analog_voltage_sensor_state",
+                "analogV_sensor",
+                "analogv_sensor",
+                "analog_voltage_sensor",
+            ),
+        ),
         (
             Platform.NUMBER,
             fan.id + "humidity_treshold",
-        ): f"number.{device_slug}_humidity_threshold",
+        ): (
+            stable_entity_id(Platform.NUMBER, fan.name, "humidity_treshold"),
+            (
+                "humidity_treshold",
+                "humidity_threshold",
+                "humidity_threshold_set",
+            ),
+        ),
         (
             Platform.NUMBER,
             fan.id + "analogV_treshold",
-        ): f"number.{device_slug}_analog_voltage_threshold",
+        ): (
+            stable_entity_id(Platform.NUMBER, fan.name, "analogV_treshold"),
+            (
+                "analogV_treshold",
+                "analogv_treshold",
+                "analogV_treshold_set",
+                "analogv_treshold_set",
+                "analog_v_treshold",
+                "analog_v_treshold_set",
+                "analog_voltage_treshold",
+                "analogV_threshold",
+                "analogv_threshold",
+                "analogV_threshold_set",
+                "analogv_threshold_set",
+                "analog_v_threshold",
+                "analog_v_threshold_set",
+                "analog_voltage_threshold",
+            ),
+        ),
     }
-    for (domain, unique_id), new_entity_id in entity_id_migrations.items():
-        entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
-        if entity_id is None or entity_id == new_entity_id:
-            continue
+    for (domain, target_unique_id), (
+        new_entity_id,
+        generated_suffixes,
+    ) in entity_id_migrations.items():
+        unique_ids = (
+            target_unique_id,
+            *_known_generated_unique_ids(fan.name, fan.id, generated_suffixes),
+        )
+        seen_entity_ids: set[str] = set()
 
-        existing = registry.async_get(new_entity_id)
-        if existing is not None and existing.unique_id != unique_id:
-            _LOGGER.debug(
-                "Skipping EcoVent V2 entity id migration for %s: %s already exists",
+        for unique_id in unique_ids:
+            entity_id = registry.async_get_entity_id(domain, DOMAIN, unique_id)
+            if entity_id is None or entity_id in seen_entity_ids:
+                continue
+            seen_entity_ids.add(entity_id)
+
+            has_generated_entity_id = _entity_id_matches_generated_suffix(
                 entity_id,
-                new_entity_id,
+                fan.name,
+                fan.id,
+                generated_suffixes,
             )
-            continue
+            has_legacy_unique_id = unique_id != target_unique_id
+            if not has_generated_entity_id and not has_legacy_unique_id:
+                _LOGGER.debug(
+                    "Skipping EcoVent V2 entity id migration for %s: user-customized "
+                    "entity ids are preserved",
+                    entity_id,
+                )
+                continue
 
-        registry.async_update_entity(entity_id, new_entity_id=new_entity_id)
-        _LOGGER.info("Migrated EcoVent V2 entity id %s to %s", entity_id, new_entity_id)
+            update_kwargs: dict[str, str] = {}
+            if has_generated_entity_id and entity_id != new_entity_id:
+                existing = registry.async_get(new_entity_id)
+                if existing is not None and existing.entity_id != entity_id:
+                    _LOGGER.debug(
+                        "Skipping EcoVent V2 entity id migration for %s: %s already "
+                        "exists",
+                        entity_id,
+                        new_entity_id,
+                    )
+                else:
+                    update_kwargs["new_entity_id"] = new_entity_id
+
+            if has_legacy_unique_id:
+                conflict_entity_id = registry.async_get_entity_id(
+                    domain,
+                    DOMAIN,
+                    target_unique_id,
+                )
+                if conflict_entity_id is not None and conflict_entity_id != entity_id:
+                    _LOGGER.debug(
+                        "Skipping EcoVent V2 unique id migration for %s: %s is "
+                        "already used by %s",
+                        entity_id,
+                        target_unique_id,
+                        conflict_entity_id,
+                    )
+                else:
+                    update_kwargs["new_unique_id"] = target_unique_id
+
+            if not update_kwargs:
+                continue
+
+            registry.async_update_entity(entity_id, **update_kwargs)
+            _LOGGER.info(
+                "Migrated EcoVent V2 registry entry %s with %s",
+                entity_id,
+                update_kwargs,
+            )
 
     if fan.supports_parameter("weekly_schedule_setup"):
         schedule_switch_entity_id = registry.async_get_entity_id(

--- a/custom_components/ecovent_v2/binary_sensor.py
+++ b/custom_components/ecovent_v2/binary_sensor.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import (
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
+from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -168,7 +169,9 @@ async def async_setup_entry(
     )
 
 
-class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEntity
+class VentoBinarySensor(
+    StableObjectIdMixin, CoordinatorEntity, BinarySensorEntity
+):  # CoordinatorEntity
     """Vento Binary Sensor class."""
 
     _attr_entity_category = EntityCategory.DIAGNOSTIC
@@ -192,6 +195,7 @@ class VentoBinarySensor(CoordinatorEntity, BinarySensorEntity):  # CoordinatorEn
         super().__init__(coordinator)
         self._fan: Fan = coordinator._fan
         self._attr_unique_id = self._fan.id + key
+        self._ecovent_object_id_suffix = clean_object_id_suffix(method)
         self._attr_name = name
         self._state = None
         self._attr_device_class = device_class

--- a/custom_components/ecovent_v2/entity_naming.py
+++ b/custom_components/ecovent_v2/entity_naming.py
@@ -1,0 +1,50 @@
+"""Entity naming helpers for stable EcoVent registry ids."""
+
+from __future__ import annotations
+
+from homeassistant.const import Platform
+from homeassistant.util import slugify
+
+
+_SUFFIX_REPLACEMENTS = (
+    ("analogV", "analog_voltage"),
+    ("analogv", "analog_voltage"),
+    ("treshold", "threshold"),
+    ("fan1", "fan_1"),
+    ("fan2", "fan_2"),
+    ("man_speed", "manual_speed"),
+)
+
+
+def clean_object_id_suffix(value: str) -> str:
+    """Return a stable object-id suffix decoupled from UI label wording."""
+    suffix = value.removeprefix("_")
+    for old, new in _SUFFIX_REPLACEMENTS:
+        suffix = suffix.replace(old, new)
+
+    if suffix.endswith("_state"):
+        suffix = suffix.removesuffix("_state")
+
+    return slugify(suffix)
+
+
+def stable_entity_id(platform: Platform, device_name: str, suffix: str) -> str:
+    """Build the preferred entity id for one-shot legacy migrations."""
+    return f"{platform}.{slugify(device_name)}_{clean_object_id_suffix(suffix)}"
+
+
+class StableObjectIdMixin:
+    """Provide a stable object id while keeping rich friendly names."""
+
+    _ecovent_object_id_suffix: str | None = None
+
+    @property
+    def suggested_object_id(self) -> str | None:
+        """Return the object id base Home Assistant should use for new entities."""
+        if self._ecovent_object_id_suffix:
+            fan = getattr(self, "_fan", None)
+            device_name = getattr(fan, "name", None)
+            if device_name:
+                return f"{slugify(device_name)}_{self._ecovent_object_id_suffix}"
+            return self._ecovent_object_id_suffix
+        return super().suggested_object_id

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.9",
+  "version": "1.2.10",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/number.py
+++ b/custom_components/ecovent_v2/number.py
@@ -18,6 +18,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
+from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
 from .number_helpers import encode_raw_number, encode_speed_percent
 
 _LOGGER = logging.getLogger(__name__)
@@ -432,7 +433,7 @@ async def async_setup_entry(
     )
 
 
-class VentoNumber(CoordinatorEntity, NumberEntity):
+class VentoNumber(StableObjectIdMixin, CoordinatorEntity, NumberEntity):
     """Representation of a Vento Number entity."""
 
     _attr_has_entity_name = True
@@ -473,6 +474,7 @@ class VentoNumber(CoordinatorEntity, NumberEntity):
         self._attr_native_unit_of_measurement = unit_of_measurement
         self._attr_name = name
         self._attr_unique_id = self._fan.id + method
+        self._ecovent_object_id_suffix = clean_object_id_suffix(method)
         self._attr_native_value = getattr(self._fan, method)
         self._func = method
         self._value_bytes = value_bytes

--- a/custom_components/ecovent_v2/select.py
+++ b/custom_components/ecovent_v2/select.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
 from .ecoventv2 import Fan
+from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -161,7 +162,7 @@ async def async_setup_entry(
     async_add_entities(entities)
 
 
-class VentoSelect(CoordinatorEntity, SelectEntity):
+class VentoSelect(StableObjectIdMixin, CoordinatorEntity, SelectEntity):
     """Writable EcoVent enum select entity."""
 
     _attr_has_entity_name = True
@@ -180,6 +181,7 @@ class VentoSelect(CoordinatorEntity, SelectEntity):
         self._method = spec.method
         self._attr_name = spec.name
         self._attr_unique_id = self._fan.id + spec.key
+        self._ecovent_object_id_suffix = clean_object_id_suffix(spec.method)
         self._attr_icon = spec.icon
         self._attr_entity_category = spec.entity_category
         self._attr_entity_registry_enabled_default = spec.enable_by_default

--- a/custom_components/ecovent_v2/sensor.py
+++ b/custom_components/ecovent_v2/sensor.py
@@ -22,6 +22,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
+from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
 from .schedule_helpers import SCHEDULE_DAY_OPTIONS, SCHEDULE_SPEED_OPTIONS
 from .sensor_helpers import enum_options_with_value
 from .sensor_specs import SENSOR_SPECS
@@ -129,7 +130,7 @@ async def async_setup_entry(
 
 
 # VentoSensor class
-class VentoSensor(CoordinatorEntity, SensorEntity):
+class VentoSensor(StableObjectIdMixin, CoordinatorEntity, SensorEntity):
     """Class for Vento Fan Sensors."""
 
     _attr_has_entity_name = True
@@ -163,6 +164,7 @@ class VentoSensor(CoordinatorEntity, SensorEntity):
         self._attr_entity_category = entity_category
         self._attr_name = name
         self._attr_unique_id = self._fan.id + key
+        self._ecovent_object_id_suffix = clean_object_id_suffix(method)
         self._attr_entity_registry_enabled_default = enable_by_default
         self._method = getattr(self, method)
         self._attr_icon = icon
@@ -400,7 +402,7 @@ class VentoSensor(CoordinatorEntity, SensorEntity):
         return self._fan.current_wifi_ip
 
 
-class WeeklyScheduleSummarySensor(CoordinatorEntity, SensorEntity):
+class WeeklyScheduleSummarySensor(StableObjectIdMixin, CoordinatorEntity, SensorEntity):
     """Single visible entity exposing the full weekly schedule summary."""
 
     _attr_has_entity_name = True
@@ -413,6 +415,7 @@ class WeeklyScheduleSummarySensor(CoordinatorEntity, SensorEntity):
         self._fan: Fan = coordinator._fan
         self._attr_name = "Weekly schedule summary"
         self._attr_unique_id = self._fan.id + "_schedule"
+        self._ecovent_object_id_suffix = clean_object_id_suffix("weekly_schedule")
         self._attr_icon = "mdi:calendar-clock"
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self._fan.id)},

--- a/custom_components/ecovent_v2/switch.py
+++ b/custom_components/ecovent_v2/switch.py
@@ -16,6 +16,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
+from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -248,7 +249,7 @@ async def async_setup_entry(
     )
 
 
-class VentoSwitch(CoordinatorEntity, SwitchEntity):
+class VentoSwitch(StableObjectIdMixin, CoordinatorEntity, SwitchEntity):
     """Class for Vento Fan Switches."""
 
     _attr_has_entity_name = True
@@ -276,6 +277,7 @@ class VentoSwitch(CoordinatorEntity, SwitchEntity):
         self._attr_entity_category = entity_category
         self._attr_name = name
         self._attr_unique_id = self._fan.id + key
+        self._ecovent_object_id_suffix = clean_object_id_suffix(method)
         self._attr_entity_registry_enabled_default = enable_by_default
         self._method = getattr(self, method)
         #  self._attribute2 = getattr(self._fan, method)  crazy cannot be done here, only works for binary sensor.

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -13,10 +13,11 @@ FAN_PATH = COMPONENT_PATH / "fan.py"
 CONFIG_FLOW_PATH = COMPONENT_PATH / "config_flow.py"
 FRONTEND_PATH = COMPONENT_PATH / "frontend.py"
 INIT_PATH = COMPONENT_PATH / "__init__.py"
+NUMBER_PATH = COMPONENT_PATH / "number.py"
+SENSOR_PATH = COMPONENT_PATH / "sensor.py"
 SWITCH_PATH = COMPONENT_PATH / "switch.py"
 SELECT_PATH = COMPONENT_PATH / "select.py"
 BINARY_SENSOR_PATH = COMPONENT_PATH / "binary_sensor.py"
-NUMBER_PATH = COMPONENT_PATH / "number.py"
 SENSOR_SPECS_PATH = COMPONENT_PATH / "sensor_specs.py"
 STRINGS_PATH = COMPONENT_PATH / "strings.json"
 TRANSLATIONS_PATH = COMPONENT_PATH / "translations"
@@ -126,7 +127,53 @@ class Issue35RegressionTest(unittest.TestCase):
         init_source = INIT_PATH.read_text()
 
         self.assertIn('fan.id + "_speed1"', init_source)
-        self.assertIn('f"sensor.{device_slug}_fan_1_speed"', init_source)
+        self.assertIn("stable_entity_id(", init_source)
+        self.assertIn('"fan1_speed"', init_source)
+
+    def test_entity_id_migration_preserves_user_custom_ids(self):
+        init_source = INIT_PATH.read_text()
+
+        self.assertIn("_entity_id_matches_generated_suffix(", init_source)
+        self.assertIn("user-customized", init_source)
+        self.assertIn('object_tokens = object_id.split("_")', init_source)
+        self.assertIn("prefix == device_slug or legacy_device_match", init_source)
+        self.assertIn("_known_generated_unique_ids(", init_source)
+        self.assertIn('"new_unique_id"', init_source)
+        self.assertIn("has_legacy_unique_id", init_source)
+
+    def test_entity_id_migration_and_new_entities_share_suffixes(self):
+        init_source = INIT_PATH.read_text()
+
+        self.assertIn('"analogV_treshold"', init_source)
+        self.assertIn('"analogV_sensor_state"', init_source)
+        self.assertGreaterEqual(init_source.count("stable_entity_id("), 8)
+        self.assertIn('"analogv_treshold"', init_source)
+        self.assertIn('"analogv"', init_source)
+        self.assertIn('"analogV_status"', init_source)
+        self.assertIn('"analogV_treshold_set"', init_source)
+        self.assertIn('"analog_v_threshold"', init_source)
+        self.assertIn('"analog_voltage_status"', init_source)
+        self.assertIn('"analog_voltage_threshold"', init_source)
+        self.assertIn('"analogv_sensor_state"', init_source)
+        self.assertIn('"analog_voltage_sensor"', init_source)
+        self.assertIn('"humidity_threshold_set"', init_source)
+        self.assertIn('"fan_1_speed"', init_source)
+        self.assertIn('f"{fan_name} {fan_id}"', init_source)
+
+        for path in (
+            NUMBER_PATH,
+            SWITCH_PATH,
+            SENSOR_PATH,
+            SELECT_PATH,
+            BINARY_SENSOR_PATH,
+        ):
+            source = path.read_text()
+
+            self.assertIn("StableObjectIdMixin", source, path.name)
+            self.assertIn("clean_object_id_suffix", source, path.name)
+
+        naming_source = (COMPONENT_PATH / "entity_naming.py").read_text()
+        self.assertIn('f"{slugify(device_name)}_', naming_source)
 
     def test_alarm_status_keeps_problem_binary_sensor(self):
         binary_sensor_source = BINARY_SENSOR_PATH.read_text()


### PR DESCRIPTION
Fixes #50.

## Summary
- Preserve user-customized/generated entity ids during the legacy entity-id migration by only rewriting ids that still match known integration-generated names.
- Repair all known intermediate generated variants too, including old `*_set` number ids, typo-preserving `treshold` ids, `analogV`/`analogv`/`analog_v`/`analog_voltage` spellings, old analog voltage sensor/status ids, old switch `*_sensor_state` ids, and old speed/filter suffixes.
- Migrate known legacy `unique_id` variants as well as `entity_id` variants, so old registry entries are reused instead of Home Assistant creating duplicate entities with the new unique ids.
- Keep manually customized entity ids: when a legacy `unique_id` entry has a user-customized entity id, only the `unique_id` is migrated and the custom entity id is left alone.
- Share one stable object-id suffix normalizer between migration targets and newly created sensor, binary_sensor, switch, number, and select entities.
- Keep friendly UI labels free to improve without using label wording as the source for new entity ids.
- Bump the integration version and changelog to 1.2.10, assuming #48 ships as 1.2.9. If this PR lands before #48, I can adjust the version sequence.

## Validation
- `PYTHONPATH=tests python3 -m unittest discover -s tests -v` (80 tests)
- `ruff check custom_components tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `python3 -m json.tool custom_components/ecovent_v2/manifest.json >/dev/null && python3 -m json.tool custom_components/ecovent_v2/strings.json >/dev/null && for f in custom_components/ecovent_v2/translations/*.json; do python3 -m json.tool "$f" >/dev/null || exit 1; done`
- `git diff --check`
