### PR TITLE
fix(ecovent): verify rtc before clock writes

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ External relabels and OEM names tracked as evidence or candidates:
     clock differs from Home Assistant local time by more than a minute
   - Home Assistant startup discovery stays read-only and defers standalone
     clock correction, so restarting HA does not make every fan beep
+  - standalone periodic correction rereads the device RTC immediately before
+    writing, and skips the write if the fresh RTC state is unavailable
   - device writes that would already beep also batch the RTC rows when the
     cached clock has drifted, avoiding a separate clock-only beep
   - the `sync_device_clock` fan service can be used for manual or automated sync
@@ -342,8 +344,9 @@ Version 1.2.9
   rows.
 * Make device clock synchronization configurable and quieter: HA local time is
   used, periodic correction only writes for drift over a minute, RTC rows are
-  batched into already-noisy writes when possible, startup discovery defers
-  standalone clock correction, and the manual
+  reread before standalone correction, RTC rows are batched into already-noisy
+  writes when possible, startup discovery defers standalone clock correction,
+  and the manual
   `sync_device_clock` service remains available.
 * Turn the unit on before applying Home Assistant airflow direction or heat
   recovery changes, so Freshpoint/Breezy ventilation mode starts reliably from

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -158,11 +158,37 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         if self._recently_synced_clock(now):
             return
 
+        clock_read = await self.hass.async_add_executor_job(
+            self._refresh_device_clock_state
+        )
+        if not clock_read:
+            _LOGGER.debug(
+                "EcoVentCoordinator: skipping standalone clock sync because "
+                "fresh RTC read failed for %s",
+                self._fan.name,
+            )
+            return
+
+        now = self._device_clock_now()
+        if self._device_clock_datetime() is None:
+            _LOGGER.debug(
+                "EcoVentCoordinator: skipping standalone clock sync because "
+                "fresh RTC state is unavailable for %s",
+                self._fan.name,
+            )
+            return
+
         if not self._clock_sync_needed(now):
             return
 
         await self.hass.async_add_executor_job(self._fan.set_rtc_datetime, now)
         self._record_clock_sync(now)
+
+    def _refresh_device_clock_state(self) -> bool:
+        """Read RTC rows before a standalone clock correction write."""
+        time_read = self._fan.get_param("rtc_time")
+        date_read = self._fan.get_param("rtc_date")
+        return time_read and date_read
 
     def _clock_sync_params_if_needed(self) -> dict[str, str]:
         """Return RTC rows to batch into an already noisy device write."""

--- a/tests/test_issue49_regressions.py
+++ b/tests/test_issue49_regressions.py
@@ -86,6 +86,9 @@ class Issue49RegressionTest(unittest.TestCase):
         maybe_sync = _class_method(
             tree, "EcoVentCoordinator", "_async_maybe_sync_clock"
         )
+        refresh_clock = _class_method(
+            tree, "EcoVentCoordinator", "_refresh_device_clock_state"
+        )
         sync_params = _class_method(
             tree, "EcoVentCoordinator", "_clock_sync_params_if_needed"
         )
@@ -116,8 +119,21 @@ class Issue49RegressionTest(unittest.TestCase):
         )
         self.assertLess(
             maybe_sync_source.index("_recently_synced_clock"),
+            maybe_sync_source.index("_refresh_device_clock_state"),
+        )
+        self.assertLess(
+            maybe_sync_source.index("_refresh_device_clock_state"),
+            maybe_sync_source.index("_clock_sync_needed"),
+        )
+        self.assertLess(
+            maybe_sync_source.index("_device_clock_datetime"),
             maybe_sync_source.index("set_rtc_datetime"),
         )
+        refresh_source = ast.get_source_segment(
+            COORDINATOR_PATH.read_text(), refresh_clock
+        )
+        self.assertIn('"rtc_time"', refresh_source)
+        self.assertIn('"rtc_date"', refresh_source)
         self.assertTrue(
             any(
                 isinstance(node, ast.Attribute) and node.attr == "rtc_datetime_params"


### PR DESCRIPTION
## Summary
- keep automatic RTC sync behavior, including the five-minute periodic check merged in #52
- before any standalone periodic RTC write, reread `rtc_time` and `rtc_date` read-only
- skip the standalone write if the fresh RTC read fails or the fresh RTC state is unavailable/unparseable
- keep opportunistic RTC batching into already-noisy writes and the manual `sync_device_clock` service

## Validation
- PYTHONPATH=tests python3 -m unittest discover -s tests -v
- ruff check custom_components tests
- python3 -m compileall -q custom_components/ecovent_v2 tests
- git diff --check