### PR TITLE
Fix silent-mode preset speed changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,3 +403,15 @@ Version 1.2.13
   manual mode. Explicit direction or heat-recovery/airflow commands still need
   the device airflow register and are allowed as audible writes, without
   opportunistic RTC rows while the fan is already in manual mode.
+
+Version 1.2.14
+* In silent manual-speed mode, map Home Assistant `percentage: 0` to an on,
+  manual, zero-speed state instead of turning the EcoVent unit off. This lets
+  quiet-home automations reduce airflow with the quiet manual-speed register
+  rather than using audible power or preset writes.
+* Allow the visible manual speed number to be set to `0%`, matching the silent
+  zero-speed control path.
+* In silent manual-speed mode, keep preset changes effective even when a device
+  does not report configurable preset speed setpoints, by falling back to
+  deterministic low/medium/high manual-speed percentages instead of reusing the
+  current manual speed.

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -29,6 +29,16 @@ import logging
 _LOGGER = logging.getLogger(__name__)
 
 DEFAULT_ON_PERCENTAGE = 5
+DEFAULT_PRESET_PERCENTAGES = {
+    "low": 33,
+    "medium": 66,
+    "high": 100,
+    "speed_1": 20,
+    "speed_2": 40,
+    "speed_3": 60,
+    "speed_4": 80,
+    "speed_5": 100,
+}
 SPEED_RANGE = (1, 3)  # off is not included
 
 DIRECTIONS = ["forward", "reverse"]
@@ -218,7 +228,7 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     def _manual_speed_value(self, percentage: int) -> str:
         """Encode a manual speed percentage for a raw protocol batch write."""
         return encode_speed_percent(
-            max(2, percentage),
+            percentage,
             self._fan.device_profile.speed_percent_scale,
         )
 
@@ -234,18 +244,30 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             targets["state"] = "on"
         if self._fan.speed != "manual":
             targets["speed"] = "manual"
-        if percentage is not None and self._fan.man_speed != max(2, percentage):
-            targets["man_speed"] = self._manual_speed_value(percentage)
+        if percentage is not None:
+            target_percentage = max(0, min(100, percentage))
+            if self._fan.man_speed != target_percentage:
+                targets["man_speed"] = self._manual_speed_value(target_percentage)
         return targets
 
     def _silent_preset_percentage(self, preset_mode: str) -> int:
         """Map an HA-facing preset to the manual percentage sent to the fan."""
         if preset_mode == "manual":
-            return self._fan.man_speed or DEFAULT_ON_PERCENTAGE
+            if self._fan.man_speed is not None:
+                return self._fan.man_speed
+            return DEFAULT_ON_PERCENTAGE
 
-        preset_percentage = self._fan.preset_speed_percent(preset_mode)
+        preset_percentage = self._fan.preset_speed_percent(
+            preset_mode,
+            fallback_to_manual=False,
+        )
         if preset_percentage is None:
