### PR TITLE
Fix timer mode select and frontend route race

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ External relabels and OEM names tracked as evidence or candidates:
   - high
   - manual
 * In manual mode speed percentage
+* Timer mode selection on devices exposing `0x0007`
 * Silent mode
   - optional configuration checkbox for VENTO/TwinFresh-style devices
   - keeps the device in manual speed mode and maps Home Assistant preset changes
@@ -253,14 +254,27 @@ Version 1.1.1
 Version 1.2.0
 
 * Merged @AndyNew2 pull request v1.2.0 Rework ecovent library #36
-** this is a massive rework of your integration:
-** moved your library into the integration to avoid confusions ;-)
-** There was a massive bug in the binary_sensor multiplying the update rate by 4 - 6. Therefore you had a real update rate around 10 seconds instead of the intended 1 minute ;-) This was on top of the double update before your last update ;-)
-** Added job executor to free HA timings. I checked UDP async IO but do not like it. Timeout handling is really difficult with it. Since we do the updates many less now, due to a few fixed, the overhead of an executor thread is fine. This allows now reenabling sleeps for retries. Works very well now.
-** Many bug fixes in the init and deinit code. Was no longer up to date for HA and would have created massive warnings soon. That is fixed now.
-** Few further fixes like not updating manual speed etc. Do not remember each of them, but there had been quite a lot of them.
-** Config flow has now update rate configurable and added reconfigure dialog. Set default update rate to 30 seconds (still is around 3x slower than before ;-))
-** Let me know, what you think about the changes. Runs a lot better than before. This unindented fast update created together with the fix of retries many HA issues. HA is not prepared to be blocked around 5 - 10 seconds...
+  * this is a massive rework of your integration:
+  * moved your library into the integration to avoid confusions ;-)
+  * There was a massive bug in the binary_sensor multiplying the update rate by
+    4 - 6. Therefore you had a real update rate around 10 seconds instead of the
+    intended 1 minute ;-) This was on top of the double update before your last
+    update ;-)
+  * Added job executor to free HA timings. I checked UDP async IO but do not
+    like it. Timeout handling is really difficult with it. Since we do the
+    updates many less now, due to a few fixed, the overhead of an executor
+    thread is fine. This allows now reenabling sleeps for retries. Works very
+    well now.
+  * Many bug fixes in the init and deinit code. Was no longer up to date for HA
+    and would have created massive warnings soon. That is fixed now.
+  * Few further fixes like not updating manual speed etc. Do not remember each
+    of them, but there had been quite a lot of them.
+  * Config flow has now update rate configurable and added reconfigure dialog.
+    Set default update rate to 30 seconds (still is around 3x slower than before
+    ;-))
+  * Let me know, what you think about the changes. Runs a lot better than
+    before. This unindented fast update created together with the fix of retries
+    many HA issues. HA is not prepared to be blocked around 5 - 10 seconds...
 
 Version 1.2.1
 * Merged @AndyNew2 pull request bugfix for initialization not using job executor and some config flow fixes #37
@@ -270,13 +284,13 @@ Version 1.2.2
 * fix for case, where HW returns unknown value for some statuses/states
 
 Version 1.2.3
-* Merge pull request #39 from AndyNew2/AndyNew2-Rework   
-** v1.2.3 bugfix and stability improvement
+* Merge pull request #39 from AndyNew2/AndyNew2-Rework
+  * v1.2.3 bugfix and stability improvement
 
 Version 1.2.4
 * Merge pull request #40 from AndyNew2
-** added weekly_schedule_state on request
-** Add weekly schedule state to VentoSwitch
+  * added weekly_schedule_state on request
+  * Add weekly schedule state to VentoSwitch
 
 Version 1.2.5
 * Clean up Home Assistant entity names and categories
@@ -415,3 +429,11 @@ Version 1.2.14
   does not report configurable preset speed setpoints, by falling back to
   deterministic low/medium/high manual-speed percentages instead of reusing the
   current manual speed.
