### PR TITLE
fix(ecovent): keep rtc and silent manual writes quiet

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,9 +388,18 @@ Version 1.2.13
   require Supervisor to report the host clock as NTP synchronized. Core and
   container installs keep the previous behavior because no Supervisor clock
   quality signal is available there.
-
-Version 1.2.14
 * In silent manual-speed mode, treat an already-on fan with the requested manual
   speed as an unchanged preset even after Home Assistant restarts and loses the
   in-memory preset facade. The facade is restored in HA state without sending a
   duplicate device write.
+* Keep steady-state silent manual-speed changes to the only observed quiet
+  write: the manual speed register. Entering silent mode may still switch the
+  fan into manual mode once, and opportunistic RTC rows may be batched there
+  because that packet already writes an audible mode register.
+* Add an internal audible-write counter so tests can assert that silent-mode
+  paths do not leak device-acknowledged writes.
+* Guard the Home Assistant fan facade with behavior tests: silent preset and
+  percentage changes may only send the manual speed register while already in
+  manual mode. Explicit direction or heat-recovery/airflow commands still need
+  the device airflow register and are allowed as audible writes, without
+  opportunistic RTC rows while the fan is already in manual mode.

--- a/README.md
+++ b/README.md
@@ -99,6 +99,8 @@ External relabels and OEM names tracked as evidence or candidates:
   - automatic sync is enabled by default and can be disabled in reconfigure
   - periodic sync checks every five minutes and writes only when the device
     clock differs from Home Assistant local time by more than a minute
+  - on Home Assistant OS/Supervised installs, automatic clock writes require
+    Supervisor to report the host clock as NTP synchronized
   - Home Assistant startup discovery stays read-only and defers standalone
     clock correction, so restarting HA does not make every fan beep
   - standalone periodic correction rereads the device RTC immediately before
@@ -380,3 +382,9 @@ Version 1.2.12
   work or refreshing the device, so repeated automations do not trigger extra
   EcoVent commands when the fan is already off, already at the requested
   preset, or already at the requested percentage.
+
+Version 1.2.13
+* On Home Assistant OS/Supervised installs, automatic device clock writes now
+  require Supervisor to report the host clock as NTP synchronized. Core and
+  container installs keep the previous behavior because no Supervisor clock
+  quality signal is available there.

--- a/README.md
+++ b/README.md
@@ -388,3 +388,9 @@ Version 1.2.13
   require Supervisor to report the host clock as NTP synchronized. Core and
   container installs keep the previous behavior because no Supervisor clock
   quality signal is available there.
+
+Version 1.2.14
+* In silent manual-speed mode, treat an already-on fan with the requested manual
+  speed as an unchanged preset even after Home Assistant restarts and loses the
+  in-memory preset facade. The facade is restored in HA state without sending a
+  duplicate device write.

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -26,6 +26,16 @@ from homeassistant.helpers.update_coordinator import (
 )
 from homeassistant.util import dt as dt_util
 
+try:
+    from homeassistant.components.hassio.coordinator import get_host_info
+    from homeassistant.helpers.hassio import is_hassio
+except ImportError:
+    get_host_info = None
+
+    def is_hassio(hass):
+        """Return false when HA has no Supervisor helper available."""
+        return False
+
 from .const import CONF_AUTO_CLOCK_SYNC, CONF_SILENT_MODE, DOMAIN
 
 _LOGGER = logging.getLogger(__name__)
@@ -158,6 +168,13 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         if self._recently_synced_clock(now):
             return
 
+        if not self._host_clock_synchronized():
+            _LOGGER.debug(
+                "EcoVentCoordinator: skipping standalone clock sync because "
+                "Home Assistant host time is not NTP synchronized"
+            )
+            return
+
         clock_read = await self.hass.async_add_executor_job(
             self._refresh_device_clock_state
         )
@@ -190,9 +207,26 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         date_read = self._fan.get_param("rtc_date")
         return time_read and date_read
 