-            return self._fan.man_speed or DEFAULT_ON_PERCENTAGE
+            fallback_percentage = DEFAULT_PRESET_PERCENTAGES.get(preset_mode)
+            if fallback_percentage is not None:
+                return fallback_percentage
+            if self._fan.man_speed is not None:
+                return self._fan.man_speed
+            return DEFAULT_ON_PERCENTAGE
         return preset_percentage
 
     def _set_silent_manual_percentage(
@@ -302,7 +324,7 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             return (
                 self._fan.state == "on"
                 and self._fan.speed == "manual"
-                and self._fan.man_speed == max(2, target_percentage)
+                and self._fan.man_speed == max(0, min(100, target_percentage))
             )
 
         return preset_mode == self.preset_mode
@@ -310,7 +332,11 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     def set_airflow_mode(self, airflow: str, turn_on: bool = True) -> None:
         """Set airflow mode, optionally turning the fan on first."""
         if self._silent_mode_controls_manual_speed:
-            percentage = self._fan.man_speed or DEFAULT_ON_PERCENTAGE
+            percentage = (
+                self._fan.man_speed
+                if self._fan.man_speed is not None
+                else DEFAULT_ON_PERCENTAGE
+            )
             preset_mode = self.coordinator.silent_preset_mode or "manual"
             self._set_silent_manual_percentage(
                 percentage,
@@ -466,6 +492,13 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
     def set_percentage(self, percentage: int, turn_on: bool = True) -> None:
         """Set the speed of the fan, as a percentage."""
         if percentage <= 0:
+            if self._silent_mode_controls_manual_speed:
+                self._set_silent_manual_percentage(
+                    0,
+                    turn_on=turn_on,
+                    preset_mode="manual",
+                )
+                return
             self._set_param_if_changed("state", "off")
             return
 
@@ -491,7 +524,11 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
 
     async def async_set_percentage(self, percentage: int) -> None:
         """Set the speed of the fan, as a percentage."""
-        if percentage <= 0 and self._fan.state == "off":
+        if (
+            percentage <= 0
+            and self._fan.state == "off"
+            and not self._silent_mode_controls_manual_speed
+        ):
             _LOGGER.debug(
                 "Skipping unchanged percentage command for %s: %s%%",
                 self._fan.name,
@@ -500,10 +537,10 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             return
 
         if (
-            percentage > 0
-            and not self._fan.uses_operating_mode_presets
+            not self._fan.uses_operating_mode_presets
             and self._fan.speed == "manual"
             and percentage == self.percentage
+            and (percentage > 0 or self._silent_mode_controls_manual_speed)
         ):
             if self._silent_mode_controls_manual_speed:
                 self.coordinator.set_silent_preset_mode("manual")

--- a/custom_components/ecovent_v2/fan_controls.py
+++ b/custom_components/ecovent_v2/fan_controls.py
@@ -23,7 +23,7 @@ class FanControlsMixin:
             self.send_command(self.func["write_return"], request, value)
 
     def set_man_speed_percent(self, speed):
-        if speed >= 2 and speed <= 100:
+        if speed >= 0 and speed <= 100:
             request = "0044"
             if self.device_profile.speed_percent_scale == "percent":
                 value = speed

--- a/custom_components/ecovent_v2/fan_speed_properties.py
+++ b/custom_components/ecovent_v2/fan_speed_properties.py
@@ -94,7 +94,7 @@ class FanSpeedPropertiesMixin:
     def exhaust_speed_5(self, input):
         self._exhaust_speed_5 = self._preset_speed_percent(input)
 
-    def preset_speed_percent(self, preset):
+    def preset_speed_percent(self, preset, *, fallback_to_manual=True):
         if self.uses_operating_mode_presets:
             return self.max_speed_setpoint
 
@@ -110,7 +110,7 @@ class FanSpeedPropertiesMixin:
         }
         preset_speed = preset_speeds.get(preset)
         if preset_speed is None:
-            return self.man_speed
+            return self.man_speed if fallback_to_manual else None
 
         supply_speed, exhaust_speed = preset_speed
         if self.airflow == "air_supply" and supply_speed is not None:
@@ -123,7 +123,7 @@ class FanSpeedPropertiesMixin:
         ]
         if available_speeds:
             return int(sum(available_speeds) / len(available_speeds))
-        return self.man_speed
+        return self.man_speed if fallback_to_manual else None
 
     @property
     def man_speed(self):

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.13",
+  "version": "1.2.14",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "iot_class": "local_polling",

--- a/custom_components/ecovent_v2/number.py
+++ b/custom_components/ecovent_v2/number.py
@@ -50,7 +50,7 @@ NUMBER_SPECS = (
         "man_speed",
         "mdi:fan",
         True,
-        native_min_value=2.0,
+        native_min_value=0.0,
         native_max_value=100.0,
         native_step=1,
         unit_of_measurement=PERCENTAGE,

--- a/tests/test_ecovent_number_helpers.py
+++ b/tests/test_ecovent_number_helpers.py
@@ -55,6 +55,7 @@ class NumberHelperTest(unittest.TestCase):
             _keyword_value(manual_specs[0], "write_mode"),
             "manual_speed_percent",
         )
+        self.assertEqual(_keyword_value(manual_specs[0], "native_min_value"), 0.0)
 
     def test_preset_speed_numbers_are_disabled_by_default(self):
         speed_specs = [

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -177,6 +177,18 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertIn("0344bb", calls[0])
         self.assertEqual(fan.audible_write_command_count, 0)
 
+    def test_manual_speed_zero_write_reaches_device(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+        fan.send = lambda data: calls.append(data) or True
+        fan.receive = lambda: packet_with_payload([])
+
+        fan.set_man_speed_percent(0)
+
+        self.assertEqual(len(calls), 1)
+        self.assertIn("034400", calls[0])
+        self.assertEqual(fan.audible_write_command_count, 0)
+
     def test_read_commands_do_not_increment_audible_write_count(self):
         fan = Fan("192.0.2.1")
         fan.send = lambda data: True

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -136,7 +136,7 @@ class Issue35RegressionTest(unittest.TestCase):
             ),
             (
                 "async_set_percentage",
-                "percentage <= 0 and self._fan.state == \"off\"",
+                "percentage <= 0",
                 "async_add_executor_job",
             ),
         ]
@@ -167,20 +167,27 @@ class Issue35RegressionTest(unittest.TestCase):
             source, _class_method(tree, "VentoExpertFan", "_is_preset_mode_unchanged")
         )
         self.assertIn("target_percentage = self._silent_preset_percentage(preset_mode)", preset_guard)