+
+Version 1.2.15
+* Expose `timer_mode` as a writable select on devices that support the
+  documented `0x0007` timer mode parameter, allowing Home Assistant to select
+  Off, Night, or Party mode.
+* Guard schedule frontend registration before the first await, preventing
+  duplicate static route registration when multiple EcoVent config entries are
+  set up concurrently.

--- a/custom_components/ecovent_v2/frontend.py
+++ b/custom_components/ecovent_v2/frontend.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from hashlib import sha256
 from pathlib import Path
 
@@ -13,6 +14,7 @@ from .const import DOMAIN
 
 _FRONTEND_URL_BASE = f"/api/{DOMAIN}/frontend"
 _DIALOG_JS = "ecovent-schedule-dialog.js"
+_LOCK_KEY = f"{DOMAIN}_frontend_registration_lock"
 _REGISTERED_KEY = f"{DOMAIN}_frontend_registered"
 
 
@@ -24,19 +26,25 @@ def _frontend_module_url(frontend_dir: Path) -> str:
 
 async def async_register_frontend(hass: HomeAssistant) -> None:
     """Expose and register the schedule dialog frontend once."""
-    if hass.data.get(_REGISTERED_KEY):
-        return
+    lock = hass.data.get(_LOCK_KEY)
+    if lock is None:
+        lock = asyncio.Lock()
+        hass.data[_LOCK_KEY] = lock
 
-    frontend_dir = Path(__file__).parent / "frontend"
-    await hass.http.async_register_static_paths(
-        [
-            StaticPathConfig(
-                f"{_FRONTEND_URL_BASE}/{_DIALOG_JS}",
-                str(frontend_dir / _DIALOG_JS),
-                cache_headers=False,
-            )
-        ]
-    )
-    module_url = await hass.async_add_executor_job(_frontend_module_url, frontend_dir)
-    add_extra_js_url(hass, module_url)
-    hass.data[_REGISTERED_KEY] = True
+    async with lock:
+        if hass.data.get(_REGISTERED_KEY):
+            return
+
+        frontend_dir = Path(__file__).parent / "frontend"
+        await hass.http.async_register_static_paths(
+            [
+                StaticPathConfig(
+                    f"{_FRONTEND_URL_BASE}/{_DIALOG_JS}",
+                    str(frontend_dir / _DIALOG_JS),
+                    cache_headers=False,
+                )
+            ]
+        )
+        module_url = await hass.async_add_executor_job(_frontend_module_url, frontend_dir)
+        add_extra_js_url(hass, module_url)
+        hass.data[_REGISTERED_KEY] = True

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,9 +2,10 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.14",
+  "version": "1.2.15",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
+  "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",
   "iot_class": "local_polling",
   "loggers": ["pyEcoventV2"],
   "requirements": []

--- a/custom_components/ecovent_v2/select.py
+++ b/custom_components/ecovent_v2/select.py
@@ -45,6 +45,14 @@ SELECT_SPECS = (
         translation_key="beeper",
     ),
     SelectSpec(
+        "_timer_mode",
+        "Timer mode",
+        "timer_mode",
+        "mdi:timer-cog-outline",
+        ("timer_mode",),
+        translation_key="timer_mode",
+    ),
+    SelectSpec(
         "_screen_backlight_mode",
         "Screen backlight mode",
         "screen_backlight_mode",

--- a/hacs.json
+++ b/hacs.json
@@ -1,8 +1,6 @@
 {
   "name": "EcoVent VENTO Expert A50/80/100 V.2 Fans",
   "content_in_root": false,
-  "domains": ["fan"],  
   "homeassistant": "2025.1.0",
-  "iot_class": "local_poll",
   "render_readme": true
 }

--- a/tests/test_ecovent_profiles.py
+++ b/tests/test_ecovent_profiles.py
@@ -195,6 +195,27 @@ class ProfileParseTest(unittest.TestCase):
             [(fan.func["write_return"], "0072", "01", 10)],
         )
 