+    def _host_clock_synchronized(self) -> bool:
+        """Return whether HA has a trustworthy host clock signal."""
+        if not is_hassio(self.hass):
+            return True
+
+        if get_host_info is None:
+            return False
+
+        host_info = get_host_info(self.hass)
+        if host_info is None:
+            return False
+
+        return host_info.get("dt_synchronized") is True
+
     def _clock_sync_params_if_needed(self) -> dict[str, str]:
         """Return RTC rows to batch into an already noisy device write."""
         if not self._auto_clock_sync or not self._supports_device_clock_sync():
+            return {}
+
+        if not self._host_clock_synchronized():
             return {}
 
         now = self._device_clock_now()

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -309,6 +309,7 @@ class Fan(
         self._unknown_params = {}
         self.socket = None
         self._bulk_read_supported = None
+        self.audible_write_command_count = 0
         self._profile_key = "vento"
         self._set_device_profile("vento")
 

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -279,7 +279,6 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
                 self._fan.state == "on"
                 and self._fan.speed == "manual"
                 and self._fan.man_speed == max(2, target_percentage)
-                and self.coordinator.silent_preset_mode == preset_mode
             )
 
         return preset_mode == self.preset_mode
@@ -427,6 +426,9 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         if self._is_preset_mode_unchanged(preset_mode):
             if preset_mode == "off":
                 self.coordinator.set_silent_preset_mode(None)
+            elif self._silent_mode_controls_manual_speed:
+                self.coordinator.set_silent_preset_mode(preset_mode)
+                self.async_write_ha_state()
             _LOGGER.debug(
                 "Skipping unchanged preset command for %s: %s",
                 self._fan.name,

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -172,7 +172,12 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         self._fan.set_param(name, target)
         return True
 
-    def _set_parameters_if_changed(self, targets: dict[str, Any]) -> bool:
+    def _set_parameters_if_changed(
+        self,
+        targets: dict[str, Any],
+        *,
+        include_extra_write_parameters: bool = True,
+    ) -> bool:
         """Write changed device parameters in one packet."""
         changed = {}
         for name, target in targets.items():
@@ -190,7 +195,10 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         if not changed:
             return False
 
-        self._fan.set_parameters(changed)
+        self._fan.set_parameters(
+            changed,
+            include_extra_write_parameters=include_extra_write_parameters,
+        )
         return True
 
     def _set_manual_percentage_if_changed(self, percentage: int) -> bool:
@@ -261,7 +269,23 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         if extra_targets:
             targets.update(extra_targets)
 
-        changed = self._set_parameters_if_changed(targets) or changed
+        entering_manual_mode = self._fan.speed != "manual"
+        if targets and not entering_manual_mode and not extra_targets:
+            audible_targets = set(targets) - {"man_speed"}
+            assert not audible_targets, (
+                "steady-state silent manual speed update would emit audible "
+                f"writes: {sorted(audible_targets)}"
+            )
+
+        audible_writes_before = self._fan.audible_write_command_count
+        changed = self._set_parameters_if_changed(
+            targets,
+            include_extra_write_parameters=entering_manual_mode,
+        ) or changed
+        if targets and not entering_manual_mode and not extra_targets:
+            assert (
+                self._fan.audible_write_command_count == audible_writes_before
+            ), "steady-state silent manual speed update emitted an audible write"
         self.coordinator.set_silent_preset_mode(preset_mode)
         return changed
 

--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -223,6 +223,9 @@ class FanProtocolMixin:
         if include_extra_write_parameters:
             encoded_params += self._extra_write_parameters(command, encoded_params)
 
+        if self._write_may_be_audible(command, encoded_params):
+            self.audible_write_command_count += 1
+
         data = command + encoded_params
         response = False
         i = 0
@@ -237,6 +240,22 @@ class FanProtocolMixin:
             if i >= retries:
                 # print ("EcoventV2: Timeout device: " + self._host + " bail out after " + str(i) + " retries" , file = sys.stderr )
                 return False
+
+    def _write_may_be_audible(self, command, encoded_params):
+        """Return whether a write is expected to make the device acknowledge.
+
+        Read commands do not beep, and the only known quiet write is a single
+        manual-speed register update (0x0044). Everything else is counted so
+        silent-mode tests can assert that no audible command leaked in.
+        """
+        if command != self.func["write_return"] or not encoded_params:
+            return False
+
+        return not self._is_manual_speed_only_write(encoded_params)
+
+    def _is_manual_speed_only_write(self, encoded_params):
+        """Return whether encoded params contain exactly one 0x0044 write."""
+        return len(encoded_params) == 4 and encoded_params[:2].lower() == "44"
 
     def update(self):
         request = ""

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.13",
+  "version": "1.2.14",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.12",
+  "version": "1.2.13",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.14",
+  "version": "1.2.13",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -160,6 +160,54 @@ class PacketBuilderTest(unittest.TestCase):
             ],
         )
 
