### PR TITLE
fix(ecovent): defer startup clock sync writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ External relabels and OEM names tracked as evidence or candidates:
   - automatic sync is enabled by default and can be disabled in reconfigure
   - periodic sync checks every five minutes and writes only when the device
     clock differs from Home Assistant local time by more than a minute
+  - Home Assistant startup discovery stays read-only and defers standalone
+    clock correction, so restarting HA does not make every fan beep
   - device writes that would already beep also batch the RTC rows when the
     cached clock has drifted, avoiding a separate clock-only beep
   - the `sync_device_clock` fan service can be used for manual or automated sync
@@ -340,7 +342,8 @@ Version 1.2.9
   rows.
 * Make device clock synchronization configurable and quieter: HA local time is
   used, periodic correction only writes for drift over a minute, RTC rows are
-  batched into already-noisy writes when possible, and the manual
+  batched into already-noisy writes when possible, startup discovery defers
+  standalone clock correction, and the manual
   `sync_device_clock` service remains available.
 * Turn the unit on before applying Home Assistant airflow direction or heat
   recovery changes, so Freshpoint/Breezy ventilation mode starts reliably from

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -90,6 +90,7 @@ class EcoVentCoordinator(DataUpdateCoordinator):
                 )
             self.fan_initialized = True
             await self._async_post_init_setup()
+            self._defer_startup_clock_sync()
 
         self.updateCounter += 1
         if (self.updateCounter % 2 == 0) or (self.updateCounter < 4):
@@ -110,6 +111,18 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         """Load slow one-off state after device discovery."""
         if self._should_refresh_schedule_week():
             await self.hass.async_add_executor_job(self._load_schedule_week)
+
+    def _defer_startup_clock_sync(self) -> None:
+        """Avoid clock-only writes during Home Assistant startup discovery."""
+        if not self._auto_clock_sync or not self._supports_device_clock_sync():
+            return
+
+        now = self._device_clock_now()
+        self._last_clock_sync_check = now
+        _LOGGER.debug(
+            "EcoVentCoordinator: deferring startup clock sync check for %s",
+            self._fan.name,
+        )
 
     def _should_refresh_schedule_week(self) -> bool:
         """Return whether full weekly schedule reads are useful right now."""

--- a/tests/test_issue49_regressions.py
+++ b/tests/test_issue49_regressions.py
@@ -125,6 +125,23 @@ class Issue49RegressionTest(unittest.TestCase):
             )
         )
 
+    def test_startup_discovery_defers_standalone_clock_sync(self):
+        tree = _tree(COORDINATOR_PATH)
+        update_data = _class_method(tree, "EcoVentCoordinator", "_async_update_data")
+        defer_startup = _class_method(
+            tree, "EcoVentCoordinator", "_defer_startup_clock_sync"
+        )
+        source = COORDINATOR_PATH.read_text()
+        update_source = ast.get_source_segment(source, update_data)
+        defer_source = ast.get_source_segment(source, defer_startup)
+
+        self.assertLess(
+            update_source.index("_async_post_init_setup"),
+            update_source.index("_defer_startup_clock_sync"),
+        )
+        self.assertIn("_last_clock_sync_check", defer_source)
+        self.assertNotIn("set_rtc_datetime", defer_source)
+
     def test_manual_clock_sync_service_is_registered(self):
         tree = _tree(FAN_PATH)
         setup = _module_function(tree, "async_setup_entry")


### PR DESCRIPTION
## Summary
- keep automatic RTC sync behavior, including the five-minute periodic check
- keep Home Assistant startup/device discovery read-only by deferring the first standalone RTC correction window
- before any standalone periodic RTC write, reread `rtc_time` and `rtc_date` read-only and skip the write if fresh RTC state is unavailable/unparseable
- preserve opportunistic RTC batching into already-noisy writes and the manual `sync_device_clock` service
- document that HA restart should not make every fan beep because of startup clock sync

## Validation
- PYTHONPATH=tests python3 -m unittest discover -s tests -v
- ruff check custom_components tests
- python3 -m compileall -q custom_components/ecovent_v2 tests
- git diff --check