### PR TITLE
fix(ecovent): avoid executor kwargs for fan turn on

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,3 +369,8 @@ Version 1.2.10
 * Use the same stable object-id suffixes for newly created entities and legacy
   migrations, keeping readable UI labels without changing entity ids just
   because labels gained clearer prefixes.
+
+Version 1.2.11
+* Fix Home Assistant fan `turn_on` calls without an explicit speed or preset in
+  silent manual-speed mode, so `preset_mode` is not passed as an unsupported
+  executor keyword argument.

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from functools import partial
 from typing import Any
 
 from homeassistant.components.fan import FanEntity, FanEntityFeature
@@ -343,11 +344,13 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         if preset_mode is None and percentage is None:
             if self._silent_mode_controls_manual_speed:
                 await self.hass.async_add_executor_job(
-                    self._set_silent_manual_percentage,
-                    self._silent_preset_percentage(
-                        self.coordinator.silent_preset_mode or "manual"
+                    partial(
+                        self._set_silent_manual_percentage,
+                        self._silent_preset_percentage(
+                            self.coordinator.silent_preset_mode or "manual"
+                        ),
+                        preset_mode=self.coordinator.silent_preset_mode or "manual",
                     ),
-                    preset_mode=self.coordinator.silent_preset_mode or "manual",
                 )
                 await self.coordinator.async_refresh()
                 return

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.10",
+  "version": "1.2.11",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -109,6 +109,20 @@ class Issue35RegressionTest(unittest.TestCase):
             )
         )
 
+    def test_executor_jobs_do_not_use_keyword_arguments(self):
+        tree = _tree(FAN_PATH)
+
+        executor_calls_with_keywords = [
+            call.lineno
+            for call in ast.walk(tree)
+            if isinstance(call, ast.Call)
+            and isinstance(call.func, ast.Attribute)
+            and call.func.attr == "async_add_executor_job"
+            and call.keywords
+        ]
+
+        self.assertEqual(executor_calls_with_keywords, [])
+
     def test_weekly_schedule_switch_stays_visible(self):
         switch_source = SWITCH_PATH.read_text()
         init_source = INIT_PATH.read_text()


### PR DESCRIPTION
## Summary
- Fixes fan `turn_on` without an explicit speed/preset in silent manual-speed mode by wrapping the preset callback with `functools.partial` instead of passing executor keyword arguments.
- Bumps the integration manifest and README changelog to `1.2.11`.

Closes #55

## Validation
- `PYTHONPATH=tests python3 -m unittest discover -s tests -v`
- `ruff check custom_components tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `python3 -m json.tool custom_components/ecovent_v2/manifest.json >/dev/null`
- `python3 -m json.tool hacs.json >/dev/null`
- `git diff --check`