### PR TITLE
fix(ecovent): skip unchanged fan service calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,3 +374,9 @@ Version 1.2.11
 * Fix Home Assistant fan `turn_on` calls without an explicit speed or preset in
   silent manual-speed mode, so `preset_mode` is not passed as an unsupported
   executor keyword argument.
+
+Version 1.2.12
+* Skip unchanged Home Assistant fan service calls before scheduling executor
+  work or refreshing the device, so repeated automations do not trigger extra
+  EcoVent commands when the fan is already off, already at the requested
+  preset, or already at the requested percentage.

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -265,6 +265,25 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         self.coordinator.set_silent_preset_mode(preset_mode)
         return changed
 
+    def _is_preset_mode_unchanged(self, preset_mode: str) -> bool:
+        """Return whether a preset service call is a true local no-op."""
+        if preset_mode == "off":
+            return self._fan.state == "off"
+
+        if self._silent_mode_controls_manual_speed:
+            if preset_mode not in self.preset_modes:
+                return False
+
+            target_percentage = self._silent_preset_percentage(preset_mode)
+            return (
+                self._fan.state == "on"
+                and self._fan.speed == "manual"
+                and self._fan.man_speed == max(2, target_percentage)
+                and self.coordinator.silent_preset_mode == preset_mode
+            )
+
+        return preset_mode == self.preset_mode
+
     def set_airflow_mode(self, airflow: str, turn_on: bool = True) -> None:
         """Set airflow mode, optionally turning the fan on first."""
         if self._silent_mode_controls_manual_speed:
@@ -361,6 +380,10 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         """Turn off the entity."""
+        if self._fan.state == "off":
+            _LOGGER.debug("Skipping unchanged turn_off command for %s", self._fan.name)
+            return
+
         await self.hass.async_add_executor_job(
             self._set_param_if_changed, "state", "off"
         )
@@ -401,6 +424,16 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
+        if self._is_preset_mode_unchanged(preset_mode):
+            if preset_mode == "off":
+                self.coordinator.set_silent_preset_mode(None)
+            _LOGGER.debug(
+                "Skipping unchanged preset command for %s: %s",
+                self._fan.name,
+                preset_mode,
+            )
+            return
+
         await self.hass.async_add_executor_job(self.set_preset_mode, preset_mode, True)
         await self.coordinator.async_refresh()
 
@@ -432,6 +465,30 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
+        if percentage <= 0 and self._fan.state == "off":
+            _LOGGER.debug(
+                "Skipping unchanged percentage command for %s: %s%%",
+                self._fan.name,
+                percentage,
+            )
+            return
+
+        if (
+            percentage > 0
+            and not self._fan.uses_operating_mode_presets
+            and self._fan.speed == "manual"
+            and percentage == self.percentage
+        ):
+            if self._silent_mode_controls_manual_speed:
+                self.coordinator.set_silent_preset_mode("manual")
+                self.async_write_ha_state()
+            _LOGGER.debug(
+                "Skipping unchanged percentage command for %s: %s%%",
+                self._fan.name,
+                percentage,
+            )
+            return
+
         await self.hass.async_add_executor_job(self.set_percentage, percentage, True)
         await self.coordinator.async_refresh()
 

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.11",
+  "version": "1.2.12",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -123,6 +123,69 @@ class Issue35RegressionTest(unittest.TestCase):
 
         self.assertEqual(executor_calls_with_keywords, [])
 
+    def test_unchanged_fan_services_return_before_executor_job(self):
+        tree = _tree(FAN_PATH)
+        source = FAN_PATH.read_text()
+
+        methods = [
+            ("async_turn_off", "self._fan.state == \"off\"", "async_add_executor_job"),
+            (
+                "async_set_preset_mode",
+                "self._is_preset_mode_unchanged(preset_mode)",
+                "async_add_executor_job",
+            ),
+            (
+                "async_set_percentage",
+                "percentage <= 0 and self._fan.state == \"off\"",
+                "async_add_executor_job",
+            ),
+        ]
+
+        for method_name, guard, executor in methods:
+            with self.subTest(method=method_name):
+                method = _class_method(tree, "VentoExpertFan", method_name)
+                method_source = ast.get_source_segment(source, method)
+
+                self.assertIn(guard, method_source)
+                self.assertLess(
+                    method_source.index(guard),
+                    method_source.index(executor),
+                )
+
+        set_preset = ast.get_source_segment(
+            source, _class_method(tree, "VentoExpertFan", "async_set_preset_mode")
+        )
+        set_percentage = ast.get_source_segment(
+            source, _class_method(tree, "VentoExpertFan", "async_set_percentage")
+        )
+
+        self.assertLess(
+            set_preset.index("set_silent_preset_mode(None)"),
+            set_preset.index("return"),
+        )
+        preset_guard = ast.get_source_segment(
+            source, _class_method(tree, "VentoExpertFan", "_is_preset_mode_unchanged")
+        )
+        self.assertIn("target_percentage = self._silent_preset_percentage(preset_mode)", preset_guard)
+        self.assertIn("self._fan.man_speed == max(2, target_percentage)", preset_guard)
+        self.assertIn("percentage > 0", set_percentage)
+        self.assertLess(
+            set_percentage.index("percentage <= 0 and self._fan.state == \"off\""),
+            set_percentage.index("return"),
+        )
+        self.assertLess(
+            set_percentage.index("percentage <= 0 and self._fan.state == \"off\""),
+            set_percentage.index('set_silent_preset_mode("manual")'),
+        )
+        self.assertLess(
+            set_percentage.index('set_silent_preset_mode("manual")'),
+            set_percentage.index("async_write_ha_state()"),
+        )
+        self.assertLess(
+            set_percentage.index("async_write_ha_state()"),
+            set_percentage.rindex("return"),
+        )
+
     def test_weekly_schedule_switch_stays_visible(self):
         switch_source = SWITCH_PATH.read_text()
         init_source = INIT_PATH.read_text()


### PR DESCRIPTION
## Summary
- return early from unchanged `turn_off` and preset service calls before scheduling executor work or refreshing the device
- treat silent manual-speed presets as unchanged only when the underlying device is already on, in manual mode, and at the target manual percentage
- skip unchanged manual percentage calls without suppressing preset-to-manual or extract-fan operating-mode side effects
- keep silent-mode facade state consistent for local no-op percentage calls and bump the manifest/release notes to 1.2.12

## Why
Repeated Home Assistant automations can call `fan.set_preset_mode` every minute even when the EcoVent is already in the requested preset. On VENTO/TwinFresh-style devices this still walks the device command/refresh path, which can produce audible beep bursts like the ones reported in #38.

This keeps true no-op fan services local to Home Assistant while preserving calls that still have semantic side effects, such as extract-fan operating-mode writes, preset-to-manual transitions, or silent-mode preset restoration after the real manual speed changed.

Fixes #38

## Validation
- `PYTHONPATH=tests python3 -m unittest discover -s tests -v`
- `ruff check custom_components tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `git diff --check`
- `codex review --base upstream/main`