-        self.assertIn("self._fan.man_speed == max(2, target_percentage)", preset_guard)
+        self.assertIn(
+            "self._fan.man_speed == max(0, min(100, target_percentage))",
+            preset_guard,
+        )
         self.assertNotIn("self.coordinator.silent_preset_mode == preset_mode", preset_guard)
         self.assertIn("set_silent_preset_mode(preset_mode)", set_preset)
         self.assertLess(
             set_preset.index("set_silent_preset_mode(preset_mode)"),
             set_preset.index("return"),
         )
-        self.assertIn("percentage > 0", set_percentage)
+        self.assertIn("not self._fan.uses_operating_mode_presets", set_percentage)
+        self.assertIn(
+            "percentage > 0 or self._silent_mode_controls_manual_speed",
+            set_percentage,
+        )
         self.assertLess(
-            set_percentage.index("percentage <= 0 and self._fan.state == \"off\""),
+            set_percentage.index("percentage <= 0"),
             set_percentage.index("return"),
         )
         self.assertLess(
-            set_percentage.index("percentage <= 0 and self._fan.state == \"off\""),
+            set_percentage.index("percentage <= 0"),
             set_percentage.index('set_silent_preset_mode("manual")'),
         )
         self.assertLess(

--- a/tests/test_silent_fan_entity.py
+++ b/tests/test_silent_fan_entity.py
@@ -146,6 +146,24 @@ class SilentFanEntityTest(unittest.TestCase):
         self.assertNotIn("02ff", calls[0])
         self.assertNotIn("fe036f", calls[0])
 
+    def test_silent_preset_uses_fallback_when_device_has_no_setpoints(self):
+        entity, fan, calls = _silent_entity(speed="manual", man_speed=63)
+        fan._supply_speed_low = None
+        fan._exhaust_speed_low = None
+        fan._supply_speed_medium = None
+        fan._exhaust_speed_medium = None
+        fan._supply_speed_high = None
+        fan._exhaust_speed_high = None
+
+        entity.set_preset_mode("medium")
+
+        self.assertEqual(fan.audible_write_command_count, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("0344a9", calls[0])
+        self.assertNotIn("02ff", calls[0])
+        self.assertNotIn("fe036f", calls[0])
+        self.assertEqual(entity.coordinator.silent_preset_mode, "medium")
+
     def test_entering_manual_percentage_allows_one_audible_mode_write(self):
         entity, fan, calls = _silent_entity(speed="high", man_speed=30)
 
@@ -165,6 +183,18 @@ class SilentFanEntityTest(unittest.TestCase):
         self.assertEqual(fan.audible_write_command_count, 0)
         self.assertEqual(len(calls), 1)
         self.assertIn("034480", calls[0])
+        self.assertNotIn("02ff", calls[0])
+        self.assertNotIn("fe036f", calls[0])
+        self.assertEqual(entity.coordinator.silent_preset_mode, "manual")
+
+    def test_steady_state_silent_zero_percentage_keeps_manual_mode_on(self):
+        entity, fan, calls = _silent_entity(speed="manual", man_speed=11)
+
+        entity.set_percentage(0)
+
+        self.assertEqual(fan.audible_write_command_count, 0)
+        self.assertEqual(len(calls), 1)
+        self.assertIn("034400", calls[0])
         self.assertNotIn("02ff", calls[0])
         self.assertNotIn("fe036f", calls[0])
         self.assertEqual(entity.coordinator.silent_preset_mode, "manual")


### PR DESCRIPTION
## Summary

- fix silent manual-speed mode so Home Assistant preset changes (`low` / `medium` / `high`) still change the fan speed
- when the fan does not report configurable preset speed setpoints, map presets to deterministic manual-speed percentages instead of reusing the current manual speed and treating the call as unchanged
- keep `percentage: 0` in silent manual-speed mode on the quiet manual-speed path instead of converting it into an EcoVent power-off command
- allow the visible manual speed number to use `0%`, matching that quiet zero-speed control path

Fixes #58.

## Testing

- `PYTHONPATH=tests python3 -m unittest discover -s tests -v`
- `ruff check custom_components tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `git diff --check`