+    def test_manual_speed_only_write_is_counted_as_quiet(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+
+        def send(data):
+            calls.append(data)
+            return True
+
+        fan.send = send
+        fan.receive = lambda: packet_with_payload([])
+
+        fan.set_man_speed_percent(73)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("0344bb", calls[0])
+        self.assertEqual(fan.audible_write_command_count, 0)
+
+    def test_read_commands_do_not_increment_audible_write_count(self):
+        fan = Fan("192.0.2.1")
+        fan.send = lambda data: True
+        fan.receive = lambda: packet_with_payload([])
+
+        self.assertTrue(fan.get_param("state"))
+
+        self.assertEqual(fan.audible_write_command_count, 0)
+
+    def test_mode_write_increments_audible_write_count(self):
+        fan = Fan("192.0.2.1")
+        fan.send = lambda data: True
+        fan.receive = lambda: packet_with_payload([])
+
+        self.assertTrue(fan.set_param("state", "on"))
+
+        self.assertEqual(fan.audible_write_command_count, 1)
+
+    def test_clock_rows_make_manual_speed_batch_audible(self):
+        fan = Fan("192.0.2.1")
+        fan.extra_write_parameters_callback = lambda: {
+            "rtc_time": "1e2d13",
+            "rtc_date": "1704041a",
+        }
+        fan.send = lambda data: True
+        fan.receive = lambda: packet_with_payload([])
+
+        self.assertTrue(fan.set_parameters({"man_speed": "73"}))
+
+        self.assertEqual(fan.audible_write_command_count, 1)
+
     def test_opportunistic_clock_sync_is_batched_into_existing_writes(self):
         fan = Fan("192.0.2.1")
         calls = []

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -279,6 +279,10 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertIn("silent_preset_mode", fan_source)
         self.assertIn("_set_silent_manual_percentage", fan_source)
         self.assertIn("_set_parameters_if_changed", fan_source)
+        self.assertIn("entering_manual_mode = self._fan.speed != \"manual\"", fan_source)
+        self.assertIn("include_extra_write_parameters=entering_manual_mode", fan_source)
+        self.assertIn("audible_write_command_count", fan_source)
+        self.assertIn("steady-state silent manual speed update", fan_source)
         self.assertIn("This protocol ignores an off -> on transition", fan_source)
 
         silent_targets = _class_method(tree, "VentoExpertFan", "_silent_manual_targets")
@@ -291,6 +295,8 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertNotIn("humidity_sensor_state", silent_target_constants)
         self.assertNotIn("relay_sensor_state", silent_target_constants)
         self.assertNotIn("analogV_sensor_state", silent_target_constants)
+        self.assertIn("speed", silent_target_constants)
+        self.assertIn("man_speed", silent_target_constants)
         self.assertTrue(
             any(
                 isinstance(call, ast.Call)

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -168,6 +168,12 @@ class Issue35RegressionTest(unittest.TestCase):
         )
         self.assertIn("target_percentage = self._silent_preset_percentage(preset_mode)", preset_guard)
         self.assertIn("self._fan.man_speed == max(2, target_percentage)", preset_guard)
+        self.assertNotIn("self.coordinator.silent_preset_mode == preset_mode", preset_guard)
+        self.assertIn("set_silent_preset_mode(preset_mode)", set_preset)
+        self.assertLess(
+            set_preset.index("set_silent_preset_mode(preset_mode)"),
+            set_preset.index("return"),
+        )
         self.assertIn("percentage > 0", set_percentage)
         self.assertLess(
             set_percentage.index("percentage <= 0 and self._fan.state == \"off\""),

--- a/tests/test_issue49_regressions.py
+++ b/tests/test_issue49_regressions.py
@@ -59,6 +59,10 @@ class Issue49RegressionTest(unittest.TestCase):
         self.assertIn("CLOCK_SYNC_INTERVAL", source)
         self.assertIn("_device_clock_datetime", source)
         self.assertIn("_local_wall_clock", source)
+        self.assertIn("_host_clock_synchronized", source)
+        self.assertIn("dt_synchronized", source)
+        self.assertIn("get_host_info", source)
+        self.assertIn("is_hassio", source)
         self.assertIn("extra_write_parameters_callback", source)
         self.assertTrue(
             any(
@@ -119,6 +123,10 @@ class Issue49RegressionTest(unittest.TestCase):
         )
         self.assertLess(
             maybe_sync_source.index("_recently_synced_clock"),
+            maybe_sync_source.index("_host_clock_synchronized"),
+        )
+        self.assertLess(
+            maybe_sync_source.index("_host_clock_synchronized"),
             maybe_sync_source.index("_refresh_device_clock_state"),
         )
         self.assertLess(

--- a/tests/test_silent_fan_entity.py
+++ b/tests/test_silent_fan_entity.py
@@ -1,0 +1,184 @@
+"""Behavior tests for the Home Assistant silent-mode fan facade."""
+
+from __future__ import annotations
+
+from enum import IntFlag
+from pathlib import Path
+import importlib.util
+import sys
+import types
+import unittest
+
+from ecovent_test_helpers import Fan, packet_with_payload
+
+
+COMPONENT_PATH = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"
+)
+PACKAGE_NAME = "ecovent_v2_fan_entity_test"
+
+
+class _Feature(IntFlag):
+    PRESET_MODE = 1
+    TURN_OFF = 2
+    TURN_ON = 4
+    SET_SPEED = 8
+    OSCILLATE = 16
+    DIRECTION = 32
+
+
+class _CoordinatorEntity:
+    def __init__(self, coordinator):
+        self.coordinator = coordinator
+
+
+class _FakeCoordinator:
+    silent_mode_enabled = True
+    silent_preset_mode = None
+
+    def set_silent_preset_mode(self, preset_mode):
+        self.silent_preset_mode = preset_mode
+
+
+def _module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _install_homeassistant_stubs():
+    _module("homeassistant")
+    _module("homeassistant.components")
+    _module(
+        "homeassistant.components.fan",
+        FanEntity=object,
+        FanEntityFeature=_Feature,
+    )
+    _module("homeassistant.config_entries", ConfigEntry=object)
+    _module("homeassistant.core", HomeAssistant=object)
+    _module("homeassistant.helpers")
+    _module(
+        "homeassistant.helpers.device_registry",
+        DeviceInfo=lambda **kwargs: kwargs,
+    )
+    _module(
+        "homeassistant.helpers.entity_platform",
+        AddEntitiesCallback=object,
+        async_get_current_platform=lambda: None,
+    )
+    _module(
+        "homeassistant.helpers.update_coordinator",
+        CoordinatorEntity=_CoordinatorEntity,
+    )
+
+
+def _load_fan_entity_class():
+    _install_homeassistant_stubs()
+
+    package = types.ModuleType(PACKAGE_NAME)
+    package.__path__ = [str(COMPONENT_PATH)]
+    sys.modules[PACKAGE_NAME] = package
+    _module(f"{PACKAGE_NAME}.coordinator", EcoVentCoordinator=object)
+
+    module_name = f"{PACKAGE_NAME}.fan"
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        COMPONENT_PATH / "fan.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = PACKAGE_NAME
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module.VentoExpertFan
+
+
+VentoExpertFan = _load_fan_entity_class()
+
+
+def _silent_entity(*, speed="manual", man_speed=63):
+    fan = Fan("192.0.2.1")
+    fan._state = "on"
+    fan._speed = speed
+    fan._man_speed = man_speed
+    fan._airflow = "ventilation"
+    fan._supply_speed_low = 30
+    fan._exhaust_speed_low = 30
+    fan._supply_speed_medium = 50
+    fan._exhaust_speed_medium = 50
+    fan._supply_speed_high = 63
+    fan._exhaust_speed_high = 63
+    fan.extra_write_parameters_callback = lambda: {
+        "rtc_time": "1e2d13",
+        "rtc_date": "1704041a",
+    }
+
+    calls = []
+    fan.send = lambda data: calls.append(data) or True
+    fan.receive = lambda: packet_with_payload([])
+
+    entity = VentoExpertFan.__new__(VentoExpertFan)
+    entity._fan = fan
+    entity.coordinator = _FakeCoordinator()
+    return entity, fan, calls
+
+
+class SilentFanEntityTest(unittest.TestCase):
+    def test_entering_silent_manual_mode_allows_one_audible_mode_write(self):
+        entity, fan, calls = _silent_entity(speed="high", man_speed=30)
+
+        entity.set_preset_mode("high")
+
+        self.assertEqual(fan.audible_write_command_count, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("0302ff44a1", calls[0])
+        self.assertIn("fe036f1e2d13", calls[0])
+
+    def test_steady_state_silent_preset_change_writes_only_manual_speed(self):
+        entity, fan, calls = _silent_entity(speed="manual", man_speed=63)
+
+        entity.set_preset_mode("medium")
+
+        self.assertEqual(fan.audible_write_command_count, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("034480", calls[0])
+        self.assertNotIn("02ff", calls[0])
+        self.assertNotIn("fe036f", calls[0])
+
+    def test_entering_manual_percentage_allows_one_audible_mode_write(self):
+        entity, fan, calls = _silent_entity(speed="high", man_speed=30)
+
+        entity.set_percentage(63)
+
+        self.assertEqual(fan.audible_write_command_count, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("0302ff44a1", calls[0])
+        self.assertIn("fe036f1e2d13", calls[0])
+        self.assertEqual(entity.coordinator.silent_preset_mode, "manual")
+
+    def test_steady_state_silent_percentage_writes_only_manual_speed(self):
+        entity, fan, calls = _silent_entity(speed="manual", man_speed=63)
+
+        entity.set_percentage(50)
+
+        self.assertEqual(fan.audible_write_command_count, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("034480", calls[0])
+        self.assertNotIn("02ff", calls[0])
+        self.assertNotIn("fe036f", calls[0])
+        self.assertEqual(entity.coordinator.silent_preset_mode, "manual")
+
+    def test_steady_state_silent_airflow_change_is_allowed_but_audible(self):
+        entity, fan, calls = _silent_entity(speed="manual", man_speed=63)
+
+        entity.set_airflow_mode("air_supply")
+
+        self.assertEqual(fan.audible_write_command_count, 1)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("03b702", calls[0])
+        self.assertNotIn("fe036f", calls[0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- use Home Assistant Supervisor host info on HA OS/Supervised installs and skip automatic RTC writes unless `dt_synchronized` is true
- keep Core/container behavior unchanged when Supervisor is unavailable, because HA has no Supervisor clock-quality signal there
- restore the silent manual-speed preset facade after Home Assistant restarts without sending a duplicate device write
- keep steady-state silent preset/percentage changes to the quiet manual-speed register when the fan is already in manual mode
- bump manifest/release notes to a single `1.2.13` entry so this can be released directly after merge

## Validation
- `PYTHONPATH=tests python3 -m unittest discover -s tests -v`
- `ruff check custom_components tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `git diff --check origin/main...HEAD`

## Reference
- Closes #49
- Closes #16
- Closes #35
- References #38, where VENTO/TwinFresh beeper behavior was narrowed to the same practical workaround: stay in manual mode and only change manual speed when possible.
- Home Assistant Supervisor `/host/info` exposes `dt_synchronized`, documented as true when the host is synchronized with an NTP service.