+    def test_breezy_freshpoint_profile_can_write_timer_mode(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(packet_with_payload([0xFE, 0x02, 0xB9, 0x11, 0x00]))
+        )
+
+        calls = []
+
+        def fake_send_command(func, param, value="", retries=10):
+            calls.append((func, param, value, retries))
+            return True
+
+        fan.send_command = fake_send_command
+
+        self.assertEqual(fan.parameter_options("timer_mode"), ["off", "night", "party"])
+        self.assertTrue(fan.set_param("timer_mode", "night"))
+        self.assertEqual(
+            calls,
+            [(fan.func["write_return"], "0007", "01", 10)],
+        )
+
     def test_breezy_freshpoint_profile_reads_weekly_schedule_setup(self):
         fan = Fan("192.0.2.1")
         self.assertTrue(

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -2,8 +2,13 @@
 
 from pathlib import Path
 import ast
+import asyncio
+import importlib.util
 import json
+import sys
+import types
 import unittest
+from unittest.mock import patch
 
 
 COMPONENT_PATH = (
@@ -21,6 +26,7 @@ BINARY_SENSOR_PATH = COMPONENT_PATH / "binary_sensor.py"
 SENSOR_SPECS_PATH = COMPONENT_PATH / "sensor_specs.py"
 STRINGS_PATH = COMPONENT_PATH / "strings.json"
 TRANSLATIONS_PATH = COMPONENT_PATH / "translations"
+FRONTEND_TEST_PACKAGE = "ecovent_v2_frontend_test"
 
 
 def _tree(path):
@@ -59,6 +65,83 @@ def _executor_calls(node, target_attr):
             yield call
 
 
+def _module(name, **attrs):
+    module = types.ModuleType(name)
+    for key, value in attrs.items():
+        setattr(module, key, value)
+    sys.modules[name] = module
+    return module
+
+
+def _install_frontend_stubs():
+    class StaticPathConfig:
+        def __init__(self, url_path, path, cache_headers=True):
+            self.url_path = url_path
+            self.path = path
+            self.cache_headers = cache_headers
+
+    _module("homeassistant")
+    _module("homeassistant.components")
+    _module(
+        "homeassistant.components.frontend",
+        add_extra_js_url=lambda hass, url: None,
+    )
+    _module(
+        "homeassistant.components.http",
+        StaticPathConfig=StaticPathConfig,
+    )
+    _module("homeassistant.core", HomeAssistant=object)
+
+
+def _load_frontend_module():
+    _install_frontend_stubs()
+
+    package = types.ModuleType(FRONTEND_TEST_PACKAGE)
+    package.__path__ = [str(COMPONENT_PATH)]
+    sys.modules[FRONTEND_TEST_PACKAGE] = package
+
+    module_name = f"{FRONTEND_TEST_PACKAGE}.frontend"
+    spec = importlib.util.spec_from_file_location(module_name, FRONTEND_PATH)
+    module = importlib.util.module_from_spec(spec)
+    module.__package__ = FRONTEND_TEST_PACKAGE
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class _FakeFrontendHttp:
+    def __init__(self, failures=0):
+        self.calls = 0
+        self.active_calls = 0
+        self.max_active_calls = 0
+        self.failures = failures
+
+    async def async_register_static_paths(self, paths):
+        self.calls += 1
+        self.active_calls += 1
+        self.max_active_calls = max(self.max_active_calls, self.active_calls)
+        try:
+            await asyncio.sleep(0)
+            if self.failures:
+                self.failures -= 1
+                raise RuntimeError("static path registration failed")
+            await asyncio.sleep(0)
+        finally:
+            self.active_calls -= 1
+
+
+class _FakeFrontendHass:
+    def __init__(self, failures=0):
+        self.data = {}
+        self.http = _FakeFrontendHttp(failures=failures)
+        self.executor_calls = 0
+
+    async def async_add_executor_job(self, func, *args):
+        self.executor_calls += 1
+        await asyncio.sleep(0)
+        return func(*args)
+
+
 class Issue35RegressionTest(unittest.TestCase):
     def test_frontend_digest_file_io_runs_in_executor(self):
         tree = _tree(FRONTEND_PATH)
@@ -77,6 +160,43 @@ class Issue35RegressionTest(unittest.TestCase):
 
         self.assertEqual(read_bytes_calls, [])
         self.assertTrue(executor_calls)
+
+    def test_frontend_registration_serializes_concurrent_callers(self):
+        async def run_test():
+            frontend = _load_frontend_module()
+            hass = _FakeFrontendHass()
+            with patch.object(frontend, "add_extra_js_url") as add_extra_js_url:
+                await asyncio.gather(
+                    frontend.async_register_frontend(hass),
+                    frontend.async_register_frontend(hass),
+                )
+
+            self.assertEqual(hass.http.calls, 1)
+            self.assertEqual(hass.http.max_active_calls, 1)
+            self.assertEqual(hass.executor_calls, 1)
+            add_extra_js_url.assert_called_once()
+            self.assertTrue(hass.data[frontend._REGISTERED_KEY])
+
+        asyncio.run(run_test())
+
+    def test_frontend_registration_retries_after_failure(self):
+        async def run_test():
+            frontend = _load_frontend_module()
+            hass = _FakeFrontendHass(failures=1)
+            with patch.object(frontend, "add_extra_js_url") as add_extra_js_url:
+                with self.assertRaises(RuntimeError):
+                    await frontend.async_register_frontend(hass)
+
+                self.assertIsNot(hass.data.get(frontend._REGISTERED_KEY), True)
+
+                await frontend.async_register_frontend(hass)
+
+            self.assertEqual(hass.http.calls, 2)
+            self.assertEqual(hass.executor_calls, 1)
+            add_extra_js_url.assert_called_once()
+            self.assertTrue(hass.data[frontend._REGISTERED_KEY])
+
+        asyncio.run(run_test())
 
     def test_direct_speed_change_is_live_fan_control(self):
         tree = _tree(FAN_PATH)
@@ -369,6 +489,7 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertIn('"Trigger on motion"', switch_source)
         self.assertIn('"Airflow on motion/light"', select_source)
         self.assertIn('"Trigger mode on air quality"', select_source)
+        self.assertIn('"Timer mode"', select_source)
 
     def test_preset_translations_group_boost_modes(self):
         translation_paths = [STRINGS_PATH, *TRANSLATIONS_PATH.glob("*.json")]


### PR DESCRIPTION
## Summary
- expose the reported Freshpoint/Breezy `timer_mode` parameter as a writable Home Assistant select, so Night/Party/Off can be set from the UI instead of only read as a sensor
- serialize schedule frontend registration with an async lock so concurrent config entries cannot register the same static route twice during Home Assistant startup
- cover the frontend race with behavioral async regressions: concurrent callers register the static route once, and a genuine registration failure can be retried
- bump the integration version to `1.2.15` and document the new timer mode control plus the frontend route race fix in the README
- fix older README changelog nested-bullet formatting so historic 1.2.x entries render correctly

Fixes #60
Fixes #61

## Validation
- `pytest -q tests/test_issue35_regressions.py tests/test_ecovent_profiles.py`
- `pytest -q`
- `ruff check custom_components/ecovent_v2 tests`
- `python3 -m compileall -q custom_components/ecovent_v2`
- `git diff --check`
- `rg -n '^\*\*|^\* [^\n]*\*\*|\s+$' README.md custom_components/ecovent_v2/manifest.json hacs.json || true`
- HACS action container on `cd7a5be772d6c237efdf15c55f76642b871826fc` with `INPUT_IGNORE="topics issues"` for fork-only repository metadata: All 6 actionable checks passed
- `codex review --base upstream/main`
