### PR TITLE
Fix Freshpoint polling, map DF270, and add A21 Modbus

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,12 @@ them.
 
 ## Device and brand search index
 
-Searchable brands in the reviewed catalogue are `Blauberg Ventilatoren`,
-`VENTS`, `ECONOPRIME`, `Econology`, `SIKU`, `Flexit`, `DUKA`, `OXXIFY`,
-`Oxxify`, `RL Raumklima`, `Winzel`, and `NIBE`. A listed name is not
-automatically a hardware-support guarantee. The integration chooses behavior
-from the device-reported `0x00B9` unit type:
+Searchable brand and family terms in the reviewed catalogue are `Blauberg`,
+`Blauberg Ventilatoren`, `VENTS`, `Vento`, `VENTO`, `TwinFresh`, `EcoVent`,
+`VENTS Breezy`, `VENTS Arc Smart`, `ECONOPRIME`, `Econology`, `SIKU`, `Flexit`,
+`DUKA`, `OXXIFY`, `Oxxify`, `RL Raumklima`, `Winzel`, and `NIBE`. A listed name
+is not automatically a hardware-support guarantee. The integration chooses
+behavior from the device-reported `0x00B9` unit type:
 
 * **Protocol-mapped** means the reported unit type selects an implemented
   profile. It does not mean every marketing alias has been hardware-tested.
@@ -30,23 +31,26 @@ capture to an issue instead of relying on product appearance or Wi-Fi branding.
 
 ### Protocol-mapped official names
 
-| Unit type / profile | Exact brand and model search names |
-| -- | -- |
-| `0x0100` / `vento` | `ECONOPRIME DF270`<br>`ECONOPRIME DF270 Connect` |
-| `0x0200` / `freshbox` | `Freshbox 100 WiFi`<br>`Freshbox 100 ERV WiFi`<br>`Freshbox E-100 WiFi`<br>`Freshbox E2-100 ERV WiFi`<br>`Vents Micra 100 WiFi`<br>`Vents Micra 100 ERV WiFi`<br>`Vents Micra 100 E WiFi`<br>`Vents Micra 100 E2 ERV WiFi` |
-| `0x0300` / `vento` | `VENTO Expert A50-1 S10 W V.2`<br>`VENTO Expert A85-1 S10 W V.2`<br>`VENTO Expert A100-1 S10 W V.2`<br>`VENTO Expert A50-1 W V.3`<br>`TwinFresh Expert RW1-50 V.2`<br>`TwinFresh Expert RW1-85 V.2`<br>`TwinFresh Expert RW1-100 V.2`<br>`TwinFresh Expert RW1-50 V.3` |
-| `0x0400` / `vento` | `VENTO Expert DUO A30-1 S10 W V.2`<br>`VENTO Expert DUO A30-1 S10 W V.2 BLK`<br>`TwinFresh Expert Duo RW1-30 V.2` |
-| `0x0500` / `vento` | `VENTO Expert A30 S10 W V.2`<br>`TwinFresh Expert RW-30 V.2` |
-| `0x0600` / `extract_fan` | `Blauberg Smart Wi-Fi`<br>`Smart IR Wi-Fi`<br>`Vents iFan Wi-Fi`<br>`Vents iFan Move Wi-Fi` |
-| `0x0D00` / `arc` | `Vents Arc Smart`<br>`Vents Arc Smart white`<br>`Vents Arc Smart black`<br>`Blauberg O2 Supreme`<br>`O2 Supreme white`<br>`O2 Supreme black` |
-| `0x0E00` / `vento` | `Vents TwinFresh Style Wi-Fi`<br>`TwinFresh Style Wi-Fi`<br>`Vents TwinFresh Style Frost Wi-Fi`<br>`Vents TwinFresh Style Wi-Fi mini` |
-| `0x1100` / `breezy` | `Vents Breezy 160`<br>`Vents Breezy 160-E`<br>`Vents Breezy 160-E Smart`<br>`Freshpoint 160`<br>`Freshpoint 160-E`<br>`Freshpoint 160-E L055`<br>`Freshpoint 160-E L07`<br>`Freshpoint 160-E L1`<br>`Freshpoint 160-E Pro`<br>`Freshpoint 160-E Pro L055`<br>`Freshpoint 160-E Pro L07`<br>`Freshpoint 160-E Pro L1` |
-| `0x1400` / `breezy` | `Vents Breezy Eco 160`<br>`Vents Breezy Eco 160-E`<br>`Freshpoint Eco 160`<br>`Freshpoint Eco 160-E L07` |
-| `0x1600` / `breezy` | `Vents Breezy 200-E`<br>`Vents Breezy 200-E Smart`<br>`Freshpoint 200`<br>`Freshpoint 200-E`<br>`Freshpoint 200-E L055`<br>`Freshpoint 200-E L07`<br>`Freshpoint 200-E L1`<br>`Freshpoint 200-E Pro`<br>`Freshpoint 200-E Pro L055`<br>`Freshpoint 200-E Pro L07`<br>`Freshpoint 200-E Pro L1` |
-| `0x1800` / `breezy` | `Vents Breezy Eco 200`<br>`Freshpoint Eco 200` |
-| `0x1A00` / `vento` | `VENTO inHome`<br>`TwinFresh Atmo` |
-| `0x1B00` / `vento` | `VENTO inHome 100`<br>`VENTO inHome mini`<br>`VENTO inHome mini W`<br>`TwinFresh Atmo 100`<br>`Vents TwinFresh Atmo mini`<br>`Vents TwinFresh Atmo mini Wi-Fi` |
-| `0x1C00` / `vento` | `VENTO inHome 160`<br>`VENTO inHome W`<br>`TwinFresh Atmo 160`<br>`Vents TwinFresh Atmo Wi-Fi` |
+Historical README terms are retained for search. They are not additional model
+mappings.
+
+| Unit type / profile | Exact catalog names | Historical README search spellings |
+| -- | -- | -- |
+| `0x0100` / `vento` | `ECONOPRIME DF270`<br>`ECONOPRIME DF270 Connect` | — |
+| `0x0200` / `freshbox` | `Freshbox 100 WiFi`<br>`Freshbox 100 ERV WiFi`<br>`Freshbox E-100 WiFi`<br>`Freshbox E2-100 ERV WiFi`<br>`Vents Micra 100 WiFi`<br>`Vents Micra 100 ERV WiFi`<br>`Vents Micra 100 E WiFi`<br>`Vents Micra 100 E2 ERV WiFi` | `Blauberg Freshbox 100 WiFi`<br>`Freshbox E1-100 WiFi`<br>`VENTS Micra 100 WiFi`<br>`Micra 100 E1 WiFi` |
+| `0x0300` / `vento` | `VENTO Expert A50-1 S10 W V.2`<br>`VENTO Expert A85-1 S10 W V.2`<br>`VENTO Expert A100-1 S10 W V.2`<br>`VENTO Expert A50-1 W V.3`<br>`TwinFresh Expert RW1-50 V.2`<br>`TwinFresh Expert RW1-85 V.2`<br>`TwinFresh Expert RW1-100 V.2`<br>`TwinFresh Expert RW1-50 V.3` | — |
+| `0x0400` / `vento` | `VENTO Expert DUO A30-1 S10 W V.2`<br>`VENTO Expert DUO A30-1 S10 W V.2 BLK`<br>`TwinFresh Expert Duo RW1-30 V.2` | `Blauberg VENTO Expert DUO A30-1 W V.2` |
+| `0x0500` / `vento` | `VENTO Expert A30 S10 W V.2`<br>`TwinFresh Expert RW-30 V.2` | `Blauberg VENTO Expert A30 W V.2` |
+| `0x0600` / `extract_fan` | `Blauberg Smart Wi-Fi`<br>`Smart IR Wi-Fi`<br>`Vents iFan Wi-Fi`<br>`Vents iFan Move Wi-Fi` | — |
+| `0x0D00` / `arc` | `Vents Arc Smart`<br>`Vents Arc Smart white`<br>`Vents Arc Smart black`<br>`Blauberg O2 Supreme`<br>`O2 Supreme white`<br>`O2 Supreme black` | — |
+| `0x0E00` / `vento` | `Vents TwinFresh Style Wi-Fi`<br>`TwinFresh Style Wi-Fi`<br>`Vents TwinFresh Style Frost Wi-Fi`<br>`Vents TwinFresh Style Wi-Fi mini` | — |
+| `0x1100` / `breezy` | `Vents Breezy 160`<br>`Vents Breezy 160-E`<br>`Vents Breezy 160-E Smart`<br>`Freshpoint 160`<br>`Freshpoint 160-E`<br>`Freshpoint 160-E L055`<br>`Freshpoint 160-E L07`<br>`Freshpoint 160-E L1`<br>`Freshpoint 160-E Pro`<br>`Freshpoint 160-E Pro L055`<br>`Freshpoint 160-E Pro L07`<br>`Freshpoint 160-E Pro L1` | — |
+| `0x1400` / `breezy` | `Vents Breezy Eco 160`<br>`Vents Breezy Eco 160-E`<br>`Freshpoint Eco 160`<br>`Freshpoint Eco 160-E L07` | — |
+| `0x1600` / `breezy` | `Vents Breezy 200-E`<br>`Vents Breezy 200-E Smart`<br>`Freshpoint 200`<br>`Freshpoint 200-E`<br>`Freshpoint 200-E L055`<br>`Freshpoint 200-E L07`<br>`Freshpoint 200-E L1`<br>`Freshpoint 200-E Pro`<br>`Freshpoint 200-E Pro L055`<br>`Freshpoint 200-E Pro L07`<br>`Freshpoint 200-E Pro L1` | — |
+| `0x1800` / `breezy` | `Vents Breezy Eco 200`<br>`Freshpoint Eco 200` | — |
+| `0x1A00` / `vento` | `VENTO inHome`<br>`TwinFresh Atmo` | — |
+| `0x1B00` / `vento` | `VENTO inHome 100`<br>`VENTO inHome mini`<br>`VENTO inHome mini W`<br>`TwinFresh Atmo 100`<br>`Vents TwinFresh Atmo mini`<br>`Vents TwinFresh Atmo mini Wi-Fi` | — |
+| `0x1C00` / `vento` | `VENTO inHome 160`<br>`VENTO inHome W`<br>`TwinFresh Atmo 160`<br>`Vents TwinFresh Atmo Wi-Fi` | — |
 
 ### Reported/relabel evidence
 
@@ -65,7 +69,7 @@ justify targeted protocol testing. It still does not supply a BGCP unit type.
 | Research target | Exact search names and evidence |
 | -- | -- |
 | near `0x0100` | `VENTS VUT 270 V5B EC A21` — `documentary_match` |
-| near `0x0300` | `Flexit Roomie One WiFi V2` — `candidate`<br>`DUKA One Pro 50 S Wi-Fi` — `candidate`<br>`NIBE DVC 10` — `candidate`<br>`NIBE DVC 10-50W` — `candidate` |
+| near `0x0300` | `Flexit Roomie One WiFi V2` — `candidate`<br>`DUKA One Pro 50 S Wi-Fi` — `candidate`<br>`NIBE DVC 10` — `candidate`<br>`NIBE DVC 10-50W` — `candidate`<br>`Roomie One Wifi V2` — `legacy_search`<br>`DUKA One S4 Wi-Fi` — `legacy_search`<br>`DUKA One S6 Wi-Fi` — `legacy_search`<br>`Winzel V.2` — `legacy_search` |
 | near `0x0400` | `Roomie Dual WiFi V2` — `candidate`<br>`Flexit Aura` — `candidate`<br>`Flexit Muto` — `candidate`<br>`NIBE DVC 10-D30W` — `candidate` |
 | near `0x0500` | `SIKU RV 25 W Pro WiFi V2` — `candidate`<br>`RL 25RVW` — `candidate` |
 | near `0x0E00` | `Oxxify.smart 30` — `candidate`<br>`oxxify.smart 50k` — `candidate`<br>`OXXIFY.pro 50` — `candidate`<br>`OXXIFY.eco 50` — `candidate` |
@@ -86,25 +90,6 @@ and web search can find them, but they are not runtime aliases:
 | No network protocol evidence | `Zephyr 100 S`, `ZEPH100`, `Airion 100`, `Airion 150` | Current manuals provide installation/control data but no BGCP or compatible local-network protocol. |
 
 The strongest new model lead is the [ECONOPRIME Bora family](https://www.econology.fr/bora-extracteur-d-air-double-flux-econoprime.html). A cross-document comparison of the ECONOPRIME Bora and Blauberg Freshpoint manuals found the same 160/200 dimensions, performance tables, wall-length variants, Pro/Prime sensor package, Wi-Fi provisioning (`FAN:` plus 16-character ID and password `11111111`), and control behavior. This suggests a protocol-family lead; neither manufacturer identifies Bora as Freshpoint/Breezy or documents Bora's BGCP unit type. Bora therefore remains a targeted `documentary_match` outside parser-facing names until a real unit reports `0x00B9`.
-
-### Legacy discovery aliases — no additional compatibility claim
-
-These exact strings were present in earlier README search guidance and are kept
-to avoid making existing devices harder to find. They are not runtime aliases
-unless the same exact name also appears in one of the catalogued sections above:
-
-`Blauberg VENTO Expert DUO A30-1 W V.2`,
-`Blauberg VENTO Expert A30 W V.2`,
-`Blauberg Freshbox 100 WiFi`,
-`Freshbox E1-100 WiFi`,
-`VENTS Micra 100 WiFi`,
-`Micra 100 E1 WiFi`,
-`VENTS Breezy`,
-`VENTS Arc Smart`,
-`DUKA One S4 Wi-Fi`,
-`DUKA One S6 Wi-Fi`,
-`Winzel V.2`, and
-`Roomie One Wifi V2`.
 
 # Hardware smoke-tested:
 * Blauberg VENTO Expert A50-1 W V.2

--- a/README.md
+++ b/README.md
@@ -10,69 +10,103 @@ from the protocol device type reported by parameter `0x00B9`; candidate OEM
 relationships remain labelled as candidates until manufacturer evidence proves
 them.
 
-## Device names and search keywords
+## Device and brand search index
 
-Use this list for search/discovery. Some third-party/OEM names are recorded as
-compatibility evidence or candidates; if your device is listed as a candidate,
-please open an issue with its reported unit type (`0x00B9`) so it can be mapped
-confidently.
+Searchable brands in the reviewed catalogue are `Blauberg Ventilatoren`,
+`VENTS`, `ECONOPRIME`, `Econology`, `SIKU`, `Flexit`, `DUKA`, `OXXIFY`,
+`Oxxify`, `RL Raumklima`, `Winzel`, and `NIBE`. A listed name is not
+automatically a hardware-support guarantee. The integration chooses behavior
+from the device-reported `0x00B9` unit type:
 
-Official Blauberg / VENTS platform families and names:
+* **Protocol-mapped** means the reported unit type selects an implemented
+  profile. It does not mean every marketing alias has been hardware-tested.
+* **Reported/relabel evidence** ties a name to an existing unit type with the
+  evidence label shown below.
+* **Candidate** is a research lead only. It is not added to the parser-facing
+  device name and must not be treated as supported without a device report.
 
-* Blauberg Ventilatoren, VENTS, Vento, VENTO, TwinFresh, EcoVent
-* Blauberg VENTO Expert, VENTO Expert A50-1 W V.2, VENTO Expert A50-1 S10 W V.2,
-  VENTO Expert A85-1 S10 W V.2, VENTO Expert A100-1 S10 W V.2,
-  VENTO Expert A50-1 W V.3
-* VENTS TwinFresh Expert, TwinFresh Expert RW1-50 V.2,
-  TwinFresh Expert RW1-85 V.2, TwinFresh Expert RW1-100 V.2,
-  TwinFresh Expert RW1-50 V.3
-* Blauberg VENTO Expert DUO A30-1 W V.2,
-  VENTO Expert DUO A30-1 S10 W V.2,
-  VENTS TwinFresh Expert Duo RW1-30 V.2
-* Blauberg VENTO Expert A30 W V.2, VENTO Expert A30 S10 W V.2,
-  VENTS TwinFresh Expert RW-30 V.2
-* Blauberg VENTO inHome, VENTO inHome W, VENTO inHome mini,
-  VENTO inHome mini W, VENTO inHome 100, VENTO inHome 160
-* VENTS TwinFresh Atmo, TwinFresh Atmo 100, TwinFresh Atmo 160,
-  TwinFresh Atmo mini, TwinFresh Atmo Wi-Fi, TwinFresh Atmo mini Wi-Fi
-* VENTS TwinFresh Style Wi-Fi, TwinFresh Style Frost Wi-Fi,
-  TwinFresh Style Wi-Fi mini
-* Blauberg Smart Wi-Fi, Smart IR Wi-Fi, VENTS iFan Wi-Fi,
-  VENTS iFan Move Wi-Fi
-* Blauberg Freshbox 100 WiFi, Freshbox 100 ERV WiFi, Freshbox E-100 WiFi,
-  Freshbox E1-100 WiFi, Freshbox E2-100 WiFi
-* VENTS Micra 100 WiFi, Micra 100 ERV WiFi, Micra 100 E WiFi,
-  Micra 100 E1 WiFi, Micra 100 E2 WiFi
-* VENTS Breezy, Breezy 160, Breezy 160-E, Breezy 160-E Smart,
-  Breezy 200-E, Breezy 200-E Smart, Breezy Eco 160, Breezy Eco 200
-* Blauberg Freshpoint, Freshpoint 160, Freshpoint 160-E,
-  Freshpoint 160-E L055/L07/L1, Freshpoint 160-E Pro L055/L07/L1,
-  Freshpoint 200, Freshpoint 200-E L055/L07/L1,
-  Freshpoint 200-E Pro L055/L07/L1, Freshpoint Eco 160, Freshpoint Eco 200
-* VENTS Arc Smart, Arc Smart white, Arc Smart black,
-  Blauberg O2 Supreme, O2 Supreme white, O2 Supreme black
+If a candidate speaks BGCP, please attach its `0x00B9` value and a UDP packet
+capture to an issue instead of relying on product appearance or Wi-Fi branding.
 
-External relabels and OEM names tracked as evidence or candidates:
+### Protocol-mapped official names
 
-* OXXIFY.smart 50, Oxxify.smart 50, Oxxify smart 50,
-  Oxxify.smart 30, oxxify.smart 50k, OXXIFY.pro 50, OXXIFY.eco 50
-* SIKU RV, SIKU RV 50 W Pro WiFi V2, SIKU RV 50 W PRO WIFI V2,
-  SIKU RV 30 DW Pro Duo WiFi V2, SIKU RV 30 DW PRO DUO WIFI V2,
-  SIKU RV 25 W Pro WiFi V2
-* Flexit Roomie One WiFi V2, Roomie One Wifi V2, Roomie Dual Wifi,
-  Roomie Dual WiFi V2, Flexit Aura, Flexit Muto
-* DUKA One, DUKA One S6W, DUKA One S6BW, DUKA One S4 Wi-Fi,
-  DUKA One S6 Wi-Fi, DUKA One Pro 25 S Wi-Fi, DUKA One Pro 50 S Wi-Fi
-* RL Raumklima, RL PRO-Serie, RL 50RVW, RL 30DVW, RL 25RVW
-* Winzel V.2, Winzel Expert WiFi RW1-50 P,
-  Blauberg Winzel Expert WiFi RW1-50 P
-* NIBE DVC 10, NIBE DVC 10-50W, NIBE DVC 10-D30W
-* ECONOPRIME DF270, ECONOPRIME DF270 Connect, and the reported seller spelling
-  Econology DF270 Connect (`0x0100`, mapped to the tested VENTO protocol
-  profile). VENTS VUT 270 V5B EC A21 is recorded only as an unconfirmed OEM
-  candidate; its published A21/Modbus documents do not prove that relationship.
+| Unit type / profile | Exact brand and model search names |
+| -- | -- |
+| `0x0100` / `vento` | `ECONOPRIME DF270`<br>`ECONOPRIME DF270 Connect` |
+| `0x0200` / `freshbox` | `Freshbox 100 WiFi`<br>`Freshbox 100 ERV WiFi`<br>`Freshbox E-100 WiFi`<br>`Freshbox E2-100 ERV WiFi`<br>`Vents Micra 100 WiFi`<br>`Vents Micra 100 ERV WiFi`<br>`Vents Micra 100 E WiFi`<br>`Vents Micra 100 E2 ERV WiFi` |
+| `0x0300` / `vento` | `VENTO Expert A50-1 S10 W V.2`<br>`VENTO Expert A85-1 S10 W V.2`<br>`VENTO Expert A100-1 S10 W V.2`<br>`VENTO Expert A50-1 W V.3`<br>`TwinFresh Expert RW1-50 V.2`<br>`TwinFresh Expert RW1-85 V.2`<br>`TwinFresh Expert RW1-100 V.2`<br>`TwinFresh Expert RW1-50 V.3` |
+| `0x0400` / `vento` | `VENTO Expert DUO A30-1 S10 W V.2`<br>`VENTO Expert DUO A30-1 S10 W V.2 BLK`<br>`TwinFresh Expert Duo RW1-30 V.2` |
+| `0x0500` / `vento` | `VENTO Expert A30 S10 W V.2`<br>`TwinFresh Expert RW-30 V.2` |
+| `0x0600` / `extract_fan` | `Blauberg Smart Wi-Fi`<br>`Smart IR Wi-Fi`<br>`Vents iFan Wi-Fi`<br>`Vents iFan Move Wi-Fi` |
+| `0x0D00` / `arc` | `Vents Arc Smart`<br>`Vents Arc Smart white`<br>`Vents Arc Smart black`<br>`Blauberg O2 Supreme`<br>`O2 Supreme white`<br>`O2 Supreme black` |
+| `0x0E00` / `vento` | `Vents TwinFresh Style Wi-Fi`<br>`TwinFresh Style Wi-Fi`<br>`Vents TwinFresh Style Frost Wi-Fi`<br>`Vents TwinFresh Style Wi-Fi mini` |
+| `0x1100` / `breezy` | `Vents Breezy 160`<br>`Vents Breezy 160-E`<br>`Vents Breezy 160-E Smart`<br>`Freshpoint 160`<br>`Freshpoint 160-E`<br>`Freshpoint 160-E L055`<br>`Freshpoint 160-E L07`<br>`Freshpoint 160-E L1`<br>`Freshpoint 160-E Pro`<br>`Freshpoint 160-E Pro L055`<br>`Freshpoint 160-E Pro L07`<br>`Freshpoint 160-E Pro L1` |
+| `0x1400` / `breezy` | `Vents Breezy Eco 160`<br>`Vents Breezy Eco 160-E`<br>`Freshpoint Eco 160`<br>`Freshpoint Eco 160-E L07` |
+| `0x1600` / `breezy` | `Vents Breezy 200-E`<br>`Vents Breezy 200-E Smart`<br>`Freshpoint 200`<br>`Freshpoint 200-E`<br>`Freshpoint 200-E L055`<br>`Freshpoint 200-E L07`<br>`Freshpoint 200-E L1`<br>`Freshpoint 200-E Pro`<br>`Freshpoint 200-E Pro L055`<br>`Freshpoint 200-E Pro L07`<br>`Freshpoint 200-E Pro L1` |
+| `0x1800` / `breezy` | `Vents Breezy Eco 200`<br>`Freshpoint Eco 200` |
+| `0x1A00` / `vento` | `VENTO inHome`<br>`TwinFresh Atmo` |
+| `0x1B00` / `vento` | `VENTO inHome 100`<br>`VENTO inHome mini`<br>`VENTO inHome mini W`<br>`TwinFresh Atmo 100`<br>`Vents TwinFresh Atmo mini`<br>`Vents TwinFresh Atmo mini Wi-Fi` |
+| `0x1C00` / `vento` | `VENTO inHome 160`<br>`VENTO inHome W`<br>`TwinFresh Atmo 160`<br>`Vents TwinFresh Atmo Wi-Fi` |
 
-# Tested on:
+### Reported/relabel evidence
+
+| Reported unit type | Exact search names and evidence |
+| -- | -- |
+| `0x0100` | `Econology DF270 Connect` — `community_tested` |
+| `0x0300` | `SIKU RV 50 W Pro WiFi V2` — `official_listing`<br>`SIKU RV 50 W PRO WIFI V2` — `official_listing`<br>`DUKA One S6W` — `community_tested`<br>`RL 50RVW` — `community_tested`<br>`Winzel Expert WiFi RW1-50 P` — `app_by_blauberg`<br>`Blauberg Winzel Expert WiFi RW1-50 P` — `app_by_blauberg` |
+| `0x0400` | `SIKU RV 30 DW Pro Duo WiFi V2` — `official_listing`<br>`SIKU RV 30 DW PRO DUO WIFI V2` — `official_listing`<br>`Flexit Roomie Dual Wifi` — `community_tested`<br>`DUKA One S6BW` — `community_tested`<br>`RL 30DVW` — `community_tested` |
+| `0x0E00` | `OXXIFY.smart 50` — `observed`<br>`Oxxify.smart 50` — `observed`<br>`Oxxify smart 50` — `observed` |
+
+### Candidate relationships — not parser aliases
+
+`documentary_match` means two first-party document sets match closely enough to
+justify targeted protocol testing. It still does not supply a BGCP unit type.
+
+| Research target | Exact search names and evidence |
+| -- | -- |
+| near `0x0100` | `VENTS VUT 270 V5B EC A21` — `documentary_match` |
+| near `0x0300` | `Flexit Roomie One WiFi V2` — `candidate`<br>`DUKA One Pro 50 S Wi-Fi` — `candidate`<br>`NIBE DVC 10` — `candidate`<br>`NIBE DVC 10-50W` — `candidate` |
+| near `0x0400` | `Roomie Dual WiFi V2` — `candidate`<br>`Flexit Aura` — `candidate`<br>`Flexit Muto` — `candidate`<br>`NIBE DVC 10-D30W` — `candidate` |
+| near `0x0500` | `SIKU RV 25 W Pro WiFi V2` — `candidate`<br>`RL 25RVW` — `candidate` |
+| near `0x0E00` | `Oxxify.smart 30` — `candidate`<br>`oxxify.smart 50k` — `candidate`<br>`OXXIFY.pro 50` — `candidate`<br>`OXXIFY.eco 50` — `candidate` |
+| near `0x1100` | `Bora 160` — `documentary_match`<br>`Bora 160 L440` — `documentary_match`<br>`Bora 160 L550` — `documentary_match`<br>`Bora 160 L700` — `documentary_match`<br>`Bora 160 L1000` — `documentary_match`<br>`Bora 160 Prime L440` — `documentary_match`<br>`Bora 160 Prime L550` — `documentary_match`<br>`Bora 160 Prime L700` — `documentary_match`<br>`Bora 160 Prime L1000` — `documentary_match` |
+| near `0x1600` | `Bora 200` — `documentary_match`<br>`Bora 200 L440` — `documentary_match`<br>`Bora 200 L550` — `documentary_match`<br>`Bora 200 L700` — `documentary_match`<br>`Bora 200 L1000` — `documentary_match`<br>`Bora 200 Prime L440` — `documentary_match`<br>`Bora 200 Prime L550` — `documentary_match`<br>`Bora 200 Prime L700` — `documentary_match`<br>`Bora 200 Prime L1000` — `documentary_match` |
+
+### Econology / ECONOPRIME catalogue research — not mapped
+
+The live Econology sitemap and product pages expose substantially more devices
+than the former DF270 filter page. These exact names are kept here so repository
+and web search can find them, but they are not runtime aliases:
+
+| Research group | Exact Econology / ECONOPRIME names | What the current documents prove |
+| -- | -- | -- |
+| Blauberg Home application leads | `DF 180 Flat`, `DF 180 Flat Connect`, `DFF18021`, `DF 270`, `DF27014`, `DF 270 Connect`, `DF27021`, `DF 350`, `DF 350 Connect`, `DF35021` | The [DF Connect application manual](https://www.econology.fr/media/attachment/file/n/o/notice_installateur-application_df_connect5_v3_5.pdf) explicitly names Blauberg Home. Only the reported DF270 unit currently supplies a BGCP `0x0100` observation. |
+| A14 / A21 / Modbus family | `Zephyr 240 S`, `ZEPH240A14`, `Zephyr 240 S Connect`, `ZEPH240A21`, `Zephyr 270 V R`, `114800001`, `Zephyr 270 V Connect R`, `114800002`, `Zephyr 550 V PH Connect R`, `114800003` | The [Zephyr 270 Connect page](https://www.econology.fr/zephyr-270-connect-econoprime-vmc-double-flux-114800002.html) publishes Modbus RTU/TCP/IP. `A21` is a controller generation, not BGCP unit type `0x0100`. |
+| PremAIR / GatePass family | `URC 250`, `URC250`, `URHF 150`, `URHF150`, `URHFCF 150`, `URHFCF150`, `URHF 200`, `URHF200`, `URHFCF 200`, `URHFCF200`, `URH 350`, `URH350` | The [URC 250 manual](https://www.econology.fr/media/attachment/file_pdf/notice_installateur_urc250_econoprime_v1.pdf) documents PremAIR and GatePass rather than BGCP. |
+| No network protocol evidence | `Zephyr 100 S`, `ZEPH100`, `Airion 100`, `Airion 150` | Current manuals provide installation/control data but no BGCP or compatible local-network protocol. |
+
+The strongest new model lead is the [ECONOPRIME Bora family](https://www.econology.fr/bora-extracteur-d-air-double-flux-econoprime.html). A cross-document comparison of the ECONOPRIME Bora and Blauberg Freshpoint manuals found the same 160/200 dimensions, performance tables, wall-length variants, Pro/Prime sensor package, Wi-Fi provisioning (`FAN:` plus 16-character ID and password `11111111`), and control behavior. This suggests a protocol-family lead; neither manufacturer identifies Bora as Freshpoint/Breezy or documents Bora's BGCP unit type. Bora therefore remains a targeted `documentary_match` outside parser-facing names until a real unit reports `0x00B9`.
+
+### Legacy discovery aliases — no additional compatibility claim
+
+These exact strings were present in earlier README search guidance and are kept
+to avoid making existing devices harder to find. They are not runtime aliases
+unless the same exact name also appears in one of the catalogued sections above:
+
+`Blauberg VENTO Expert DUO A30-1 W V.2`,
+`Blauberg VENTO Expert A30 W V.2`,
+`Blauberg Freshbox 100 WiFi`,
+`Freshbox E1-100 WiFi`,
+`VENTS Micra 100 WiFi`,
+`Micra 100 E1 WiFi`,
+`VENTS Breezy`,
+`VENTS Arc Smart`,
+`DUKA One S4 Wi-Fi`,
+`DUKA One S6 Wi-Fi`,
+`Winzel V.2`, and
+`Roomie One Wifi V2`.
+
+# Hardware smoke-tested:
 * Blauberg VENTO Expert A50-1 W V.2
 
 # Currently supported:

--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@
 Home Assistant Integration. Integration for newest Fans with api version 2
 
 This integration talks to the local BGCP/UDP Wi-Fi protocol used by devices on
-the Blauberg Group / VENTS platform. VENTS is an official sibling brand, not
-just a Blauberg relabel. The exact feature set is selected from the protocol
-device type reported by parameter `0x00B9`.
+the Blauberg Group / VENTS platform and compatible units. VENTS is an official
+sibling brand, not just a Blauberg relabel. The exact feature set is selected
+from the protocol device type reported by parameter `0x00B9`; candidate OEM
+relationships remain labelled as candidates until manufacturer evidence proves
+them.
 
 ## Device names and search keywords
 
@@ -44,8 +46,9 @@ Official Blauberg / VENTS platform families and names:
 * VENTS Breezy, Breezy 160, Breezy 160-E, Breezy 160-E Smart,
   Breezy 200-E, Breezy 200-E Smart, Breezy Eco 160, Breezy Eco 200
 * Blauberg Freshpoint, Freshpoint 160, Freshpoint 160-E,
-  Freshpoint 160-E Pro, Freshpoint 200, Freshpoint 200-E,
-  Freshpoint 200-E Pro, Freshpoint Eco 160, Freshpoint Eco 200
+  Freshpoint 160-E L055/L07/L1, Freshpoint 160-E Pro L055/L07/L1,
+  Freshpoint 200, Freshpoint 200-E L055/L07/L1,
+  Freshpoint 200-E Pro L055/L07/L1, Freshpoint Eco 160, Freshpoint Eco 200
 * VENTS Arc Smart, Arc Smart white, Arc Smart black,
   Blauberg O2 Supreme, O2 Supreme white, O2 Supreme black
 
@@ -64,6 +67,10 @@ External relabels and OEM names tracked as evidence or candidates:
 * Winzel V.2, Winzel Expert WiFi RW1-50 P,
   Blauberg Winzel Expert WiFi RW1-50 P
 * NIBE DVC 10, NIBE DVC 10-50W, NIBE DVC 10-D30W
+* ECONOPRIME DF270, ECONOPRIME DF270 Connect, and the reported seller spelling
+  Econology DF270 Connect (`0x0100`, mapped to the tested VENTO protocol
+  profile). VENTS VUT 270 V5B EC A21 is recorded only as an unconfirmed OEM
+  candidate; its published A21/Modbus documents do not prove that relationship.
 
 # Tested on:
 * Blauberg VENTO Expert A50-1 W V.2
@@ -437,3 +444,21 @@ Version 1.2.15
 * Guard schedule frontend registration before the first await, preventing
   duplicate static route registration when multiple EcoVent config entries are
   set up concurrently.
+
+Version 1.2.16
+* Keep protocol reads inside the documented 256-byte packet limit and verify
+  that every requested register was present in a valid bulk response. Registers
+  omitted by an otherwise valid reply are retried individually, and the parser
+  now preserves the protocol high-byte page across following parameters. A
+  refresh remains failed if an omitted register cannot be recovered, preventing
+  Home Assistant from accepting a stale cycle as complete.
+* Refresh Freshpoint humidity and all four built-in temperature registers on
+  quick updates. The non-Pro model has no VOC/CO2eq sensor, so those optional
+  readings may correctly remain unavailable.
+* Map reported device type `256` / parser key `0x0100` to ECONOPRIME DF270
+  Connect with the tested VENTO profile, while keeping the reported VENTS A21
+  OEM relationship explicitly unconfirmed.
+* Add official Freshpoint 160/200 standard and Pro length variants, current
+  Freshpoint specification/manual links, and the current VENTS VUT V5B EC A21
+  datasheet, product manual, Modbus table, and control manual as research
+  sources.

--- a/README.md
+++ b/README.md
@@ -10,88 +10,85 @@ from the protocol device type reported by parameter `0x00B9`; candidate OEM
 relationships remain labelled as candidates until manufacturer evidence proves
 them.
 
-## Device and brand search index
+## Device names and search keywords
 
-Searchable brand and family terms in the reviewed catalogue are `Blauberg`,
-`Blauberg Ventilatoren`, `VENTS`, `Vento`, `VENTO`, `TwinFresh`, `EcoVent`,
-`VENTS Breezy`, `VENTS Arc Smart`, `ECONOPRIME`, `Econology`, `SIKU`, `Flexit`,
-`DUKA`, `OXXIFY`, `Oxxify`, `RL Raumklima`, `Winzel`, and `NIBE`. A listed name
-is not automatically a hardware-support guarantee. The integration chooses
-behavior from the device-reported `0x00B9` unit type:
+Use this list for search/discovery. Some third-party/OEM names are recorded as
+compatibility evidence or candidates; if your device is listed as a candidate,
+please open an issue with its reported unit type (`0x00B9`) so it can be mapped
+confidently.
 
-* **Protocol-mapped** means the reported unit type selects an implemented
-  profile. It does not mean every marketing alias has been hardware-tested.
-* **Reported/relabel evidence** ties a name to an existing unit type with the
-  evidence label shown below.
-* **Candidate** is a research lead only. It is not added to the parser-facing
-  device name and must not be treated as supported without a device report.
+Official Blauberg / VENTS platform families and names:
 
-If a candidate speaks BGCP, please attach its `0x00B9` value and a UDP packet
-capture to an issue instead of relying on product appearance or Wi-Fi branding.
+* Blauberg Ventilatoren, VENTS, Vento, VENTO, TwinFresh, EcoVent
+* Blauberg VENTO Expert, VENTO Expert A50-1 W V.2, VENTO Expert A50-1 S10 W V.2,
+  VENTO Expert A85-1 S10 W V.2, VENTO Expert A100-1 S10 W V.2,
+  VENTO Expert A50-1 W V.3
+* VENTS TwinFresh Expert, TwinFresh Expert RW1-50 V.2,
+  TwinFresh Expert RW1-85 V.2, TwinFresh Expert RW1-100 V.2,
+  TwinFresh Expert RW1-50 V.3
+* Blauberg VENTO Expert DUO A30-1 W V.2,
+  VENTO Expert DUO A30-1 S10 W V.2,
+  VENTS TwinFresh Expert Duo RW1-30 V.2
+* Blauberg VENTO Expert A30 W V.2, VENTO Expert A30 S10 W V.2,
+  VENTS TwinFresh Expert RW-30 V.2
+* Blauberg VENTO inHome, VENTO inHome W, VENTO inHome mini,
+  VENTO inHome mini W, VENTO inHome 100, VENTO inHome 160
+* VENTS TwinFresh Atmo, TwinFresh Atmo 100, TwinFresh Atmo 160,
+  TwinFresh Atmo mini, TwinFresh Atmo Wi-Fi, TwinFresh Atmo mini Wi-Fi
+* VENTS TwinFresh Style Wi-Fi, TwinFresh Style Frost Wi-Fi,
+  TwinFresh Style Wi-Fi mini
+* Blauberg Smart Wi-Fi, Smart IR Wi-Fi, VENTS iFan Wi-Fi,
+  VENTS iFan Move Wi-Fi
+* Blauberg Freshbox 100 WiFi, Freshbox 100 ERV WiFi, Freshbox E-100 WiFi,
+  Freshbox E1-100 WiFi, Freshbox E2-100 WiFi
+* VENTS Micra 100 WiFi, Micra 100 ERV WiFi, Micra 100 E WiFi,
+  Micra 100 E1 WiFi, Micra 100 E2 WiFi
+* VENTS Breezy, Breezy 160, Breezy 160-E, Breezy 160-E Smart,
+  Breezy 200-E, Breezy 200-E Smart, Breezy Eco 160, Breezy Eco 200
+* Blauberg Freshpoint, Freshpoint 160, Freshpoint 160-E,
+  Freshpoint 160-E L055/L07/L1, Freshpoint 160-E Pro L055/L07/L1,
+  Freshpoint 200, Freshpoint 200-E L055/L07/L1,
+  Freshpoint 200-E Pro L055/L07/L1, Freshpoint Eco 160, Freshpoint Eco 200
+* VENTS Arc Smart, Arc Smart white, Arc Smart black,
+  Blauberg O2 Supreme, O2 Supreme white, O2 Supreme black
 
-### Protocol-mapped official names
+External relabels and OEM names tracked as evidence or candidates:
 
-Historical README terms are retained for search. They are not additional model
-mappings.
+* OXXIFY.smart 50, Oxxify.smart 50, Oxxify smart 50,
+  Oxxify.smart 30, oxxify.smart 50k, OXXIFY.pro 50, OXXIFY.eco 50
+* SIKU RV, SIKU RV 50 W Pro WiFi V2, SIKU RV 50 W PRO WIFI V2,
+  SIKU RV 30 DW Pro Duo WiFi V2, SIKU RV 30 DW PRO DUO WIFI V2,
+  SIKU RV 25 W Pro WiFi V2
+* Flexit Roomie One WiFi V2, Roomie One Wifi V2, Flexit Roomie Dual Wifi,
+  Roomie Dual Wifi, Roomie Dual WiFi V2, Flexit Aura, Flexit Muto
+* DUKA One, DUKA One S6W, DUKA One S6BW, DUKA One S4 Wi-Fi,
+  DUKA One S6 Wi-Fi, DUKA One Pro 25 S Wi-Fi, DUKA One Pro 50 S Wi-Fi
+* RL Raumklima, RL PRO-Serie, RL 50RVW, RL 30DVW, RL 25RVW
+* Winzel V.2, Winzel Expert WiFi RW1-50 P,
+  Blauberg Winzel Expert WiFi RW1-50 P
+* NIBE DVC 10, NIBE DVC 10-50W, NIBE DVC 10-D30W
+* ECONOPRIME DF270, ECONOPRIME DF270 Connect, and the reported seller spelling
+  Econology DF270 Connect (`0x0100`, mapped to the tested VENTO protocol
+  profile). VENTS VUT 270 V5B EC A21 remains an unconfirmed documentary
+  candidate; its published A21/Modbus documents do not prove BGCP compatibility.
+* ECONOPRIME Bora documentary candidates: Bora 160, Bora 160 L440,
+  Bora 160 L550, Bora 160 L700, Bora 160 L1000, Bora 160 Prime L440,
+  Bora 160 Prime L550, Bora 160 Prime L700, Bora 160 Prime L1000,
+  Bora 200, Bora 200 L440, Bora 200 L550, Bora 200 L700, Bora 200 L1000,
+  Bora 200 Prime L440, Bora 200 Prime L550, Bora 200 Prime L700,
+  Bora 200 Prime L1000. No Bora unit type or BGCP capture is documented.
+* Other ECONOPRIME DF search names: DF 180 Flat, DF 180 Flat Connect,
+  DFF18021, DF 270, DF27014, DF 270 Connect, DF27021, DF 350,
+  DF 350 Connect, DF35021
+* Other ECONOPRIME Zephyr search names: Zephyr 100 S, ZEPH100, Zephyr 240 S,
+  ZEPH240A14, Zephyr 240 S Connect, ZEPH240A21, Zephyr 270 V R, 114800001,
+  Zephyr 270 V Connect R, 114800002, Zephyr 550 V PH Connect R, 114800003
+* Other ECONOPRIME PremAIR/GatePass search names: URC 250, URC250, URHF 150,
+  URHF150, URHFCF 150, URHFCF150, URHF 200, URHF200, URHFCF 200,
+  URHFCF200, URH 350, URH350
+* Other ECONOPRIME search names without BGCP evidence: Airion 100, Airion 150
 
-| Unit type / profile | Exact catalog names | Historical README search spellings |
-| -- | -- | -- |
-| `0x0100` / `vento` | `ECONOPRIME DF270`<br>`ECONOPRIME DF270 Connect` | — |
-| `0x0200` / `freshbox` | `Freshbox 100 WiFi`<br>`Freshbox 100 ERV WiFi`<br>`Freshbox E-100 WiFi`<br>`Freshbox E2-100 ERV WiFi`<br>`Vents Micra 100 WiFi`<br>`Vents Micra 100 ERV WiFi`<br>`Vents Micra 100 E WiFi`<br>`Vents Micra 100 E2 ERV WiFi` | `Blauberg Freshbox 100 WiFi`<br>`Freshbox E1-100 WiFi`<br>`VENTS Micra 100 WiFi`<br>`Micra 100 E1 WiFi` |
-| `0x0300` / `vento` | `VENTO Expert A50-1 S10 W V.2`<br>`VENTO Expert A85-1 S10 W V.2`<br>`VENTO Expert A100-1 S10 W V.2`<br>`VENTO Expert A50-1 W V.3`<br>`TwinFresh Expert RW1-50 V.2`<br>`TwinFresh Expert RW1-85 V.2`<br>`TwinFresh Expert RW1-100 V.2`<br>`TwinFresh Expert RW1-50 V.3` | — |
-| `0x0400` / `vento` | `VENTO Expert DUO A30-1 S10 W V.2`<br>`VENTO Expert DUO A30-1 S10 W V.2 BLK`<br>`TwinFresh Expert Duo RW1-30 V.2` | `Blauberg VENTO Expert DUO A30-1 W V.2` |
-| `0x0500` / `vento` | `VENTO Expert A30 S10 W V.2`<br>`TwinFresh Expert RW-30 V.2` | `Blauberg VENTO Expert A30 W V.2` |
-| `0x0600` / `extract_fan` | `Blauberg Smart Wi-Fi`<br>`Smart IR Wi-Fi`<br>`Vents iFan Wi-Fi`<br>`Vents iFan Move Wi-Fi` | — |
-| `0x0D00` / `arc` | `Vents Arc Smart`<br>`Vents Arc Smart white`<br>`Vents Arc Smart black`<br>`Blauberg O2 Supreme`<br>`O2 Supreme white`<br>`O2 Supreme black` | — |
-| `0x0E00` / `vento` | `Vents TwinFresh Style Wi-Fi`<br>`TwinFresh Style Wi-Fi`<br>`Vents TwinFresh Style Frost Wi-Fi`<br>`Vents TwinFresh Style Wi-Fi mini` | — |
-| `0x1100` / `breezy` | `Vents Breezy 160`<br>`Vents Breezy 160-E`<br>`Vents Breezy 160-E Smart`<br>`Freshpoint 160`<br>`Freshpoint 160-E`<br>`Freshpoint 160-E L055`<br>`Freshpoint 160-E L07`<br>`Freshpoint 160-E L1`<br>`Freshpoint 160-E Pro`<br>`Freshpoint 160-E Pro L055`<br>`Freshpoint 160-E Pro L07`<br>`Freshpoint 160-E Pro L1` | — |
-| `0x1400` / `breezy` | `Vents Breezy Eco 160`<br>`Vents Breezy Eco 160-E`<br>`Freshpoint Eco 160`<br>`Freshpoint Eco 160-E L07` | — |
-| `0x1600` / `breezy` | `Vents Breezy 200-E`<br>`Vents Breezy 200-E Smart`<br>`Freshpoint 200`<br>`Freshpoint 200-E`<br>`Freshpoint 200-E L055`<br>`Freshpoint 200-E L07`<br>`Freshpoint 200-E L1`<br>`Freshpoint 200-E Pro`<br>`Freshpoint 200-E Pro L055`<br>`Freshpoint 200-E Pro L07`<br>`Freshpoint 200-E Pro L1` | — |
-| `0x1800` / `breezy` | `Vents Breezy Eco 200`<br>`Freshpoint Eco 200` | — |
-| `0x1A00` / `vento` | `VENTO inHome`<br>`TwinFresh Atmo` | — |
-| `0x1B00` / `vento` | `VENTO inHome 100`<br>`VENTO inHome mini`<br>`VENTO inHome mini W`<br>`TwinFresh Atmo 100`<br>`Vents TwinFresh Atmo mini`<br>`Vents TwinFresh Atmo mini Wi-Fi` | — |
-| `0x1C00` / `vento` | `VENTO inHome 160`<br>`VENTO inHome W`<br>`TwinFresh Atmo 160`<br>`Vents TwinFresh Atmo Wi-Fi` | — |
-
-### Reported/relabel evidence
-
-| Reported unit type | Exact search names and evidence |
-| -- | -- |
-| `0x0100` | `Econology DF270 Connect` — `community_tested` |
-| `0x0300` | `SIKU RV 50 W Pro WiFi V2` — `official_listing`<br>`SIKU RV 50 W PRO WIFI V2` — `official_listing`<br>`DUKA One S6W` — `community_tested`<br>`RL 50RVW` — `community_tested`<br>`Winzel Expert WiFi RW1-50 P` — `app_by_blauberg`<br>`Blauberg Winzel Expert WiFi RW1-50 P` — `app_by_blauberg` |
-| `0x0400` | `SIKU RV 30 DW Pro Duo WiFi V2` — `official_listing`<br>`SIKU RV 30 DW PRO DUO WIFI V2` — `official_listing`<br>`Flexit Roomie Dual Wifi` — `community_tested`<br>`DUKA One S6BW` — `community_tested`<br>`RL 30DVW` — `community_tested` |
-| `0x0E00` | `OXXIFY.smart 50` — `observed`<br>`Oxxify.smart 50` — `observed`<br>`Oxxify smart 50` — `observed` |
-
-### Candidate relationships — not parser aliases
-
-`documentary_match` means two first-party document sets match closely enough to
-justify targeted protocol testing. It still does not supply a BGCP unit type.
-
-| Research target | Exact search names and evidence |
-| -- | -- |
-| near `0x0100` | `VENTS VUT 270 V5B EC A21` — `documentary_match` |
-| near `0x0300` | `Flexit Roomie One WiFi V2` — `candidate`<br>`DUKA One Pro 50 S Wi-Fi` — `candidate`<br>`NIBE DVC 10` — `candidate`<br>`NIBE DVC 10-50W` — `candidate`<br>`Roomie One Wifi V2` — `legacy_search`<br>`DUKA One S4 Wi-Fi` — `legacy_search`<br>`DUKA One S6 Wi-Fi` — `legacy_search`<br>`Winzel V.2` — `legacy_search` |
-| near `0x0400` | `Roomie Dual WiFi V2` — `candidate`<br>`Flexit Aura` — `candidate`<br>`Flexit Muto` — `candidate`<br>`NIBE DVC 10-D30W` — `candidate` |
-| near `0x0500` | `SIKU RV 25 W Pro WiFi V2` — `candidate`<br>`RL 25RVW` — `candidate` |
-| near `0x0E00` | `Oxxify.smart 30` — `candidate`<br>`oxxify.smart 50k` — `candidate`<br>`OXXIFY.pro 50` — `candidate`<br>`OXXIFY.eco 50` — `candidate` |
-| near `0x1100` | `Bora 160` — `documentary_match`<br>`Bora 160 L440` — `documentary_match`<br>`Bora 160 L550` — `documentary_match`<br>`Bora 160 L700` — `documentary_match`<br>`Bora 160 L1000` — `documentary_match`<br>`Bora 160 Prime L440` — `documentary_match`<br>`Bora 160 Prime L550` — `documentary_match`<br>`Bora 160 Prime L700` — `documentary_match`<br>`Bora 160 Prime L1000` — `documentary_match` |
-| near `0x1600` | `Bora 200` — `documentary_match`<br>`Bora 200 L440` — `documentary_match`<br>`Bora 200 L550` — `documentary_match`<br>`Bora 200 L700` — `documentary_match`<br>`Bora 200 L1000` — `documentary_match`<br>`Bora 200 Prime L440` — `documentary_match`<br>`Bora 200 Prime L550` — `documentary_match`<br>`Bora 200 Prime L700` — `documentary_match`<br>`Bora 200 Prime L1000` — `documentary_match` |
-
-### Econology / ECONOPRIME catalogue research — not mapped
-
-The live Econology sitemap and product pages expose substantially more devices
-than the former DF270 filter page. These exact names are kept here so repository
-and web search can find them, but they are not runtime aliases:
-
-| Research group | Exact Econology / ECONOPRIME names | What the current documents prove |
-| -- | -- | -- |
-| Blauberg Home application leads | `DF 180 Flat`, `DF 180 Flat Connect`, `DFF18021`, `DF 270`, `DF27014`, `DF 270 Connect`, `DF27021`, `DF 350`, `DF 350 Connect`, `DF35021` | The [DF Connect application manual](https://www.econology.fr/media/attachment/file/n/o/notice_installateur-application_df_connect5_v3_5.pdf) explicitly names Blauberg Home. Only the reported DF270 unit currently supplies a BGCP `0x0100` observation. |
-| A14 / A21 / Modbus family | `Zephyr 240 S`, `ZEPH240A14`, `Zephyr 240 S Connect`, `ZEPH240A21`, `Zephyr 270 V R`, `114800001`, `Zephyr 270 V Connect R`, `114800002`, `Zephyr 550 V PH Connect R`, `114800003` | The [Zephyr 270 Connect page](https://www.econology.fr/zephyr-270-connect-econoprime-vmc-double-flux-114800002.html) publishes Modbus RTU/TCP/IP. `A21` is a controller generation, not BGCP unit type `0x0100`. |
-| PremAIR / GatePass family | `URC 250`, `URC250`, `URHF 150`, `URHF150`, `URHFCF 150`, `URHFCF150`, `URHF 200`, `URHF200`, `URHFCF 200`, `URHFCF200`, `URH 350`, `URH350` | The [URC 250 manual](https://www.econology.fr/media/attachment/file_pdf/notice_installateur_urc250_econoprime_v1.pdf) documents PremAIR and GatePass rather than BGCP. |
-| No network protocol evidence | `Zephyr 100 S`, `ZEPH100`, `Airion 100`, `Airion 150` | Current manuals provide installation/control data but no BGCP or compatible local-network protocol. |
-
-The strongest new model lead is the [ECONOPRIME Bora family](https://www.econology.fr/bora-extracteur-d-air-double-flux-econoprime.html). A cross-document comparison of the ECONOPRIME Bora and Blauberg Freshpoint manuals found the same 160/200 dimensions, performance tables, wall-length variants, Pro/Prime sensor package, Wi-Fi provisioning (`FAN:` plus 16-character ID and password `11111111`), and control behavior. This suggests a protocol-family lead; neither manufacturer identifies Bora as Freshpoint/Breezy or documents Bora's BGCP unit type. Bora therefore remains a targeted `documentary_match` outside parser-facing names until a real unit reports `0x00B9`.
-
-# Hardware smoke-tested:
+# Tested on:
 * Blauberg VENTO Expert A50-1 W V.2
 
 # Currently supported:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,12 @@
 Home Assistant Integration. Integration for newest Fans with api version 2
 
 This integration talks to the local BGCP/UDP Wi-Fi protocol used by devices on
-the Blauberg Group / VENTS platform and compatible units. VENTS is an official
-sibling brand, not just a Blauberg relabel. The exact feature set is selected
-from the protocol device type reported by parameter `0x00B9`; candidate OEM
-relationships remain labelled as candidates until manufacturer evidence proves
-them.
+the Blauberg Group / VENTS platform and compatible units, and to VENTS A21
+controllers over Modbus TCP or RTU. VENTS is an official sibling brand, not just
+a Blauberg relabel. BGCP features are selected from parameter `0x00B9`; Modbus
+onboarding requires the controller to report A21 value `1` in input register
+`37`. Candidate OEM relationships remain labelled as candidates until device
+or manufacturer evidence proves them.
 
 ## Device names and search keywords
 
@@ -69,8 +70,9 @@ External relabels and OEM names tracked as evidence or candidates:
 * NIBE DVC 10, NIBE DVC 10-50W, NIBE DVC 10-D30W
 * ECONOPRIME DF270, ECONOPRIME DF270 Connect, and the reported seller spelling
   Econology DF270 Connect (`0x0100`, mapped to the tested VENTO protocol
-  profile). VENTS VUT 270 V5B EC A21 remains an unconfirmed documentary
-  candidate; its published A21/Modbus documents do not prove BGCP compatibility.
+  profile). VENTS VUT 270 V5B EC A21 is supported through the separate A21
+  Modbus transport; this does not make it a confirmed DF270 relabel or prove
+  BGCP compatibility.
 * ECONOPRIME Bora documentary candidates: Bora 160, Bora 160 L440,
   Bora 160 L550, Bora 160 L700, Bora 160 L1000, Bora 160 Prime L440,
   Bora 160 Prime L550, Bora 160 Prime L700, Bora 160 Prime L1000,
@@ -93,6 +95,7 @@ External relabels and OEM names tracked as evidence or candidates:
 
 # Currently supported:
 * UI integration setup
+* VENTS A21 Modbus TCP/RTU with an input-register `37 == 1` identity check
 * turn_on/turn_off
 * Preset modes:
   - low
@@ -478,3 +481,8 @@ Version 1.2.16
   Freshpoint specification/manual links, and the current VENTS VUT V5B EC A21
   datasheet, product manual, Modbus table, and control manual as research
   sources.
+
+Version 1.2.17
+* Add separate VENTS A21 Modbus TCP and RTU transports with a read-only
+  controller identity check, the complete published register table, RTC and
+  weekly schedule support, and legacy BGCP config-entry migration.

--- a/custom_components/ecovent_v2/__init__.py
+++ b/custom_components/ecovent_v2/__init__.py
@@ -18,7 +18,13 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
 
-from .const import CONF_AUTO_CLOCK_SYNC, DOMAIN, UPDATE_INTERVAL
+from .const import (
+    CONF_AUTO_CLOCK_SYNC,
+    CONF_TRANSPORT,
+    DOMAIN,
+    TRANSPORT_BGCP_UDP,
+    UPDATE_INTERVAL,
+)
 from .coordinator import EcoVentCoordinator
 from .entity_naming import stable_entity_id
 from .frontend import async_register_frontend
@@ -434,15 +440,19 @@ async def _async_migrate_statistics_metadata_on_start(
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up EcoVent_v2 from a config entry."""
 
-    entry.runtime_data = {
-        CONF_IP_ADDRESS: entry.data.get(CONF_IP_ADDRESS, "<broadcast>"),
-        CONF_PORT: entry.data.get(CONF_PORT, 4000),
-        # CONF_DEVICE_ID: entry.data.get(CONF_DEVICE_ID, "DEFAULT_DEVICEID"),
-        CONF_PASSWORD: entry.data.get(CONF_PASSWORD, "1111"),
-        CONF_NAME: entry.data.get(CONF_NAME, "Vento Expert Fan"),
-        UPDATE_INTERVAL: entry.data.get(UPDATE_INTERVAL, 30),
-        CONF_AUTO_CLOCK_SYNC: entry.data.get(CONF_AUTO_CLOCK_SYNC, True),
-    }
+    entry.runtime_data = dict(entry.data)
+    entry.runtime_data.update(
+        {
+            CONF_IP_ADDRESS: entry.data.get(CONF_IP_ADDRESS, "<broadcast>"),
+            CONF_PORT: entry.data.get(CONF_PORT, 4000),
+            # CONF_DEVICE_ID: entry.data.get(CONF_DEVICE_ID, "DEFAULT_DEVICEID"),
+            CONF_PASSWORD: entry.data.get(CONF_PASSWORD, "1111"),
+            CONF_NAME: entry.data.get(CONF_NAME, "Vento Expert Fan"),
+            UPDATE_INTERVAL: entry.data.get(UPDATE_INTERVAL, 30),
+            CONF_AUTO_CLOCK_SYNC: entry.data.get(CONF_AUTO_CLOCK_SYNC, True),
+            CONF_TRANSPORT: entry.data.get(CONF_TRANSPORT, TRANSPORT_BGCP_UDP),
+        }
+    )
 
     coordinator = EcoVentCoordinator(
         hass, entry, update_seconds=entry.runtime_data[UPDATE_INTERVAL]
@@ -463,4 +473,20 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload a config entry."""
 
     unload_ok = await hass.config_entries.async_unload_platforms(entry, _PLATFORMS)
+    if unload_ok:
+        coordinator = hass.data.get(DOMAIN, {}).pop(entry.entry_id, None)
+        close = getattr(getattr(coordinator, "_fan", None), "close", None)
+        if close is not None:
+            await hass.async_add_executor_job(close)
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Mark pre-Modbus entries as the legacy BGCP/UDP transport."""
+    if entry.version >= 2:
+        return True
+
+    data = dict(entry.data)
+    data.setdefault(CONF_TRANSPORT, TRANSPORT_BGCP_UDP)
+    hass.config_entries.async_update_entry(entry, data=data, version=2)
+    return True

--- a/custom_components/ecovent_v2/a21_modbus.py
+++ b/custom_components/ecovent_v2/a21_modbus.py
@@ -1,0 +1,924 @@
+"""VENTS A21 Modbus TCP/RTU transport and Home Assistant device adapter."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from datetime import datetime
+import logging
+import re
+from threading import RLock
+from types import MappingProxyType
+from typing import Any
+
+from .a21_registers import (
+    A21_IDENTITY_REGISTER,
+    A21_IDENTITY_VALUE,
+    Firmware,
+    FilterTimer,
+    REGISTERS,
+    RtcCalendar,
+    RtcTime,
+    Runtime,
+    ScheduleEnd,
+    SchedulePeriod,
+    Table,
+    Timer,
+    get_by_address,
+    get_register,
+)
+from .const import (
+    A21_BAUD_RATES,
+    A21_STOP_BITS,
+    CONF_BAUDRATE,
+    CONF_DEVICE_MODEL,
+    CONF_PARITY,
+    CONF_SERIAL_PORT,
+    CONF_STOPBITS,
+    CONF_TRANSPORT,
+    CONF_UNIT_ID,
+    TRANSPORT_MODBUS_RTU,
+    TRANSPORT_MODBUS_TCP,
+)
+from .ecoventv2 import Fan
+from .protocol_metadata import DeviceProfile
+from .schedule_helpers import WeeklyScheduleRecord
+
+_LOGGER = logging.getLogger(__name__)
+
+_A21_PROFILE = DeviceProfile(
+    key="a21_modbus",
+    params_name="",
+    write_params_name="",
+    quick_update_request="",
+    preset_modes=(
+        "off",
+        "speed_1",
+        "speed_2",
+        "speed_3",
+        "speed_4",
+        "speed_5",
+        "manual",
+    ),
+    boost_statuses_name="statuses",
+    humidity_sensor_states_name="states",
+    schedule_speed_modes=(
+        "standby",
+        "speed_1",
+        "speed_2",
+        "speed_3",
+        "speed_4",
+        "speed_5",
+    ),
+    capabilities=frozenset(
+        {
+            "a21_modbus",
+            "battery_voltage",
+            "binary_diagnostics",
+            "co2",
+            "filter_maintenance",
+            "five_speed_setpoints",
+            "heater",
+            "sensor_switches",
+            "temperature",
+            "temperature_probes",
+            "timer_mode",
+            "voc",
+        }
+    ),
+    supports_preset_speed_settings=True,
+    speed_percent_scale="percent",
+)
+
+_TABLE_READ_METHOD = {
+    Table.COIL: "read_coils",
+    Table.DISCRETE_INPUT: "read_discrete_inputs",
+    Table.INPUT_REGISTER: "read_input_registers",
+    Table.HOLDING_REGISTER: "read_holding_registers",
+}
+_TABLE_LENGTH = {
+    Table.COIL: 26,
+    Table.DISCRETE_INPUT: 72,
+    Table.INPUT_REGISTER: 54,
+    Table.HOLDING_REGISTER: 183,
+}
+_SENSITIVE_REGISTER_KEYS = frozenset({"HR_ENGINEER_PWD"})
+_REQUIRED_POLL_SLOTS = frozenset(
+    {
+        (Table.COIL, 0),
+        (Table.INPUT_REGISTER, 37),
+        (Table.HOLDING_REGISTER, 2),
+        (Table.HOLDING_REGISTER, 17),
+    }
+)
+_MAX_ILLEGAL_ADDRESS_SPLITS = 32
+_A21_SPEEDS = {
+    0: "standby",
+    1: "speed_1",
+    2: "speed_2",
+    3: "speed_3",
+    4: "speed_4",
+    5: "speed_5",
+    0xFF: "manual",
+}
+_A21_SPEED_VALUES = {value: key for key, value in _A21_SPEEDS.items()}
+_A21_TIMER_MODES = {
+    0: "standby",
+    1: "speed_1",
+    2: "speed_2",
+    3: "speed_3",
+    4: "speed_4",
+    5: "speed_5",
+}
+_A21_TIMER_VALUES = {value: key for key, value in _A21_TIMER_MODES.items()}
+
+# These names are the stable semantic surface already consumed by the HA
+# entities. The underlying keys remain available through read_register() and
+# write_register(), so this adapter does not hide the rest of the A21 table.
+_SEMANTIC_REGISTERS = MappingProxyType(
+    {
+        "state": "CL_POWER",
+        "weekly_schedule_state": "CL_WEEK",
+        "boost_status": "CL_Boost_MODE",
+        "humidity_sensor_state": "CL_IntRH_CTRL",
+        "co2_sensor_state": "CL_IntCO2_CTRL",
+        "voc_sensor_state": "CL_IntVOC_CTRL",
+        "analogV_sensor_state": "CL_10V_SENSOR_CTRL",
+        "filter_timer_reset": "CL_RESET_FILTER_TIMER",
+        "reset_alarms": "CL_RESET_ALARM",
+        "temperature": "IR_CurSelTEMP",
+        "room_temperature": "IR_CurTEMP_ExAirIn",
+        "outdoor_temperature": "IR_CurTEMP_SuAirIn",
+        "supply_temperature": "IR_CurTEMP_SuAirOut",
+        "exhaust_in_temperature": "IR_CurTEMP_ExAirIn",
+        "exhaust_out_temperature": "IR_CurTEMP_ExAirOut",
+        "battery_voltage": "IR_CurVBAT",
+        "humidity": "IR_CurRH_Int",
+        "co2": "IR_CurCO2_Int",
+        "voc": "IR_CurVOC_Int",
+        "fan1_speed": "IR_SuRPM",
+        "fan2_speed": "IR_ExRPM",
+        "timer_counter": "IR_CurTIMER_TIME",
+        "filter_timer_countdown": "IR_CurFILTER_TIMER",
+        "machine_hours": "IR_TotalWorkingTime",
+        "filter_replacement_status": "IR_StateFILTER",
+        "schedule_speed": "IR_CurWeekSpeed",
+        "firmware": "IR_VerMAIN_FMW",
+        "alarm_status": "IR_ALARM",
+        "speed": "HR_SPEED_MODE",
+        "supply_speed_low": "HR_SuSPEED1",
+        "exhaust_speed_low": "HR_ExSPEED1",
+        "supply_speed_medium": "HR_SuSPEED2",
+        "exhaust_speed_medium": "HR_ExSPEED2",
+        "supply_speed_high": "HR_SuSPEED3",
+        "exhaust_speed_high": "HR_ExSPEED3",
+        "supply_speed_4": "HR_SuSPEED4",
+        "exhaust_speed_4": "HR_ExSPEED4",
+        "supply_speed_5": "HR_SuSPEED5",
+        "exhaust_speed_5": "HR_ExSPEED5",
+        "man_speed": "HR_ManualSPEED",
+        "temperature_treshold": "HR_SetTEMP",
+        "humidity_treshold": "HR_SetRH",
+        "co2_treshold": "HR_SetCO2",
+        "voc_treshold": "HR_SetVOC",
+        "timer_mode": "HR_TIMER_MODE",
+        "filter_timer_setpoint": "HR_SetFILTER_TIMER",
+        "rtc_time": "HR_RTC_TIME",
+        "rtc_date": "HR_RTC_CALENDAR",
+        "weekly_schedule_setup": "HR_SetWEEK_Mo_P1",
+        "heater_status": "DI_StatusHEATER",
+        "humidity_status": "DI_StatusRH",
+    }
+)
+
+
+class A21ModbusError(ConnectionError):
+    """Base error raised for an unusable A21 Modbus response."""
+
+
+class A21IdentityError(A21ModbusError):
+    """A Modbus server answered but did not identify as controller A21."""
+
+
+class A21IllegalAddressError(A21ModbusError):
+    """A controller rejected a range because at least one address is absent."""
+
+
+def _safe_identity(value: str) -> str:
+    """Return an identifier containing only stable registry-safe characters."""
+    return re.sub(r"[^a-zA-Z0-9_.-]+", "-", value).strip("-")
+
+
+def _as_raw_number(value: Any) -> int:
+    """Accept entity numeric writes, including their existing hex encoding."""
+    if isinstance(value, bool) or not isinstance(value, (int, float, str)):
+        raise ValueError(f"numeric A21 value required, got {value!r}")
+    if isinstance(value, str):
+        return int(value, 16)
+    if int(value) != value:
+        raise ValueError(f"integer A21 value required, got {value!r}")
+    return int(value)
+
+
+class A21ModbusDevice(Fan):
+    """A complete A21 register client with the integration's Fan interface."""
+
+    def __init__(
+        self,
+        *,
+        transport: str,
+        endpoint: str,
+        name: str,
+        model: str,
+        unit_id: int = 1,
+        port: int = 502,
+        baudrate: int = 115200,
+        parity: str = "N",
+        stopbits: float = 2,
+        timeout: float = 3,
+        client: Any | None = None,
+        device_id: str | None = None,
+    ) -> None:
+        if transport not in {TRANSPORT_MODBUS_TCP, TRANSPORT_MODBUS_RTU}:
+            raise ValueError(f"Unsupported A21 transport: {transport}")
+        if not 1 <= int(unit_id) <= 16:
+            raise ValueError("A21 Modbus unit id must be 1..16")
+        if int(baudrate) not in A21_BAUD_RATES:
+            raise ValueError(f"Unsupported A21 baud rate: {baudrate}")
+        if float(stopbits) not in A21_STOP_BITS:
+            raise ValueError(f"Unsupported A21 stop bits: {stopbits}")
+
+        # Initialize the inherited property surface, but never its BGCP socket.
+        super().__init__(endpoint, "", "DEFAULT_DEVICEID", name, port)
+        self.transport = transport
+        self.endpoint = endpoint
+        self.unit_id = int(unit_id)
+        self.baudrate = int(baudrate)
+        self.parity = str(parity).upper()
+        self.stopbits = float(stopbits)
+        self.timeout = float(timeout)
+        self._client = client
+        self._lock = RLock()
+        self._raw: dict[tuple[Table, int], int] = {}
+        self._decoded: dict[str, Any] = {}
+        self._unavailable: set[tuple[Table, int]] = set()
+        self.last_poll_complete = False
+        self.identity_probe_failed = False
+        self.extra_write_parameters_callback = None
+        self._unit_type = model
+        self._unit_type_id = A21_IDENTITY_VALUE
+        self._manufacturer = self._manufacturer_for_model(model)
+        self._current_wifi_ip = endpoint if transport == TRANSPORT_MODBUS_TCP else None
+        self._wifi_assigned_ip = self._current_wifi_ip
+        self.configuration_url = None
+        self.connection_description = self._connection_description()
+        self._configured_device_id = device_id
+        self._id = "DEFAULT_DEVICEID"
+        self._initialize_semantic_state()
+
+    @classmethod
+    def from_config(
+        cls, data: Mapping[str, Any], *, device_id: str | None = None
+    ) -> "A21ModbusDevice":
+        """Build an A21 client from one config-entry data mapping."""
+        transport = str(data[CONF_TRANSPORT])
+        endpoint = str(
+            data["ip_address"]
+            if transport == TRANSPORT_MODBUS_TCP
+            else data[CONF_SERIAL_PORT]
+        )
+        return cls(
+            transport=transport,
+            endpoint=endpoint,
+            port=int(data.get("port", 502)),
+            unit_id=int(data.get(CONF_UNIT_ID, 1)),
+            baudrate=int(data.get(CONF_BAUDRATE, 115200)),
+            parity=str(data.get(CONF_PARITY, "N")),
+            stopbits=float(data.get(CONF_STOPBITS, 2)),
+            name=str(data.get("name", "VENTS A21")),
+            model=str(data.get(CONF_DEVICE_MODEL, "Generic VENTS A21 controller")),
+            device_id=device_id,
+        )
+
+    @staticmethod
+    def _manufacturer_for_model(model: str) -> str:
+        if model.upper().startswith("ECONOPRIME"):
+            return "ECONOPRIME"
+        return "VENTS"
+
+    def _connection_description(self) -> str:
+        if self.transport == TRANSPORT_MODBUS_TCP:
+            return f"Modbus TCP: {self.endpoint}:{self.port}, unit {self.unit_id}"
+        return (
+            f"Modbus RTU: {self.endpoint}, {self.baudrate} {self.parity}"
+            f"8{self.stopbits:g}, unit {self.unit_id}"
+        )
+
+    def _initialize_semantic_state(self) -> None:
+        for semantic in _SEMANTIC_REGISTERS:
+            setattr(self, f"_{semantic}", None)
+        self._alarm_list = None
+        self._firmware = None
+        self._profile_key = "a21_modbus"
+        self.audible_write_command_count = 0
+
+    @property
+    def device_profile(self) -> DeviceProfile:
+        return _A21_PROFILE
+
+    @property
+    def manufacturer(self) -> str:
+        return self._manufacturer
+
+    @property
+    def raw_registers(self) -> Mapping[tuple[Table, int], int]:
+        """Return a read-only snapshot of all successfully read raw addresses."""
+        return MappingProxyType(dict(self._raw))
+
+    @property
+    def decoded_registers(self) -> Mapping[str, Any]:
+        """Return a read-only snapshot indexed by the official register keys."""
+        return MappingProxyType(dict(self._decoded))
+
+    @property
+    def unavailable_addresses(self) -> frozenset[tuple[Table, int]]:
+        return frozenset(self._unavailable)
+
+    def supports_capability(self, capability: str) -> bool:
+        return capability in self.device_profile.capabilities
+
+    def supports_parameter(self, parameter: str) -> bool:
+        return parameter in _SEMANTIC_REGISTERS
+
+    def parameter_range(self, parameter: str) -> tuple[int, int] | None:
+        """Return the A21 limits for a semantic HA number parameter."""
+        key = _SEMANTIC_REGISTERS.get(parameter)
+        if key is None:
+            return None
+        spec = get_register(key)
+        if spec.minimum is None or spec.maximum is None:
+            return None
+        # HA NumberEntity cannot express the published disjoint range
+        # ``0 or 70..365``. Keep 0 available through the typed API and expose
+        # only the continuous timer setpoint interval in the UI.
+        if key == "HR_SetFILTER_TIMER":
+            return (70, 365)
+        return (spec.minimum, spec.maximum)
+
+    def supports_entity(
+        self,
+        *,
+        required_params: Iterable[str] = (),
+        required_capabilities: Iterable[str] = (),
+        excluded_params: Iterable[str] = (),
+        excluded_capabilities: Iterable[str] = (),
+    ) -> bool:
+        return (
+            all(self.supports_parameter(param) for param in required_params)
+            and all(
+                self.supports_capability(capability)
+                for capability in required_capabilities
+            )
+            and not any(self.supports_parameter(param) for param in excluded_params)
+            and not any(
+                self.supports_capability(capability)
+                for capability in excluded_capabilities
+            )
+        )
+
+    def parameter_options(self, parameter: str) -> list[str] | None:
+        if parameter == "timer_mode":
+            return list(_A21_TIMER_VALUES)
+        return None
+
+    def _build_client(self):
+        try:
+            from pymodbus.client import ModbusSerialClient, ModbusTcpClient
+        except ImportError as err:  # pragma: no cover - HA installs requirements
+            raise A21ModbusError("pymodbus is not installed") from err
+
+        if self.transport == TRANSPORT_MODBUS_TCP:
+            return ModbusTcpClient(
+                self.endpoint,
+                port=self.port,
+                timeout=self.timeout,
+                retries=3,
+            )
+        return ModbusSerialClient(
+            port=self.endpoint,
+            baudrate=self.baudrate,
+            bytesize=8,
+            parity=self.parity,
+            stopbits=self.stopbits,
+            timeout=self.timeout,
+            retries=3,
+        )
+
+    def _ensure_connected(self) -> None:
+        if self._client is None:
+            self._client = self._build_client()
+        if getattr(self._client, "connected", False):
+            return
+        if not self._client.connect():
+            raise A21ModbusError(f"Cannot connect to {self.connection_description}")
+
+    def close(self) -> None:
+        with self._lock:
+            if self._client is not None:
+                self._client.close()
+
+    @staticmethod
+    def _check_response(response: Any, operation: str) -> Any:
+        if response is None:
+            raise A21ModbusError(f"A21 Modbus {operation} failed: {response!r}")
+        if callable(getattr(response, "isError", None)) and response.isError():
+            if getattr(response, "exception_code", None) == 2:
+                raise A21IllegalAddressError(
+                    f"A21 Modbus {operation} rejected an address: {response!r}"
+                )
+            raise A21ModbusError(f"A21 Modbus {operation} failed: {response!r}")
+        return response
+
+    @staticmethod
+    def _invoke(method, *args, **kwargs) -> Any:
+        """Call pymodbus while preserving programming errors as programming errors."""
+        try:
+            return method(*args, **kwargs)
+        except (OSError, ConnectionError, TimeoutError) as err:
+            raise A21ModbusError(f"A21 Modbus transport failed: {err}") from err
+        except Exception as err:
+            if err.__class__.__module__.startswith("pymodbus"):
+                raise A21ModbusError(f"A21 Modbus transport failed: {err}") from err
+            raise
+
+    def read_raw(self, table: Table, address: int, count: int = 1) -> tuple[int, ...]:
+        """Read arbitrary published A21 addresses using functions 1/2/3/4."""
+        table = Table(table)
+        if address < 0 or count < 1 or address + count > _TABLE_LENGTH[table]:
+            raise ValueError(f"A21 {table.value} range outside published table")
+        with self._lock:
+            self._ensure_connected()
+            method = getattr(self._client, _TABLE_READ_METHOD[table])
+            response = self._check_response(
+                self._invoke(method, address, count=count, device_id=self.unit_id),
+                f"read {table.value} {address}:{address + count - 1}",
+            )
+            values = (
+                tuple(int(value) for value in response.bits[:count])
+                if table in {Table.COIL, Table.DISCRETE_INPUT}
+                else tuple(int(value) for value in response.registers[:count])
+            )
+            if len(values) != count:
+                raise A21ModbusError(
+                    f"A21 Modbus short {table.value} response: "
+                    f"expected {count}, got {len(values)}"
+                )
+            for offset, value in enumerate(values):
+                self._raw[(table, address + offset)] = value
+                self._unavailable.discard((table, address + offset))
+            return values
+
+    def write_raw(
+        self, table: Table, address: int, values: Sequence[int | bool]
+    ) -> bool:
+        """Write published A21 coils/registers using functions 5/6/15/16."""
+        table = Table(table)
+        if table not in {Table.COIL, Table.HOLDING_REGISTER}:
+            raise PermissionError(f"{table.value} is read-only")
+        if not values or address < 0 or address + len(values) > _TABLE_LENGTH[table]:
+            raise ValueError(f"A21 {table.value} write outside published table")
+        for offset in range(len(values)):
+            spec = get_by_address(table, address + offset)
+            if not spec.access.writable:
+                raise PermissionError(
+                    f"{spec.key} at {table.value}/{address + offset} is read-only"
+                )
+
+        with self._lock:
+            self._ensure_connected()
+            if table is Table.COIL:
+                if any(value not in {False, True, 0, 1} for value in values):
+                    raise ValueError("Modbus coil values must be boolean")
+                bool_values = tuple(bool(value) for value in values)
+                if len(bool_values) == 1:
+                    response = self._invoke(
+                        self._client.write_coil,
+                        address,
+                        bool_values[0],
+                        device_id=self.unit_id,
+                    )
+                else:
+                    response = self._invoke(
+                        self._client.write_coils,
+                        address,
+                        list(bool_values),
+                        device_id=self.unit_id,
+                    )
+                cached = tuple(int(value) for value in bool_values)
+            else:
+                words = tuple(int(value) for value in values)
+                if any(value < 0 or value > 0xFFFF for value in words):
+                    raise ValueError("Modbus register values must be 0..65535")
+                if len(words) == 1:
+                    response = self._invoke(
+                        self._client.write_register,
+                        address,
+                        words[0],
+                        device_id=self.unit_id,
+                    )
+                else:
+                    response = self._invoke(
+                        self._client.write_registers,
+                        address,
+                        list(words),
+                        device_id=self.unit_id,
+                    )
+                cached = words
+            self._check_response(response, f"write {table.value} {address}")
+            for offset, value in enumerate(cached):
+                self._raw[(table, address + offset)] = value
+            return True
+
+    def read_register(self, key: str) -> Any:
+        """Read and decode one official A21 register definition."""
+        spec = get_register(key)
+        if not spec.access.readable:
+            raise PermissionError(f"{key} is write-only")
+        words = self.read_raw(spec.table, spec.address, spec.word_count)
+        value = spec.decode(words)
+        self._decoded[key] = value
+        self._apply_semantics()
+        return value
+
+    def write_register(self, key: str, value: Any) -> bool:
+        """Validate and write one official A21 register definition."""
+        spec = get_register(key)
+        if not spec.access.writable:
+            raise PermissionError(f"{key} is read-only")
+        if spec.enum is not None and isinstance(value, int) and value not in spec.enum:
+            raise ValueError(f"{key} has no documented enum value {value}")
+        words = spec.encode(value)
+        self.write_raw(spec.table, spec.address, words)
+        self._decoded[key] = value
+        self._apply_semantics()
+        return True
+
+    def _read_resilient(
+        self,
+        table: Table,
+        address: int,
+        count: int,
+        split_budget: list[int] | None = None,
+    ) -> bool:
+        if split_budget is None:
+            split_budget = [_MAX_ILLEGAL_ADDRESS_SPLITS]
+        try:
+            self.read_raw(table, address, count)
+            return True
+        except A21IllegalAddressError:
+            if split_budget[0] <= 0:
+                raise A21ModbusError(
+                    f"A21 {table.value} returned too many illegal-address responses"
+                )
+            split_budget[0] -= 1
+            if count == 1:
+                self._unavailable.add((table, address))
+                _LOGGER.debug("A21 address unavailable: %s/%d", table.value, address)
+                return False
+            left = count // 2
+            return self._read_resilient(
+                table, address, left, split_budget
+            ) & self._read_resilient(table, address + left, count - left, split_budget)
+
+    def _decode_cache(self) -> None:
+        for spec in REGISTERS:
+            if not spec.access.readable or spec.key in _SENSITIVE_REGISTER_KEYS:
+                continue
+            slots = [
+                (spec.table, spec.address + offset) for offset in range(spec.word_count)
+            ]
+            if not all(slot in self._raw for slot in slots):
+                continue
+            try:
+                self._decoded[spec.key] = spec.decode(self._raw[slot] for slot in slots)
+            except ValueError:
+                _LOGGER.debug("Invalid A21 value for %s", spec.key, exc_info=True)
+        self._apply_semantics()
+
+    def read_all_registers(self, *, include_sensitive: bool = False) -> bool:
+        """Poll the complete readable published surface.
+
+        Write-only action coils are skipped. The engineering password is only
+        read after an explicit opt-in; raw read/write methods still implement
+        its documented two-register protocol.
+        """
+        ranges = (
+            (Table.COIL, 0, 17),
+            (Table.COIL, 20, 6),
+            (Table.DISCRETE_INPUT, 0, 72),
+            (Table.INPUT_REGISTER, 0, 54),
+            (Table.HOLDING_REGISTER, 0, 124),
+            (Table.HOLDING_REGISTER, 126, 57),
+        )
+        complete = True
+        for table, address, count in ranges:
+            complete = self._read_resilient(table, address, count) and complete
+        if include_sensitive:
+            complete = self._read_resilient(Table.HOLDING_REGISTER, 124, 2) and complete
+        self._decode_cache()
+        self._verify_cached_identity()
+        self.last_poll_complete = complete
+        return not bool(_REQUIRED_POLL_SLOTS & self._unavailable)
+
+    def _verify_cached_identity(self) -> None:
+        identity = self._decoded.get(A21_IDENTITY_REGISTER.key)
+        if identity != A21_IDENTITY_VALUE:
+            self.identity_probe_failed = True
+            raise A21IdentityError(
+                f"Controller identity register 37 is {identity!r}; expected A21 value 1"
+            )
+
+    def init_device(self) -> bool:
+        """Connect and accept only a controller that reports A21 at IR37."""
+        self.identity_probe_failed = False
+        try:
+            identity = self.read_register(A21_IDENTITY_REGISTER.key)
+        except A21ModbusError:
+            raise
+        if identity != A21_IDENTITY_VALUE:
+            self.identity_probe_failed = True
+            return False
+
+        endpoint_id = _safe_identity(
+            f"{self.transport}-{self.endpoint}-{self.port}-{self.unit_id}"
+        )
+        self._id = self._configured_device_id or f"a21-{endpoint_id}"
+        return self.update()
+
+    def update(self) -> bool:
+        """Refresh every non-sensitive readable address in the A21 table."""
+        return self.read_all_registers()
+
+    def quick_update(self) -> bool:
+        """Refresh the high-frequency operational portion of the table."""
+        ranges = (
+            (Table.COIL, 0, 17),
+            (Table.DISCRETE_INPUT, 0, 19),
+            (Table.INPUT_REGISTER, 0, 54),
+            (Table.HOLDING_REGISTER, 0, 76),
+        )
+        complete = True
+        for table, address, count in ranges:
+            complete = self._read_resilient(table, address, count) and complete
+        self._decode_cache()
+        self._verify_cached_identity()
+        self.last_poll_complete = complete
+        return not bool(_REQUIRED_POLL_SLOTS & self._unavailable)
+
+    def update_preset_speed_settings(self) -> bool:
+        return self._read_resilient(Table.HOLDING_REGISTER, 5, 13)
+
+    @staticmethod
+    def _valid_temperature(value: Any) -> float | None:
+        if value in (-3276.8, 3276.7):
+            return None
+        return value
+
+    def _apply_semantics(self) -> None:
+        value = self._decoded.get
+        if "CL_POWER" in self._decoded:
+            self._state = "on" if value("CL_POWER") else "off"
+        if "HR_SPEED_MODE" in self._decoded:
+            self._speed = _A21_SPEEDS.get(
+                value("HR_SPEED_MODE"), f"unknown_{value('HR_SPEED_MODE')}"
+            )
+        if "HR_ManualSPEED" in self._decoded:
+            self._man_speed = value("HR_ManualSPEED")
+
+        speed_attributes = {
+            "_supply_speed_low": "HR_SuSPEED1",
+            "_exhaust_speed_low": "HR_ExSPEED1",
+            "_supply_speed_medium": "HR_SuSPEED2",
+            "_exhaust_speed_medium": "HR_ExSPEED2",
+            "_supply_speed_high": "HR_SuSPEED3",
+            "_exhaust_speed_high": "HR_ExSPEED3",
+            "_supply_speed_4": "HR_SuSPEED4",
+            "_exhaust_speed_4": "HR_ExSPEED4",
+            "_supply_speed_5": "HR_SuSPEED5",
+            "_exhaust_speed_5": "HR_ExSPEED5",
+        }
+        for attribute, key in speed_attributes.items():
+            if key in self._decoded:
+                setattr(self, attribute, value(key))
+
+        temperatures = {
+            "_temperature": "IR_CurSelTEMP",
+            "_room_temperature": "IR_CurTEMP_ExAirIn",
+            "_outdoor_temperature": "IR_CurTEMP_SuAirIn",
+            "_supply_temperature": "IR_CurTEMP_SuAirOut",
+            "_exhaust_in_temperature": "IR_CurTEMP_ExAirIn",
+            "_exhaust_out_temperature": "IR_CurTEMP_ExAirOut",
+        }
+        for attribute, key in temperatures.items():
+            if key in self._decoded:
+                setattr(self, attribute, self._valid_temperature(value(key)))
+
+        direct = {
+            "_humidity": "IR_CurRH_Int",
+            "_co2": "IR_CurCO2_Int",
+            "_voc": "IR_CurVOC_Int",
+            "_fan1_speed": "IR_SuRPM",
+            "_fan2_speed": "IR_ExRPM",
+            "_humidity_treshold": "HR_SetRH",
+            "_temperature_treshold": "HR_SetTEMP",
+            "_co2_treshold": "HR_SetCO2",
+            "_voc_treshold": "HR_SetVOC",
+        }
+        for attribute, key in direct.items():
+            if key in self._decoded:
+                setattr(self, attribute, value(key))
+
+        bool_states = {
+            "_weekly_schedule_state": "CL_WEEK",
+            "_boost_status": "CL_Boost_MODE",
+            "_humidity_sensor_state": "CL_IntRH_CTRL",
+            "_co2_sensor_state": "CL_IntCO2_CTRL",
+            "_voc_sensor_state": "CL_IntVOC_CTRL",
+            "_analogV_sensor_state": "CL_10V_SENSOR_CTRL",
+            "_heater_status": "DI_StatusHEATER",
+            "_humidity_status": "DI_StatusRH",
+        }
+        for attribute, key in bool_states.items():
+            if key in self._decoded:
+                setattr(self, attribute, "on" if value(key) else "off")
+
+        if "IR_CurVBAT" in self._decoded:
+            self._battery_voltage = f"{value('IR_CurVBAT')} mV"
+        if isinstance(value("IR_CurTIMER_TIME"), Timer):
+            timer = value("IR_CurTIMER_TIME")
+            self._timer_counter = f"{timer.hours}h {timer.minutes}m {timer.seconds}s "
+        if isinstance(value("IR_CurFILTER_TIMER"), FilterTimer):
+            timer = value("IR_CurFILTER_TIMER")
+            self._filter_timer_countdown = (
+                f"{timer.days}d {timer.hours}h {timer.minutes}m "
+            )
+        if "HR_SetFILTER_TIMER" in self._decoded:
+            self._filter_timer_setpoint = f"{value('HR_SetFILTER_TIMER')} d"
+        if isinstance(value("IR_TotalWorkingTime"), Runtime):
+            runtime = value("IR_TotalWorkingTime")
+            self._machine_hours = (
+                f"{runtime.days}d {runtime.hours}h {runtime.minutes}m "
+            )
+        if isinstance(value("IR_VerMAIN_FMW"), Firmware):
+            firmware = value("IR_VerMAIN_FMW")
+            self._firmware = (
+                f"{firmware.major}.{firmware.minor} "
+                f"{firmware.year:04d}-{firmware.month:02d}-{firmware.day:02d}"
+            )
+        if "IR_StateFILTER" in self._decoded:
+            self._filter_replacement_status = (
+                "off" if value("IR_StateFILTER") == 0 else "on"
+            )
+        if "IR_ALARM" in self._decoded:
+            self._alarm_status = {0: "no", 1: "alarm", 2: "warning"}.get(
+                value("IR_ALARM"), f"unknown_{value('IR_ALARM')}"
+            )
+        alarm_codes = [
+            str(code) for code in range(53) if value(f"DI_AlarmCODE{code}") is True
+        ]
+        self._alarm_list = ", ".join(alarm_codes) if alarm_codes else "none"
+        if "IR_CurWeekSpeed" in self._decoded:
+            self._schedule_speed = _A21_SPEEDS.get(
+                value("IR_CurWeekSpeed"),
+                f"unknown_{value('IR_CurWeekSpeed')}",
+            )
+        if "HR_TIMER_MODE" in self._decoded:
+            self._timer_mode = _A21_TIMER_MODES.get(
+                value("HR_TIMER_MODE"), f"unknown_{value('HR_TIMER_MODE')}"
+            )
+        if isinstance(value("HR_RTC_TIME"), RtcTime):
+            rtc = value("HR_RTC_TIME")
+            self._rtc_time = f"{rtc.hours:02d}:{rtc.minutes:02d}:{rtc.seconds:02d}"
+        if isinstance(value("HR_RTC_CALENDAR"), RtcCalendar):
+            rtc = value("HR_RTC_CALENDAR")
+            self._rtc_weekday = rtc.weekday
+            self._rtc_date = f"20{rtc.year:02d}-{rtc.month:02d}-{rtc.day:02d}"
+
+    def get_param(self, parameter: str) -> bool:
+        key = _SEMANTIC_REGISTERS.get(parameter)
+        if key is None:
+            return False
+        self.read_register(key)
+        return True
+
+    def _semantic_value(self, parameter: str, value: Any) -> Any:
+        if parameter in {
+            "state",
+            "weekly_schedule_state",
+            "humidity_sensor_state",
+            "co2_sensor_state",
+            "voc_sensor_state",
+            "analogV_sensor_state",
+        }:
+            if value not in {"on", "off", True, False, 0, 1}:
+                raise ValueError(f"Invalid {parameter} state: {value!r}")
+            return value in {"on", True, 1}
+        if parameter in {"filter_timer_reset", "reset_alarms"}:
+            return True
+        if parameter == "speed":
+            if value == "off":
+                self.write_register("CL_POWER", False)
+                return None
+            if value not in _A21_SPEED_VALUES:
+                raise ValueError(f"Invalid A21 speed: {value!r}")
+            return _A21_SPEED_VALUES[value]
+        if parameter == "timer_mode":
+            if value not in _A21_TIMER_VALUES:
+                raise ValueError(f"Invalid A21 timer mode: {value!r}")
+            return _A21_TIMER_VALUES[value]
+        if parameter in {"rtc_time", "rtc_date"}:
+            return value
+        return _as_raw_number(value)
+
+    def set_param(self, parameter: str, value: Any) -> bool:
+        key = _SEMANTIC_REGISTERS.get(parameter)
+        if key is None:
+            return False
+        converted = self._semantic_value(parameter, value)
+        if converted is None:
+            return True
+        return self.write_register(key, converted)
+
+    def set_parameters(
+        self,
+        values: Mapping[str, Any],
+        include_extra_write_parameters: bool = True,
+    ) -> bool:
+        targets = dict(values)
+        if include_extra_write_parameters and self.extra_write_parameters_callback:
+            for key, value in self.extra_write_parameters_callback().items():
+                targets.setdefault(key, value)
+        if not targets:
+            return False
+        return all(self.set_param(key, value) for key, value in targets.items())
+
+    set_params = set_parameters
+
+    def set_man_speed_percent(self, speed: int) -> bool:
+        target = max(0, min(100, int(speed)))
+        return self.write_register("HR_ManualSPEED", target)
+
+    def read_weekly_schedule_day(self, day: int) -> dict[int, WeeklyScheduleRecord]:
+        if day not in range(1, 8):
+            raise ValueError(f"Invalid schedule day: {day}")
+        labels = ("Mo", "Tu", "We", "Th", "Fr", "Sa", "Su")
+        label = labels[day - 1]
+        base = 126 + (day - 1) * 8
+        self.read_raw(Table.HOLDING_REGISTER, base, 8)
+        self._decode_cache()
+        records: dict[int, WeeklyScheduleRecord] = {}
+        for period in range(1, 5):
+            schedule = self._decoded[f"HR_SetWEEK_{label}_P{period}"]
+            end = self._decoded[f"HR_SetWEEK_{label}_P{period}_END"]
+            records[period] = WeeklyScheduleRecord(
+                day=day,
+                period=period,
+                speed=_A21_SPEEDS[schedule.speed],
+                end_hour=end.hour,
+                end_minute=end.minute,
+                reserved=schedule.temperature,
+            )
+        return records
+
+    def write_weekly_schedule_record(self, record: WeeklyScheduleRecord) -> bool:
+        if not isinstance(record, WeeklyScheduleRecord):
+            raise TypeError("record must be a WeeklyScheduleRecord")
+        if record.day not in range(1, 8) or record.period not in range(1, 5):
+            raise ValueError("Invalid A21 weekly schedule slot")
+        labels = ("Mo", "Tu", "We", "Th", "Fr", "Sa", "Su")
+        prefix = f"HR_SetWEEK_{labels[record.day - 1]}_P{record.period}"
+        speed = _A21_SPEED_VALUES[record.speed]
+        written = self.write_register(
+            prefix, SchedulePeriod(speed=speed, temperature=record.reserved)
+        )
+        if record.period < 4:
+            written = (
+                self.write_register(
+                    f"{prefix}_END",
+                    ScheduleEnd(hour=record.end_hour, minute=record.end_minute),
+                )
+                and written
+            )
+        return written
+
+    def rtc_datetime_params(self, value: datetime) -> dict[str, Any]:
+        return {
+            "rtc_time": RtcTime(value.hour, value.minute, value.second),
+            "rtc_date": RtcCalendar(
+                value.day, value.isoweekday(), value.month, value.year % 100
+            ),
+        }
+
+    def set_rtc_datetime(self, value: datetime) -> bool:
+        return self.set_parameters(
+            self.rtc_datetime_params(value), include_extra_write_parameters=False
+        )

--- a/custom_components/ecovent_v2/a21_registers.py
+++ b/custom_components/ecovent_v2/a21_registers.py
@@ -10,7 +10,7 @@ from this documentation alone.
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from enum import Enum
 from typing import Any, Iterable, Mapping
 
@@ -233,6 +233,7 @@ class RegisterSpec:
     word_count: int = 1
     enum: Mapping[int, str] | None = None
     source_note: str | None = None
+    default: Any = None
 
     def decode(self, words: Iterable[int]) -> Any:
         return decode(self.kind, words)
@@ -246,8 +247,8 @@ class RegisterSpec:
         return words
 
 
-def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None, source_note: str | None = None) -> RegisterSpec:
-    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum, source_note)
+def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None, source_note: str | None = None, default: Any = None) -> RegisterSpec:
+    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum, source_note, default)
 
 
 _COILS = [
@@ -311,7 +312,65 @@ def _catalogue() -> tuple[RegisterSpec, ...]:
     return tuple(out)
 
 
-REGISTERS = _catalogue()
+_ENUMS = {
+    "HR_OPERATION_MODE": {0: "ventilation only", 1: "heating", 2: "cooling", 3: "auto"},
+    "HR_TIMER_MODE": {0: "standby", 1: "speed 1", 2: "speed 2", 3: "speed 3", 4: "speed 4", 5: "speed 5"},
+    "HR_SelTEMP_SENSOR": {0: "extract air duct", 1: "external panel sensor", 2: "supply air duct"},
+    "HR_MainHEATER_TYPE": {0: "off", 1: "electric", 2: "water"},
+    "HR_COOLER_TYPE": {0: "off", 1: "digital", 2: "analogue 0-10 V"},
+    "HR_DEF_MODE": {0: "off", 1: "preheating", 2: "bypass/rotor", 3: "fan imbalance"},
+    "HR_MainHeaterMODE": {1: "manual", 2: "auto"}, "HR_CoolerMODE": {1: "manual", 2: "auto"},
+    "HR_PreHeaterMODE": {1: "manual", 2: "auto"}, "HR_BPS_ROTOR_MODE": {0: "closed/start", 1: "open/stop/manual", 2: "auto"},
+}
+
+
+def _published_metadata(spec: RegisterSpec) -> RegisterSpec:
+    """Apply every numeric/default field published in V55-8-1EN-02."""
+    if spec.table is Table.COIL:
+        defaults = (0, 0, 0, None, None, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, None, None, None, 0, 1, 1, 0, 1, 1)
+        return replace(spec, default=defaults[spec.address])
+    if spec.table is Table.INPUT_REGISTER:
+        extra = {
+            25: (0, 59, "min/sec + hours", None), 27: (0, 365, "days/hours/min", None), 29: (0, 65535, "days/hours/min", None),
+            31: (0, 3, None, None), 32: (0, 5, None, None), 33: (0, 30, "°C", None), 34: (0, 65535, None, None), 37: (0, 65535, None, None), 38: (0, 2, None, None),
+            39: (0, 100, "%", None), 40: (0, 100, "%", None), 41: (0, 100, "%", None), 42: (0, 100, "%", None),
+            43: (0, 200, "%", None), 44: (0, 200, "%", None), 45: (0, 200, "%", None), 46: (0, 100, "%", None), 47: (0, 100, "%", None),
+            48: (100, 400, "0.1 °C", None), 49: (100, 400, "0.1 °C", None), 50: (300, 600, "0.1 °C", None), 51: (0, 100, "%", None), 52: (0, 100, "%", None), 53: (0, 100, "%", None),
+        }
+        if spec.address in extra:
+            low, high, unit, default = extra[spec.address]
+            return replace(spec, minimum=low, maximum=high, unit=unit or spec.unit, default=default)
+        return spec
+    if spec.table is not Table.HOLDING_REGISTER:
+        return spec
+    # address: (min, max, default, unit, kind override)
+    details = {
+        0:(0,2,1,None,None),1:(3,5,3,None,None),2:(1,255,1,None,None),3:(0,100,30,"%",None),4:(0,100,100,"%",None),
+        43:(0,3,3,None,None),44:(15,30,23,"°C",None),45:(40,80,60,"%RH",None),46:(400,2000,1200,"ppm",Kind.U16),47:(100,1000,400,"µg/m³",Kind.U16),48:(20,100,40,"%",None),49:(0,5,1,None,None),50:(0,30,23,"°C",None),51:(0,23,ScheduleEnd(0,30),"hours/min",Kind.SCHEDULE_END),52:(5,15,7,"°C",None),53:(0,2,2,None,None),54:(0,2,None,None,None),55:(0,2,None,None,None),56:(0,3,None,None,None),57:(0,5,None,None,None),58:(0,365,90,"days",None),59:(0,60,0,"min",None),60:(0,15,0,"min",None),
+        65:(500,10000,2000,"ppm",Kind.U16),66:(500,10000,1000,"µg/m³",Kind.U16),67:(5,12,10,"°C",None),68:(1,2,2,None,None),69:(0,100,50,"%",None),70:(1,2,2,None,None),71:(0,100,0,"%",None),72:(1,2,2,None,None),73:(0,100,50,"%",None),74:(0,2,2,None,None),75:(0,100,100,"%",None),
+        103:(0,255,2,None,None),104:(5,120,30,"sec",None),105:(0,240,0,"sec",None),106:(20,240,120,"sec",None),107:(0,20,3,"min",None),108:(0,20,1,"min",None),109:(1,10,2,"°C",None),110:(0,1,None,None,None),111:(2,300,None,"sec",Kind.U16),
+        112:(-500,500,0,"0.1 °C",Kind.S16),113:(-500,500,0,"0.1 °C",Kind.S16),114:(-500,500,0,"0.1 °C",Kind.S16),115:(-500,500,0,"0.1 °C",Kind.S16),116:(-500,500,0,"0.1 °C",Kind.S16),117:(-500,500,0,"0.1 °C",Kind.S16),118:(0,100,0,"%",None),119:(2,30,5,"min",None),120:(30,60,30,"°C",Kind.S16),121:(30,60,50,"°C",Kind.S16),122:(10,30,12,"°C",Kind.S16),123:(10,30,20,"°C",Kind.S16),124:(48,57,"1111","ASCII",None),182:(4,10,5,"°C",None),
+    }
+    if 5 <= spec.address <= 22:
+        defaults=(0,0,40,40,70,70,100,100,100,100,100,100,50,50,100,100,60,40)
+        return replace(spec, minimum=0, maximum=100, default=defaults[spec.address-5], unit="%")
+    if 23 <= spec.address <= 42:
+        return replace(spec, minimum=0, maximum=10000, unit="m³/h" if spec.address <= 36 else "Pa")
+    if 76 <= spec.address <= 102:
+        defaults=(150,150,0,150,150,0,150,150,0,150,150,0,200,200,500,400,400,600,200,200,500,200,200,500,120,120,350)
+        return replace(spec, minimum=0, maximum=1000, default=defaults[spec.address-76])
+    if 126 <= spec.address <= 181:
+        period=(spec.address-126)%8
+        default = SchedulePeriod(1,23) if period % 2 == 0 else ScheduleEnd((6,9,19,23)[period//2], 0 if period < 6 else 59)
+        if period == 7: default = ScheduleEnd(23,59)
+        return replace(spec, minimum=0, maximum=30, unit="speed/°C" if period % 2 == 0 else "hours/min", default=default)
+    if spec.address in details:
+        low, high, default, unit, kind = details[spec.address]
+        return replace(spec, minimum=low, maximum=high, default=default, unit=unit or spec.unit, kind=kind or spec.kind, enum=_ENUMS.get(spec.key, spec.enum))
+    return replace(spec, enum=_ENUMS.get(spec.key, spec.enum))
+
+
+REGISTERS = tuple(_published_metadata(spec) for spec in _catalogue())
 
 
 def _indexes(registers: Iterable[RegisterSpec]) -> tuple[dict[str, RegisterSpec], dict[tuple[Table, int], RegisterSpec]]:

--- a/custom_components/ecovent_v2/a21_registers.py
+++ b/custom_components/ecovent_v2/a21_registers.py
@@ -232,6 +232,7 @@ class RegisterSpec:
     unit: str | None = None
     word_count: int = 1
     enum: Mapping[int, str] | None = None
+    source_note: str | None = None
 
     def decode(self, words: Iterable[int]) -> Any:
         return decode(self.kind, words)
@@ -245,8 +246,8 @@ class RegisterSpec:
         return words
 
 
-def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None) -> RegisterSpec:
-    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum)
+def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None, source_note: str | None = None) -> RegisterSpec:
+    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum, source_note)
 
 
 _COILS = [
@@ -280,7 +281,17 @@ def _catalogue() -> tuple[RegisterSpec, ...]:
     for address, key in enumerate(hr_names):
         ro = address in {0,1,3,4,23,24,37,38,57}; kind = Kind.U16 if address in set(range(23,43)) | {46,58} else Kind.U8
         low, high = (0,10000) if kind is Kind.U16 else (0,255)
-        out.append(_spec(key, Table.HOLDING_REGISTER, address, Access.READ_ONLY if ro else Access.READ_WRITE, kind, key[3:].replace("_", " "), low, high))
+        if address == 57:
+            # V55-8-1EN-02's maximum column says 4, while its explicit list
+            # continues with 5 (three-point bypass).  Preserve that discrepancy
+            # instead of silently losing the documented enum member.
+            high = 5
+            enum = {0: "not available", 1: "two-point bypass", 2: "analogue bypass", 3: "discrete rotary", 4: "analogue rotary", 5: "three-point bypass"}
+            note = "V55-8-1EN-02 numeric maximum is 4; its prose enum also documents value 5 (three-point bypass)."
+        else:
+            enum = None
+            note = None
+        out.append(_spec(key, Table.HOLDING_REGISTER, address, Access.READ_ONLY if ro else Access.READ_WRITE, kind, key[3:].replace("_", " "), low, high, enum=enum, source_note=note))
     out += [_spec("HR_RTC_TIME",Table.HOLDING_REGISTER,61,Access.READ_WRITE,Kind.RTC_TIME,"RTC time",word_count=2), _spec("HR_RTC_CALENDAR",Table.HOLDING_REGISTER,63,Access.READ_WRITE,Kind.RTC_CALENDAR,"RTC calendar",word_count=2)]
     for address, key in enumerate(["HR_MaxCO2_Int","HR_MaxPM2_5_Int","HR_SetMinSuAirOutTEMP","HR_MainHeaterMODE","HR_SetMainHeaterMANUAL","HR_CoolerMODE","HR_SetCoolerMANUAL","HR_PreHeaterMODE","HR_SetPreHeaterMANUAL","HR_BPS_ROTOR_MODE","HR_SetBpsRotorMANUAL"],65): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16 if address<67 else Kind.U8,key[3:].replace("_"," ")))
     for address, key in enumerate([f"HR_{controller}_{term}" for controller in ("RH","CO2","PM2_5","VOC","PreHeater","MainHeater","BPS_ROTOR","KKB","ReturnWater") for term in ("Kp","Ki","Kd")],76): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16,key[3:].replace("_"," "),0,1000))
@@ -328,4 +339,3 @@ def get_by_address(table: Table, address: int) -> RegisterSpec:
 
 A21_IDENTITY_REGISTER = BY_KEY["IR_DeviceTYPE"]
 A21_IDENTITY_VALUE = 1
-

--- a/custom_components/ecovent_v2/a21_registers.py
+++ b/custom_components/ecovent_v2/a21_registers.py
@@ -1,0 +1,331 @@
+"""VENTS A21 Modbus catalogue (V55-8-1EN-02).
+
+Addresses in this module are zero based Modbus PDU addresses.  The catalogue is
+the published A21 surface, not the BGCP/UDP map: A21 is identified by input
+register 37 being ``1``.  In particular, BGCP parameter 0x00B9 is unrelated.
+
+All multi-byte values use ordinary Modbus word order.  The ECONOPRIME hardware
+byte order has not been captured, so do not infer a device-specific byte swap
+from this documentation alone.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Iterable, Mapping
+
+
+class Table(str, Enum):
+    COIL = "coil"
+    DISCRETE_INPUT = "discrete_input"
+    INPUT_REGISTER = "input_register"
+    HOLDING_REGISTER = "holding_register"
+
+
+class Access(str, Enum):
+    READ_ONLY = "R"
+    WRITE_ONLY = "W"
+    READ_WRITE = "R/W"
+
+    @property
+    def readable(self) -> bool:
+        return self is not Access.WRITE_ONLY
+
+    @property
+    def writable(self) -> bool:
+        return self is not Access.READ_ONLY
+
+
+class Kind(str, Enum):
+    BOOL = "bool"
+    U8 = "u8"
+    U16 = "u16"
+    S16 = "s16"
+    TENTHS_S16 = "tenths_s16"
+    BYTE_PAIR = "byte_pair"
+    TIMER = "timer"
+    FILTER_TIMER = "filter_timer"
+    RUNTIME = "runtime"
+    FIRMWARE = "firmware"
+    RTC_TIME = "rtc_time"
+    RTC_CALENDAR = "rtc_calendar"
+    PASSWORD = "password"
+    SCHEDULE_SPEED_TEMP = "schedule_speed_temp"
+    SCHEDULE_END = "schedule_end"
+
+
+@dataclass(frozen=True)
+class Timer:
+    hours: int
+    minutes: int
+    seconds: int = 0
+
+
+@dataclass(frozen=True)
+class FilterTimer:
+    days: int
+    hours: int
+    minutes: int
+
+
+@dataclass(frozen=True)
+class Runtime:
+    days: int
+    hours: int
+    minutes: int
+
+
+@dataclass(frozen=True)
+class Firmware:
+    major: int
+    minor: int
+    day: int
+    month: int
+    year: int
+
+
+@dataclass(frozen=True)
+class RtcTime:
+    hours: int
+    minutes: int
+    seconds: int
+
+
+@dataclass(frozen=True)
+class RtcCalendar:
+    day: int
+    weekday: int
+    month: int
+    year: int
+
+
+@dataclass(frozen=True)
+class SchedulePeriod:
+    speed: int
+    temperature: int
+
+
+@dataclass(frozen=True)
+class ScheduleEnd:
+    hour: int
+    minute: int
+
+
+def _word(value: Any) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 0xFFFF:
+        raise ValueError(f"not a Modbus word: {value!r}")
+    return value
+
+
+def _byte(value: int, name: str = "byte") -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 0xFF:
+        raise ValueError(f"{name} must be 0..255")
+    return value
+
+
+def _range(value: int, low: int, high: int, name: str) -> int:
+    if not low <= value <= high:
+        raise ValueError(f"{name} must be {low}..{high}")
+    return value
+
+
+def _pair(high: int, low: int) -> int:
+    return (_byte(high, "high byte") << 8) | _byte(low, "low byte")
+
+
+def _unpair(word: int) -> tuple[int, int]:
+    word = _word(word)
+    return word >> 8, word & 0xFF
+
+
+def decode(kind: Kind, words: Iterable[int]) -> Any:
+    """Decode one catalogue value from standard-order Modbus words."""
+    ws = tuple(_word(w) for w in words)
+    needed = 2 if kind in {Kind.TIMER, Kind.FILTER_TIMER, Kind.RUNTIME, Kind.RTC_TIME, Kind.RTC_CALENDAR, Kind.PASSWORD} else 3 if kind is Kind.FIRMWARE else 1
+    if len(ws) != needed:
+        raise ValueError(f"{kind.value} requires {needed} words, got {len(ws)}")
+    w = ws[0]
+    if kind is Kind.BOOL:
+        if w not in (0, 1): raise ValueError("bool word must be 0 or 1")
+        return bool(w)
+    if kind is Kind.U8: return _range(w, 0, 255, "u8")
+    if kind is Kind.U16: return w
+    if kind is Kind.S16: return w - 0x10000 if w & 0x8000 else w
+    if kind is Kind.TENTHS_S16:
+        value = w - 0x10000 if w & 0x8000 else w
+        return value / 10
+    if kind is Kind.BYTE_PAIR: return _unpair(w)
+    if kind is Kind.TIMER:
+        minute, second = _unpair(ws[0]); _, hour = _unpair(ws[1]); return Timer(hour, minute, second)
+    if kind is Kind.FILTER_TIMER:
+        hour, minute = _unpair(ws[0]); return FilterTimer(ws[1], hour, minute)
+    if kind is Kind.RUNTIME:
+        hour, minute = _unpair(ws[0]); return Runtime(ws[1], hour, minute)
+    if kind is Kind.FIRMWARE:
+        major, minor = _unpair(ws[0]); day, month = _unpair(ws[1]); return Firmware(major, minor, day, month, ws[2])
+    if kind is Kind.RTC_TIME:
+        minute, second = _unpair(ws[0]); _, hour = _unpair(ws[1]); return RtcTime(hour, minute, second)
+    if kind is Kind.RTC_CALENDAR:
+        day, weekday = _unpair(ws[0]); month, year = _unpair(ws[1]); return RtcCalendar(day, weekday, month, year)
+    if kind is Kind.PASSWORD:
+        chars = bytes(_unpair(ws[0]) + _unpair(ws[1])); return chars.split(b"\0", 1)[0].decode("ascii")
+    if kind is Kind.SCHEDULE_SPEED_TEMP:
+        speed, temp = _unpair(w); return SchedulePeriod(speed, temp)
+    if kind is Kind.SCHEDULE_END:
+        hour, minute = _unpair(w); return ScheduleEnd(hour, minute)
+    raise AssertionError(kind)
+
+
+def encode(kind: Kind, value: Any) -> tuple[int, ...]:
+    """Encode a value to Modbus words, validating the documented record shape."""
+    if kind is Kind.BOOL:
+        if not isinstance(value, bool): raise ValueError("bool required")
+        return (int(value),)
+    if kind is Kind.U8: return (_byte(value),)
+    if kind is Kind.U16: return (_word(value),)
+    if kind is Kind.S16:
+        _range(value, -32768, 32767, "s16"); return (value & 0xFFFF,)
+    if kind is Kind.TENTHS_S16:
+        raw = round(value * 10)
+        if raw != value * 10: raise ValueError("tenths value must have one decimal place")
+        _range(raw, -32768, 32767, "tenths_s16"); return (raw & 0xFFFF,)
+    if kind is Kind.BYTE_PAIR:
+        high, low = value; return (_pair(high, low),)
+    if kind in {Kind.TIMER, Kind.RTC_TIME}:
+        cls = Timer if kind is Kind.TIMER else RtcTime
+        if not isinstance(value, cls): raise ValueError(f"{kind.value} record required")
+        return (_pair(_range(value.minutes, 0, 59, "minutes"), _range(value.seconds, 0, 59, "seconds")), _pair(0, _range(value.hours, 0, 23, "hours")))
+    if kind is Kind.FILTER_TIMER:
+        if not isinstance(value, FilterTimer): raise ValueError("filter timer record required")
+        return (_pair(_range(value.hours, 0, 23, "hours"), _range(value.minutes, 0, 59, "minutes")), _range(value.days, 0, 365, "days"))
+    if kind is Kind.RUNTIME:
+        if not isinstance(value, Runtime): raise ValueError("runtime record required")
+        return (_pair(_range(value.hours, 0, 23, "hours"), _range(value.minutes, 0, 59, "minutes")), _word(value.days))
+    if kind is Kind.FIRMWARE:
+        if not isinstance(value, Firmware): raise ValueError("firmware record required")
+        return (_pair(value.major, value.minor), _pair(_range(value.day, 1, 31, "day"), _range(value.month, 1, 12, "month")), _word(value.year))
+    if kind is Kind.RTC_CALENDAR:
+        if not isinstance(value, RtcCalendar): raise ValueError("calendar record required")
+        return (_pair(_range(value.day, 1, 31, "day"), _range(value.weekday, 1, 7, "weekday")), _pair(_range(value.month, 1, 12, "month"), _range(value.year, 0, 99, "year")))
+    if kind is Kind.PASSWORD:
+        if not isinstance(value, str) or not 1 <= len(value) <= 4 or not value.isascii() or not value.isdigit(): raise ValueError("password must be 1-4 ASCII digits")
+        raw = value.encode().ljust(4, b"\0"); return ((raw[0] << 8) | raw[1], (raw[2] << 8) | raw[3])
+    if kind is Kind.SCHEDULE_SPEED_TEMP:
+        if not isinstance(value, SchedulePeriod): raise ValueError("schedule period required")
+        return (_pair(_range(value.speed, 0, 5, "speed"), _range(value.temperature, 0, 30, "temperature")),)
+    if kind is Kind.SCHEDULE_END:
+        if not isinstance(value, ScheduleEnd): raise ValueError("schedule end required")
+        return (_pair(_range(value.hour, 0, 23, "hour"), _range(value.minute, 0, 59, "minute")),)
+    raise AssertionError(kind)
+
+
+@dataclass(frozen=True)
+class RegisterSpec:
+    key: str
+    table: Table
+    address: int
+    access: Access
+    kind: Kind
+    description: str
+    minimum: int | None = None
+    maximum: int | None = None
+    unit: str | None = None
+    word_count: int = 1
+    enum: Mapping[int, str] | None = None
+
+    def decode(self, words: Iterable[int]) -> Any:
+        return decode(self.kind, words)
+
+    def encode(self, value: Any) -> tuple[int, ...]:
+        if not self.access.writable: raise PermissionError(f"{self.key} is read-only")
+        words = encode(self.kind, value)
+        if self.minimum is not None and self.kind in {Kind.U8, Kind.U16, Kind.S16, Kind.TENTHS_S16}:
+            numeric = value * 10 if self.kind is Kind.TENTHS_S16 else value
+            if not self.minimum <= numeric <= self.maximum: raise ValueError(f"{self.key} outside documented range")
+        return words
+
+
+def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None) -> RegisterSpec:
+    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum)
+
+
+_COILS = [
+    ("CL_POWER", "Unit On/Off"), ("CL_TIMER", "Main timer"), ("CL_WEEK", "Weekly Schedule"), ("CL_Boost_MODE", "Boost mode"), ("CL_FPLC_MODE", "Fireplace mode"),
+    ("CL_IntRH_CTRL", "Main humidity sensor activation"), ("CL_ExtRH_CTRL", "External humidity sensor activation"), ("CL_IntCO2_CTRL", "Main CO2 sensor activation"), ("CL_ExtCO2_CTRL", "External CO2 sensor activation"), ("CL_IntPM2_5_CTRL", "Main PM2.5 sensor activation"),
+    ("CL_ExtPM2_5_CTRL", "External PM2.5 sensor activation"), ("CL_IntVOC_CTRL", "Main VOC sensor activation"), ("CL_ExtVOC_CTRL", "External VOC sensor activation"), ("CL_BoostSWITCH_CTRL", "Boost switch input activation"), ("CL_FplcSWITCH_CTRL", "Fireplace switch input activation"),
+    ("CL_FireALARM_CTRL", "Fire alarm sensor activation"), ("CL_10V_SENSOR_CTRL", "External 0-10 V input activation"), ("CL_RESET_FILTER_TIMER", "Reset filter timer"), ("CL_RESET_ALARM", "Reset all alarms"), ("CL_RESTORE_FACTORY", "Restore factory settings"),
+    ("CL_CLOUD_CTRL", "Cloud control activation"), ("CL_MinSuAirOutTEMP_CTRL", "Minimum supply air temperature control"), ("CL_WaterPRESS_CTRL", "Heat medium water pressure sensor activation"), ("CL_WaterFLOW_CTRL", "Heat medium water flow sensor activation"), ("CL_WaterHeaterAutoRestart", "Automatic restart after return-water emergency"), ("CL_AutoReductionAirFlow", "Automatic air-flow reduction on main heater failure"),
+]
+_DI_BASE = ["DI_CurBoostSWITCH", "DI_CurFplcSWITCH", "DI_CurFireALARM", "DI_StatusRH", "DI_StatusCO2", "DI_StatusPM2_5", "DI_StatusVOC", "DI_StatusHEATER", "DI_StatusCOOLER", "DI_StatusFanBLOWING", "DI_CurPreHeaterThermostat", "DI_CurMainHeaterThermostat", "DI_CurSuFilterPRESS", "DI_CurExFilterPRESS", "DI_CurWaterPRESS", "DI_CurWaterFLOW", "DI_CurSuFanPRESS", "DI_CurExFanPRESS", "DI_WaterPreheatingStatus"]
+_IR = [
+    ("IR_CurSelTEMP", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_SuAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_SuAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_ExAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_ExAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_Ext", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_AfterPreHeater", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_BeforeMainHeater", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_Water", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurVBAT", Kind.U16, 0, 5000, "mV"),
+    ("IR_CurRH_Int", Kind.U8, 0, 100, "%"), ("IR_CurRH_Ext", Kind.U8, 0, 100, "%"), ("IR_CurCO2_Int", Kind.U16, 0, 10000, "ppm"), ("IR_CurCO2_Ext", Kind.U16, 0, 10000, "ppm"), ("IR_CurPM2_5_Int", Kind.U16, 0, 1000, "µg/m³"), ("IR_CurPM2_5_Ext", Kind.U16, 0, 1000, "µg/m³"), ("IR_CurVOC_Int", Kind.U8, 0, 100, "%"), ("IR_CurVOC_Ext", Kind.U8, 0, 100, "%"), ("IR_Cur10V_SENSOR", Kind.U16, 0, 100, "%"), ("IR_CurSuAirFLOW", Kind.U16, 0, 10000, "m³/h"), ("IR_CurExAirFLOW", Kind.U16, 0, 10000, "m³/h"), ("IR_CurSuPRESS", Kind.U16, 0, 10000, "Pa"), ("IR_CurExPRESS", Kind.U16, 0, 10000, "Pa"), ("IR_SuRPM", Kind.U16, 0, 5000, "rpm"), ("IR_ExRPM", Kind.U16, 0, 5000, "rpm"),
+]
+
+
+def _catalogue() -> tuple[RegisterSpec, ...]:
+    out: list[RegisterSpec] = []
+    for address, (key, text) in enumerate(_COILS):
+        access = Access.WRITE_ONLY if address in (17, 18, 19) else Access.READ_ONLY if address in (3, 4) else Access.READ_WRITE
+        out.append(_spec(key, Table.COIL, address, access, Kind.BOOL, text, 1 if access is Access.WRITE_ONLY else 0, 1, None))
+    out.extend(_spec(key, Table.DISCRETE_INPUT, address, Access.READ_ONLY, Kind.BOOL, key.replace("DI_", "").replace("_", " "), 0, 1) for address, key in enumerate(_DI_BASE))
+    out.extend(_spec(f"DI_AlarmCODE{address - 19}", Table.DISCRETE_INPUT, address, Access.READ_ONLY, Kind.BOOL, f"Alarm indicator with code No. {address - 19}", 0, 1) for address in range(19, 72))
+    for address, (key, kind, low, high, unit) in enumerate(_IR): out.append(_spec(key, Table.INPUT_REGISTER, address, Access.READ_ONLY, kind, key[3:].replace("_", " "), low, high, unit))
+    out += [_spec("IR_CurTIMER_TIME", Table.INPUT_REGISTER, 25, Access.READ_ONLY, Kind.TIMER, "Current countdown time of main timer", word_count=2), _spec("IR_CurFILTER_TIMER", Table.INPUT_REGISTER, 27, Access.READ_ONLY, Kind.FILTER_TIMER, "Filter replacement timer countdown", word_count=2), _spec("IR_TotalWorkingTime", Table.INPUT_REGISTER, 29, Access.READ_ONLY, Kind.RUNTIME, "Motor hours", word_count=2), _spec("IR_StateFILTER", Table.INPUT_REGISTER, 31, Access.READ_ONLY, Kind.U8, "Filter condition", 0, 3, enum={0:"clean",1:"supply clogged",2:"extract clogged",3:"both/timer"}), _spec("IR_CurWeekSpeed", Table.INPUT_REGISTER, 32, Access.READ_ONLY, Kind.U8, "Weekly schedule speed", 0, 5), _spec("IR_CurWeekSetTemp", Table.INPUT_REGISTER, 33, Access.READ_ONLY, Kind.U8, "Weekly schedule temperature", 0, 30, "°C"), _spec("IR_VerMAIN_FMW", Table.INPUT_REGISTER, 34, Access.READ_ONLY, Kind.FIRMWARE, "Firmware version and creation date", word_count=3), _spec("IR_DeviceTYPE", Table.INPUT_REGISTER, 37, Access.READ_ONLY, Kind.U16, "Controller type; 1 is A21", 0, 65535), _spec("IR_ALARM", Table.INPUT_REGISTER, 38, Access.READ_ONLY, Kind.U8, "Alarm/warning indicator", 0, 2, enum={0:"none",1:"alarm",2:"warning"})]
+    for address, key in enumerate(["IR_RH_U", "IR_CO2_U", "IR_PM2_5_U", "IR_VOC_U", "IR_PreHeater_U", "IR_MainHeater_U", "IR_BPS_ROTOR_U", "IR_KKB_U", "IR_ReturnWater_U", "IR_SuAirOutSetTemp", "IR_WaterStandbySetTemp", "IR_WaterStartSetTemp", "IR_StatusBpsRotor", "IR_CurSuFanSpeed", "IR_CurExFanSpeed"], 39):
+        kind = Kind.TENTHS_S16 if address in (48,49,50) else Kind.U8; out.append(_spec(key, Table.INPUT_REGISTER, address, Access.READ_ONLY, kind, key[3:].replace("_", " ")))
+    hr_names = ["HR_VENTILATION_MODE","HR_MaxSPEED_MODE","HR_SPEED_MODE","HR_MinSPEED","HR_MaxSPEED","HR_SuSPEED0","HR_ExSPEED0","HR_SuSPEED1","HR_ExSPEED1","HR_SuSPEED2","HR_ExSPEED2","HR_SuSPEED3","HR_ExSPEED3","HR_SuSPEED4","HR_ExSPEED4","HR_SuSPEED5","HR_ExSPEED5","HR_ManualSPEED","HR_BlowingSPEED","HR_Boost_SuSPEED","HR_Boost_ExSPEED","HR_FPLC_SuSPEED","HR_FPLC_ExSPEED","HR_MinAirFLOW","HR_MaxAirFLOW"]
+    hr_names += [f"HR_{side}SPEED{speed}_FLOW" for speed in range(0,6) for side in ("Su","Ex")]
+    hr_names += ["HR_MinAirPRESS","HR_MaxAirPRESS","HR_SuSPEED0_PRESS","HR_ExSPEED0_PRESS","HR_SuSPEED1_PRESS","HR_ExSPEED1_PRESS","HR_OPERATION_MODE","HR_SetTEMP","HR_SetRH","HR_SetCO2","HR_SetPM2_5","HR_SetVOC","HR_TIMER_MODE","HR_SetTIMER_TEMP","HR_SetTIMER_TIME","HR_SetTEMP_WinterSummer","HR_SelTEMP_SENSOR","HR_MainHEATER_TYPE","HR_COOLER_TYPE","HR_DEF_MODE","HR_BPS_ROTOR_TYPE","HR_SetFILTER_TIMER","HR_BoostDelaySwitchingOff","HR_BoostDelaySwitchingOn"]
+    for address, key in enumerate(hr_names):
+        ro = address in {0,1,3,4,23,24,37,38,57}; kind = Kind.U16 if address in set(range(23,43)) | {46,58} else Kind.U8
+        low, high = (0,10000) if kind is Kind.U16 else (0,255)
+        out.append(_spec(key, Table.HOLDING_REGISTER, address, Access.READ_ONLY if ro else Access.READ_WRITE, kind, key[3:].replace("_", " "), low, high))
+    out += [_spec("HR_RTC_TIME",Table.HOLDING_REGISTER,61,Access.READ_WRITE,Kind.RTC_TIME,"RTC time",word_count=2), _spec("HR_RTC_CALENDAR",Table.HOLDING_REGISTER,63,Access.READ_WRITE,Kind.RTC_CALENDAR,"RTC calendar",word_count=2)]
+    for address, key in enumerate(["HR_MaxCO2_Int","HR_MaxPM2_5_Int","HR_SetMinSuAirOutTEMP","HR_MainHeaterMODE","HR_SetMainHeaterMANUAL","HR_CoolerMODE","HR_SetCoolerMANUAL","HR_PreHeaterMODE","HR_SetPreHeaterMANUAL","HR_BPS_ROTOR_MODE","HR_SetBpsRotorMANUAL"],65): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16 if address<67 else Kind.U8,key[3:].replace("_"," ")))
+    for address, key in enumerate([f"HR_{controller}_{term}" for controller in ("RH","CO2","PM2_5","VOC","PreHeater","MainHeater","BPS_ROTOR","KKB","ReturnWater") for term in ("Kp","Ki","Kd")],76): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16,key[3:].replace("_"," "),0,1000))
+    tail = ["HR_FanAlarmCTRL","HR_SetTimeDetectFanALARM","HR_SetTimeOpenVALVE","HR_SetTimeFanBLOWING","HR_KKB_MinTimeOFF","HR_KKB_MinTimeON","HR_KKB_HYSTERESIS","HR_BPS_Position","HR_TimeOpenBPS","HR_CorrTEMP_SuAirIn","HR_CorrTEMP_SuAirOut","HR_CorrTEMP_ExAirIn","HR_CorrTEMP_ExAirOut","HR_CorrTEMP_Water","HR_CorrTEMP_Ext","HR_WaterValveMinPos","HR_WaterMaxStartTime","HR_WaterMinStartTemp","HR_WaterMaxStartTemp","HR_WaterMinAlarmTemp","HR_WaterMaxAlarmTemp"]
+    for address,key in enumerate(tail,103):
+        ro=address in {103,104,110,111}; kind=Kind.S16 if address in set(range(112,118))|set(range(120,124)) else Kind.U8
+        out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_ONLY if ro else Access.READ_WRITE,kind,key[3:].replace("_"," ")))
+    out.append(_spec("HR_ENGINEER_PWD",Table.HOLDING_REGISTER,124,Access.READ_WRITE,Kind.PASSWORD,"Engineering menu password",48,57,"ASCII",2))
+    days=("Mo","Tu","We","Th","Fr","Sa","Su")
+    for day_no, day in enumerate(days):
+        base=126+day_no*8
+        for period in range(1,5):
+            out.append(_spec(f"HR_SetWEEK_{day}_P{period}",Table.HOLDING_REGISTER,base+(period-1)*2,Access.READ_WRITE,Kind.SCHEDULE_SPEED_TEMP,f"{day} period {period}: speed and temperature",word_count=1))
+            end_access=Access.READ_ONLY if period==4 else Access.READ_WRITE
+            out.append(_spec(f"HR_SetWEEK_{day}_P{period}_END",Table.HOLDING_REGISTER,base+(period-1)*2+1,end_access,Kind.SCHEDULE_END,f"{day} period {period} end time",word_count=1))
+    out.append(_spec("HR_DEF_SetTemp",Table.HOLDING_REGISTER,182,Access.READ_ONLY,Kind.U8,"Exhaust air frost-protection temperature",4,10,"°C"))
+    return tuple(out)
+
+
+REGISTERS = _catalogue()
+
+
+def _indexes(registers: Iterable[RegisterSpec]) -> tuple[dict[str, RegisterSpec], dict[tuple[Table, int], RegisterSpec]]:
+    keys: dict[str, RegisterSpec] = {}; addresses: dict[tuple[Table,int], RegisterSpec] = {}
+    for spec in registers:
+        if spec.key in keys: raise ValueError(f"duplicate key {spec.key}")
+        keys[spec.key] = spec
+        for address in range(spec.address, spec.address + spec.word_count):
+            slot=(spec.table,address)
+            if slot in addresses: raise ValueError(f"overlap at {slot}")
+            addresses[slot]=spec
+    return keys, addresses
+
+
+BY_KEY, BY_TABLE_ADDRESS = _indexes(REGISTERS)
+
+
+def get_register(key: str) -> RegisterSpec:
+    return BY_KEY[key]
+
+
+def get_by_address(table: Table, address: int) -> RegisterSpec:
+    return BY_TABLE_ADDRESS[(table, address)]
+
+
+A21_IDENTITY_REGISTER = BY_KEY["IR_DeviceTYPE"]
+A21_IDENTITY_VALUE = 1
+

--- a/custom_components/ecovent_v2/a21_registers.py
+++ b/custom_components/ecovent_v2/a21_registers.py
@@ -8,6 +8,7 @@ All multi-byte values use ordinary Modbus word order.  The ECONOPRIME hardware
 byte order has not been captured, so do not infer a device-specific byte swap
 from this documentation alone.
 """
+
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
@@ -112,7 +113,11 @@ class ScheduleEnd:
 
 
 def _word(value: Any) -> int:
-    if not isinstance(value, int) or isinstance(value, bool) or not 0 <= value <= 0xFFFF:
+    if (
+        not isinstance(value, int)
+        or isinstance(value, bool)
+        or not 0 <= value <= 0xFFFF
+    ):
         raise ValueError(f"not a Modbus word: {value!r}")
     return value
 
@@ -141,81 +146,172 @@ def _unpair(word: int) -> tuple[int, int]:
 def decode(kind: Kind, words: Iterable[int]) -> Any:
     """Decode one catalogue value from standard-order Modbus words."""
     ws = tuple(_word(w) for w in words)
-    needed = 2 if kind in {Kind.TIMER, Kind.FILTER_TIMER, Kind.RUNTIME, Kind.RTC_TIME, Kind.RTC_CALENDAR, Kind.PASSWORD} else 3 if kind is Kind.FIRMWARE else 1
+    needed = (
+        2
+        if kind
+        in {
+            Kind.TIMER,
+            Kind.FILTER_TIMER,
+            Kind.RUNTIME,
+            Kind.RTC_TIME,
+            Kind.RTC_CALENDAR,
+            Kind.PASSWORD,
+        }
+        else 3
+        if kind is Kind.FIRMWARE
+        else 1
+    )
     if len(ws) != needed:
         raise ValueError(f"{kind.value} requires {needed} words, got {len(ws)}")
     w = ws[0]
     if kind is Kind.BOOL:
-        if w not in (0, 1): raise ValueError("bool word must be 0 or 1")
+        if w not in (0, 1):
+            raise ValueError("bool word must be 0 or 1")
         return bool(w)
-    if kind is Kind.U8: return _range(w, 0, 255, "u8")
-    if kind is Kind.U16: return w
-    if kind is Kind.S16: return w - 0x10000 if w & 0x8000 else w
+    if kind is Kind.U8:
+        return _range(w, 0, 255, "u8")
+    if kind is Kind.U16:
+        return w
+    if kind is Kind.S16:
+        return w - 0x10000 if w & 0x8000 else w
     if kind is Kind.TENTHS_S16:
         value = w - 0x10000 if w & 0x8000 else w
         return value / 10
-    if kind is Kind.BYTE_PAIR: return _unpair(w)
+    if kind is Kind.BYTE_PAIR:
+        return _unpair(w)
     if kind is Kind.TIMER:
-        minute, second = _unpair(ws[0]); _, hour = _unpair(ws[1]); return Timer(hour, minute, second)
+        minute, second = _unpair(ws[0])
+        _, hour = _unpair(ws[1])
+        return Timer(hour, minute, second)
     if kind is Kind.FILTER_TIMER:
-        hour, minute = _unpair(ws[0]); return FilterTimer(ws[1], hour, minute)
+        hour, minute = _unpair(ws[0])
+        return FilterTimer(ws[1], hour, minute)
     if kind is Kind.RUNTIME:
-        hour, minute = _unpair(ws[0]); return Runtime(ws[1], hour, minute)
+        hour, minute = _unpair(ws[0])
+        return Runtime(ws[1], hour, minute)
     if kind is Kind.FIRMWARE:
-        major, minor = _unpair(ws[0]); day, month = _unpair(ws[1]); return Firmware(major, minor, day, month, ws[2])
+        major, minor = _unpair(ws[0])
+        day, month = _unpair(ws[1])
+        return Firmware(major, minor, day, month, ws[2])
     if kind is Kind.RTC_TIME:
-        minute, second = _unpair(ws[0]); _, hour = _unpair(ws[1]); return RtcTime(hour, minute, second)
+        minute, second = _unpair(ws[0])
+        _, hour = _unpair(ws[1])
+        return RtcTime(hour, minute, second)
     if kind is Kind.RTC_CALENDAR:
-        day, weekday = _unpair(ws[0]); month, year = _unpair(ws[1]); return RtcCalendar(day, weekday, month, year)
+        day, weekday = _unpair(ws[0])
+        month, year = _unpair(ws[1])
+        return RtcCalendar(day, weekday, month, year)
     if kind is Kind.PASSWORD:
-        chars = bytes(_unpair(ws[0]) + _unpair(ws[1])); return chars.split(b"\0", 1)[0].decode("ascii")
+        chars = bytes(_unpair(ws[0]) + _unpair(ws[1]))
+        return chars.split(b"\0", 1)[0].decode("ascii")
     if kind is Kind.SCHEDULE_SPEED_TEMP:
-        speed, temp = _unpair(w); return SchedulePeriod(speed, temp)
+        speed, temp = _unpair(w)
+        return SchedulePeriod(speed, temp)
     if kind is Kind.SCHEDULE_END:
-        hour, minute = _unpair(w); return ScheduleEnd(hour, minute)
+        hour, minute = _unpair(w)
+        return ScheduleEnd(hour, minute)
     raise AssertionError(kind)
 
 
 def encode(kind: Kind, value: Any) -> tuple[int, ...]:
     """Encode a value to Modbus words, validating the documented record shape."""
     if kind is Kind.BOOL:
-        if not isinstance(value, bool): raise ValueError("bool required")
+        if not isinstance(value, bool):
+            raise ValueError("bool required")
         return (int(value),)
-    if kind is Kind.U8: return (_byte(value),)
-    if kind is Kind.U16: return (_word(value),)
+    if kind is Kind.U8:
+        return (_byte(value),)
+    if kind is Kind.U16:
+        return (_word(value),)
     if kind is Kind.S16:
-        _range(value, -32768, 32767, "s16"); return (value & 0xFFFF,)
+        _range(value, -32768, 32767, "s16")
+        return (value & 0xFFFF,)
     if kind is Kind.TENTHS_S16:
         raw = round(value * 10)
-        if raw != value * 10: raise ValueError("tenths value must have one decimal place")
-        _range(raw, -32768, 32767, "tenths_s16"); return (raw & 0xFFFF,)
+        if raw != value * 10:
+            raise ValueError("tenths value must have one decimal place")
+        _range(raw, -32768, 32767, "tenths_s16")
+        return (raw & 0xFFFF,)
     if kind is Kind.BYTE_PAIR:
-        high, low = value; return (_pair(high, low),)
+        high, low = value
+        return (_pair(high, low),)
     if kind in {Kind.TIMER, Kind.RTC_TIME}:
         cls = Timer if kind is Kind.TIMER else RtcTime
-        if not isinstance(value, cls): raise ValueError(f"{kind.value} record required")
-        return (_pair(_range(value.minutes, 0, 59, "minutes"), _range(value.seconds, 0, 59, "seconds")), _pair(0, _range(value.hours, 0, 23, "hours")))
+        if not isinstance(value, cls):
+            raise ValueError(f"{kind.value} record required")
+        return (
+            _pair(
+                _range(value.minutes, 0, 59, "minutes"),
+                _range(value.seconds, 0, 59, "seconds"),
+            ),
+            _pair(0, _range(value.hours, 0, 23, "hours")),
+        )
     if kind is Kind.FILTER_TIMER:
-        if not isinstance(value, FilterTimer): raise ValueError("filter timer record required")
-        return (_pair(_range(value.hours, 0, 23, "hours"), _range(value.minutes, 0, 59, "minutes")), _range(value.days, 0, 365, "days"))
+        if not isinstance(value, FilterTimer):
+            raise ValueError("filter timer record required")
+        return (
+            _pair(
+                _range(value.hours, 0, 23, "hours"),
+                _range(value.minutes, 0, 59, "minutes"),
+            ),
+            _range(value.days, 0, 365, "days"),
+        )
     if kind is Kind.RUNTIME:
-        if not isinstance(value, Runtime): raise ValueError("runtime record required")
-        return (_pair(_range(value.hours, 0, 23, "hours"), _range(value.minutes, 0, 59, "minutes")), _word(value.days))
+        if not isinstance(value, Runtime):
+            raise ValueError("runtime record required")
+        return (
+            _pair(
+                _range(value.hours, 0, 23, "hours"),
+                _range(value.minutes, 0, 59, "minutes"),
+            ),
+            _word(value.days),
+        )
     if kind is Kind.FIRMWARE:
-        if not isinstance(value, Firmware): raise ValueError("firmware record required")
-        return (_pair(value.major, value.minor), _pair(_range(value.day, 1, 31, "day"), _range(value.month, 1, 12, "month")), _word(value.year))
+        if not isinstance(value, Firmware):
+            raise ValueError("firmware record required")
+        return (
+            _pair(value.major, value.minor),
+            _pair(_range(value.day, 1, 31, "day"), _range(value.month, 1, 12, "month")),
+            _word(value.year),
+        )
     if kind is Kind.RTC_CALENDAR:
-        if not isinstance(value, RtcCalendar): raise ValueError("calendar record required")
-        return (_pair(_range(value.day, 1, 31, "day"), _range(value.weekday, 1, 7, "weekday")), _pair(_range(value.month, 1, 12, "month"), _range(value.year, 0, 99, "year")))
+        if not isinstance(value, RtcCalendar):
+            raise ValueError("calendar record required")
+        return (
+            _pair(
+                _range(value.day, 1, 31, "day"), _range(value.weekday, 1, 7, "weekday")
+            ),
+            _pair(
+                _range(value.month, 1, 12, "month"), _range(value.year, 0, 99, "year")
+            ),
+        )
     if kind is Kind.PASSWORD:
-        if not isinstance(value, str) or not 1 <= len(value) <= 4 or not value.isascii() or not value.isdigit(): raise ValueError("password must be 1-4 ASCII digits")
-        raw = value.encode().ljust(4, b"\0"); return ((raw[0] << 8) | raw[1], (raw[2] << 8) | raw[3])
+        if (
+            not isinstance(value, str)
+            or not 1 <= len(value) <= 4
+            or not value.isascii()
+            or not value.isdigit()
+        ):
+            raise ValueError("password must be 1-4 ASCII digits")
+        raw = value.encode().ljust(4, b"\0")
+        return ((raw[0] << 8) | raw[1], (raw[2] << 8) | raw[3])
     if kind is Kind.SCHEDULE_SPEED_TEMP:
-        if not isinstance(value, SchedulePeriod): raise ValueError("schedule period required")
-        return (_pair(_range(value.speed, 0, 5, "speed"), _range(value.temperature, 0, 30, "temperature")),)
+        if not isinstance(value, SchedulePeriod):
+            raise ValueError("schedule period required")
+        return (
+            _pair(
+                _range(value.speed, 0, 5, "speed"),
+                _range(value.temperature, 0, 30, "temperature"),
+            ),
+        )
     if kind is Kind.SCHEDULE_END:
-        if not isinstance(value, ScheduleEnd): raise ValueError("schedule end required")
-        return (_pair(_range(value.hour, 0, 23, "hour"), _range(value.minute, 0, 59, "minute")),)
+        if not isinstance(value, ScheduleEnd):
+            raise ValueError("schedule end required")
+        return (
+            _pair(
+                _range(value.hour, 0, 23, "hour"), _range(value.minute, 0, 59, "minute")
+            ),
+        )
     raise AssertionError(kind)
 
 
@@ -234,154 +330,865 @@ class RegisterSpec:
     enum: Mapping[int, str] | None = None
     source_note: str | None = None
     default: Any = None
+    allowed_ranges: tuple[tuple[int, int], ...] = ()
 
     def decode(self, words: Iterable[int]) -> Any:
         return decode(self.kind, words)
 
     def encode(self, value: Any) -> tuple[int, ...]:
-        if not self.access.writable: raise PermissionError(f"{self.key} is read-only")
+        if not self.access.writable:
+            raise PermissionError(f"{self.key} is read-only")
         words = encode(self.kind, value)
-        if self.minimum is not None and self.kind in {Kind.U8, Kind.U16, Kind.S16, Kind.TENTHS_S16}:
-            numeric = value * 10 if self.kind is Kind.TENTHS_S16 else value
-            if not self.minimum <= numeric <= self.maximum: raise ValueError(f"{self.key} outside documented range")
+        if self.minimum is not None and self.kind in {
+            Kind.BOOL,
+            Kind.U8,
+            Kind.U16,
+            Kind.S16,
+            Kind.TENTHS_S16,
+        }:
+            numeric = (
+                int(value)
+                if self.kind is Kind.BOOL
+                else value * 10
+                if self.kind is Kind.TENTHS_S16
+                else value
+            )
+            if not self.minimum <= numeric <= self.maximum:
+                raise ValueError(f"{self.key} outside documented range")
+            if self.allowed_ranges and not any(
+                low <= numeric <= high for low, high in self.allowed_ranges
+            ):
+                raise ValueError(f"{self.key} outside documented allowed ranges")
         return words
 
 
-def _spec(key: str, table: Table, address: int, access: Access, kind: Kind, description: str, minimum: int | None = None, maximum: int | None = None, unit: str | None = None, word_count: int = 1, enum: Mapping[int, str] | None = None, source_note: str | None = None, default: Any = None) -> RegisterSpec:
-    return RegisterSpec(key, table, address, access, kind, description, minimum, maximum, unit, word_count, enum, source_note, default)
+def _spec(
+    key: str,
+    table: Table,
+    address: int,
+    access: Access,
+    kind: Kind,
+    description: str,
+    minimum: int | None = None,
+    maximum: int | None = None,
+    unit: str | None = None,
+    word_count: int = 1,
+    enum: Mapping[int, str] | None = None,
+    source_note: str | None = None,
+    default: Any = None,
+) -> RegisterSpec:
+    return RegisterSpec(
+        key,
+        table,
+        address,
+        access,
+        kind,
+        description,
+        minimum,
+        maximum,
+        unit,
+        word_count,
+        enum,
+        source_note,
+        default,
+    )
 
 
 _COILS = [
-    ("CL_POWER", "Unit On/Off"), ("CL_TIMER", "Main timer"), ("CL_WEEK", "Weekly Schedule"), ("CL_Boost_MODE", "Boost mode"), ("CL_FPLC_MODE", "Fireplace mode"),
-    ("CL_IntRH_CTRL", "Main humidity sensor activation"), ("CL_ExtRH_CTRL", "External humidity sensor activation"), ("CL_IntCO2_CTRL", "Main CO2 sensor activation"), ("CL_ExtCO2_CTRL", "External CO2 sensor activation"), ("CL_IntPM2_5_CTRL", "Main PM2.5 sensor activation"),
-    ("CL_ExtPM2_5_CTRL", "External PM2.5 sensor activation"), ("CL_IntVOC_CTRL", "Main VOC sensor activation"), ("CL_ExtVOC_CTRL", "External VOC sensor activation"), ("CL_BoostSWITCH_CTRL", "Boost switch input activation"), ("CL_FplcSWITCH_CTRL", "Fireplace switch input activation"),
-    ("CL_FireALARM_CTRL", "Fire alarm sensor activation"), ("CL_10V_SENSOR_CTRL", "External 0-10 V input activation"), ("CL_RESET_FILTER_TIMER", "Reset filter timer"), ("CL_RESET_ALARM", "Reset all alarms"), ("CL_RESTORE_FACTORY", "Restore factory settings"),
-    ("CL_CLOUD_CTRL", "Cloud control activation"), ("CL_MinSuAirOutTEMP_CTRL", "Minimum supply air temperature control"), ("CL_WaterPRESS_CTRL", "Heat medium water pressure sensor activation"), ("CL_WaterFLOW_CTRL", "Heat medium water flow sensor activation"), ("CL_WaterHeaterAutoRestart", "Automatic restart after return-water emergency"), ("CL_AutoReductionAirFlow", "Automatic air-flow reduction on main heater failure"),
+    ("CL_POWER", "Unit On/Off"),
+    ("CL_TIMER", "Main timer"),
+    ("CL_WEEK", "Weekly Schedule"),
+    ("CL_Boost_MODE", "Boost mode"),
+    ("CL_FPLC_MODE", "Fireplace mode"),
+    ("CL_IntRH_CTRL", "Main humidity sensor activation"),
+    ("CL_ExtRH_CTRL", "External humidity sensor activation"),
+    ("CL_IntCO2_CTRL", "Main CO2 sensor activation"),
+    ("CL_ExtCO2_CTRL", "External CO2 sensor activation"),
+    ("CL_IntPM2_5_CTRL", "Main PM2.5 sensor activation"),
+    ("CL_ExtPM2_5_CTRL", "External PM2.5 sensor activation"),
+    ("CL_IntVOC_CTRL", "Main VOC sensor activation"),
+    ("CL_ExtVOC_CTRL", "External VOC sensor activation"),
+    ("CL_BoostSWITCH_CTRL", "Boost switch input activation"),
+    ("CL_FplcSWITCH_CTRL", "Fireplace switch input activation"),
+    ("CL_FireALARM_CTRL", "Fire alarm sensor activation"),
+    ("CL_10V_SENSOR_CTRL", "External 0-10 V input activation"),
+    ("CL_RESET_FILTER_TIMER", "Reset filter timer"),
+    ("CL_RESET_ALARM", "Reset all alarms"),
+    ("CL_RESTORE_FACTORY", "Restore factory settings"),
+    ("CL_CLOUD_CTRL", "Cloud control activation"),
+    ("CL_MinSuAirOutTEMP_CTRL", "Minimum supply air temperature control"),
+    ("CL_WaterPRESS_CTRL", "Heat medium water pressure sensor activation"),
+    ("CL_WaterFLOW_CTRL", "Heat medium water flow sensor activation"),
+    ("CL_WaterHeaterAutoRestart", "Automatic restart after return-water emergency"),
+    ("CL_AutoReductionAirFlow", "Automatic air-flow reduction on main heater failure"),
 ]
-_DI_BASE = ["DI_CurBoostSWITCH", "DI_CurFplcSWITCH", "DI_CurFireALARM", "DI_StatusRH", "DI_StatusCO2", "DI_StatusPM2_5", "DI_StatusVOC", "DI_StatusHEATER", "DI_StatusCOOLER", "DI_StatusFanBLOWING", "DI_CurPreHeaterThermostat", "DI_CurMainHeaterThermostat", "DI_CurSuFilterPRESS", "DI_CurExFilterPRESS", "DI_CurWaterPRESS", "DI_CurWaterFLOW", "DI_CurSuFanPRESS", "DI_CurExFanPRESS", "DI_WaterPreheatingStatus"]
+_DI_BASE = [
+    "DI_CurBoostSWITCH",
+    "DI_CurFplcSWITCH",
+    "DI_CurFireALARM",
+    "DI_StatusRH",
+    "DI_StatusCO2",
+    "DI_StatusPM2_5",
+    "DI_StatusVOC",
+    "DI_StatusHEATER",
+    "DI_StatusCOOLER",
+    "DI_StatusFanBLOWING",
+    "DI_CurPreHeaterThermostat",
+    "DI_CurMainHeaterThermostat",
+    "DI_CurSuFilterPRESS",
+    "DI_CurExFilterPRESS",
+    "DI_CurWaterPRESS",
+    "DI_CurWaterFLOW",
+    "DI_CurSuFanPRESS",
+    "DI_CurExFanPRESS",
+    "DI_WaterPreheatingStatus",
+]
 _IR = [
-    ("IR_CurSelTEMP", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_SuAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_SuAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_ExAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_ExAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_Ext", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_AfterPreHeater", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_BeforeMainHeater", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurTEMP_Water", Kind.TENTHS_S16, -32768, 32767, "°C"), ("IR_CurVBAT", Kind.U16, 0, 5000, "mV"),
-    ("IR_CurRH_Int", Kind.U8, 0, 100, "%"), ("IR_CurRH_Ext", Kind.U8, 0, 100, "%"), ("IR_CurCO2_Int", Kind.U16, 0, 10000, "ppm"), ("IR_CurCO2_Ext", Kind.U16, 0, 10000, "ppm"), ("IR_CurPM2_5_Int", Kind.U16, 0, 1000, "µg/m³"), ("IR_CurPM2_5_Ext", Kind.U16, 0, 1000, "µg/m³"), ("IR_CurVOC_Int", Kind.U8, 0, 100, "%"), ("IR_CurVOC_Ext", Kind.U8, 0, 100, "%"), ("IR_Cur10V_SENSOR", Kind.U16, 0, 100, "%"), ("IR_CurSuAirFLOW", Kind.U16, 0, 10000, "m³/h"), ("IR_CurExAirFLOW", Kind.U16, 0, 10000, "m³/h"), ("IR_CurSuPRESS", Kind.U16, 0, 10000, "Pa"), ("IR_CurExPRESS", Kind.U16, 0, 10000, "Pa"), ("IR_SuRPM", Kind.U16, 0, 5000, "rpm"), ("IR_ExRPM", Kind.U16, 0, 5000, "rpm"),
+    ("IR_CurSelTEMP", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_SuAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_SuAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_ExAirIn", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_ExAirOut", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_Ext", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_AfterPreHeater", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_BeforeMainHeater", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurTEMP_Water", Kind.TENTHS_S16, -32768, 32767, "°C"),
+    ("IR_CurVBAT", Kind.U16, 0, 5000, "mV"),
+    ("IR_CurRH_Int", Kind.U8, 0, 100, "%"),
+    ("IR_CurRH_Ext", Kind.U8, 0, 100, "%"),
+    ("IR_CurCO2_Int", Kind.U16, 0, 10000, "ppm"),
+    ("IR_CurCO2_Ext", Kind.U16, 0, 10000, "ppm"),
+    ("IR_CurPM2_5_Int", Kind.U16, 0, 1000, "µg/m³"),
+    ("IR_CurPM2_5_Ext", Kind.U16, 0, 1000, "µg/m³"),
+    ("IR_CurVOC_Int", Kind.U8, 0, 100, "%"),
+    ("IR_CurVOC_Ext", Kind.U8, 0, 100, "%"),
+    ("IR_Cur10V_SENSOR", Kind.U16, 0, 100, "%"),
+    ("IR_CurSuAirFLOW", Kind.U16, 0, 10000, "m³/h"),
+    ("IR_CurExAirFLOW", Kind.U16, 0, 10000, "m³/h"),
+    ("IR_CurSuPRESS", Kind.U16, 0, 10000, "Pa"),
+    ("IR_CurExPRESS", Kind.U16, 0, 10000, "Pa"),
+    ("IR_SuRPM", Kind.U16, 0, 5000, "rpm"),
+    ("IR_ExRPM", Kind.U16, 0, 5000, "rpm"),
 ]
 
 
 def _catalogue() -> tuple[RegisterSpec, ...]:
     out: list[RegisterSpec] = []
     for address, (key, text) in enumerate(_COILS):
-        access = Access.WRITE_ONLY if address in (17, 18, 19) else Access.READ_ONLY if address in (3, 4) else Access.READ_WRITE
-        out.append(_spec(key, Table.COIL, address, access, Kind.BOOL, text, 1 if access is Access.WRITE_ONLY else 0, 1, None))
-    out.extend(_spec(key, Table.DISCRETE_INPUT, address, Access.READ_ONLY, Kind.BOOL, key.replace("DI_", "").replace("_", " "), 0, 1) for address, key in enumerate(_DI_BASE))
-    out.extend(_spec(f"DI_AlarmCODE{address - 19}", Table.DISCRETE_INPUT, address, Access.READ_ONLY, Kind.BOOL, f"Alarm indicator with code No. {address - 19}", 0, 1) for address in range(19, 72))
-    for address, (key, kind, low, high, unit) in enumerate(_IR): out.append(_spec(key, Table.INPUT_REGISTER, address, Access.READ_ONLY, kind, key[3:].replace("_", " "), low, high, unit))
-    out += [_spec("IR_CurTIMER_TIME", Table.INPUT_REGISTER, 25, Access.READ_ONLY, Kind.TIMER, "Current countdown time of main timer", word_count=2), _spec("IR_CurFILTER_TIMER", Table.INPUT_REGISTER, 27, Access.READ_ONLY, Kind.FILTER_TIMER, "Filter replacement timer countdown", word_count=2), _spec("IR_TotalWorkingTime", Table.INPUT_REGISTER, 29, Access.READ_ONLY, Kind.RUNTIME, "Motor hours", word_count=2), _spec("IR_StateFILTER", Table.INPUT_REGISTER, 31, Access.READ_ONLY, Kind.U8, "Filter condition", 0, 3, enum={0:"clean",1:"supply clogged",2:"extract clogged",3:"both/timer"}), _spec("IR_CurWeekSpeed", Table.INPUT_REGISTER, 32, Access.READ_ONLY, Kind.U8, "Weekly schedule speed", 0, 5), _spec("IR_CurWeekSetTemp", Table.INPUT_REGISTER, 33, Access.READ_ONLY, Kind.U8, "Weekly schedule temperature", 0, 30, "°C"), _spec("IR_VerMAIN_FMW", Table.INPUT_REGISTER, 34, Access.READ_ONLY, Kind.FIRMWARE, "Firmware version and creation date", word_count=3), _spec("IR_DeviceTYPE", Table.INPUT_REGISTER, 37, Access.READ_ONLY, Kind.U16, "Controller type; 1 is A21", 0, 65535), _spec("IR_ALARM", Table.INPUT_REGISTER, 38, Access.READ_ONLY, Kind.U8, "Alarm/warning indicator", 0, 2, enum={0:"none",1:"alarm",2:"warning"})]
-    for address, key in enumerate(["IR_RH_U", "IR_CO2_U", "IR_PM2_5_U", "IR_VOC_U", "IR_PreHeater_U", "IR_MainHeater_U", "IR_BPS_ROTOR_U", "IR_KKB_U", "IR_ReturnWater_U", "IR_SuAirOutSetTemp", "IR_WaterStandbySetTemp", "IR_WaterStartSetTemp", "IR_StatusBpsRotor", "IR_CurSuFanSpeed", "IR_CurExFanSpeed"], 39):
-        kind = Kind.TENTHS_S16 if address in (48,49,50) else Kind.U8; out.append(_spec(key, Table.INPUT_REGISTER, address, Access.READ_ONLY, kind, key[3:].replace("_", " ")))
-    hr_names = ["HR_VENTILATION_MODE","HR_MaxSPEED_MODE","HR_SPEED_MODE","HR_MinSPEED","HR_MaxSPEED","HR_SuSPEED0","HR_ExSPEED0","HR_SuSPEED1","HR_ExSPEED1","HR_SuSPEED2","HR_ExSPEED2","HR_SuSPEED3","HR_ExSPEED3","HR_SuSPEED4","HR_ExSPEED4","HR_SuSPEED5","HR_ExSPEED5","HR_ManualSPEED","HR_BlowingSPEED","HR_Boost_SuSPEED","HR_Boost_ExSPEED","HR_FPLC_SuSPEED","HR_FPLC_ExSPEED","HR_MinAirFLOW","HR_MaxAirFLOW"]
-    hr_names += [f"HR_{side}SPEED{speed}_FLOW" for speed in range(0,6) for side in ("Su","Ex")]
-    hr_names += ["HR_MinAirPRESS","HR_MaxAirPRESS","HR_SuSPEED0_PRESS","HR_ExSPEED0_PRESS","HR_SuSPEED1_PRESS","HR_ExSPEED1_PRESS","HR_OPERATION_MODE","HR_SetTEMP","HR_SetRH","HR_SetCO2","HR_SetPM2_5","HR_SetVOC","HR_TIMER_MODE","HR_SetTIMER_TEMP","HR_SetTIMER_TIME","HR_SetTEMP_WinterSummer","HR_SelTEMP_SENSOR","HR_MainHEATER_TYPE","HR_COOLER_TYPE","HR_DEF_MODE","HR_BPS_ROTOR_TYPE","HR_SetFILTER_TIMER","HR_BoostDelaySwitchingOff","HR_BoostDelaySwitchingOn"]
+        access = (
+            Access.WRITE_ONLY
+            if address in (17, 18, 19)
+            else Access.READ_ONLY
+            if address in (3, 4)
+            else Access.READ_WRITE
+        )
+        out.append(
+            _spec(
+                key,
+                Table.COIL,
+                address,
+                access,
+                Kind.BOOL,
+                text,
+                1 if access is Access.WRITE_ONLY else 0,
+                1,
+                None,
+            )
+        )
+    out.extend(
+        _spec(
+            key,
+            Table.DISCRETE_INPUT,
+            address,
+            Access.READ_ONLY,
+            Kind.BOOL,
+            key.replace("DI_", "").replace("_", " "),
+            0,
+            1,
+        )
+        for address, key in enumerate(_DI_BASE)
+    )
+    out.extend(
+        _spec(
+            f"DI_AlarmCODE{address - 19}",
+            Table.DISCRETE_INPUT,
+            address,
+            Access.READ_ONLY,
+            Kind.BOOL,
+            f"Alarm indicator with code No. {address - 19}",
+            0,
+            1,
+        )
+        for address in range(19, 72)
+    )
+    for address, (key, kind, low, high, unit) in enumerate(_IR):
+        out.append(
+            _spec(
+                key,
+                Table.INPUT_REGISTER,
+                address,
+                Access.READ_ONLY,
+                kind,
+                key[3:].replace("_", " "),
+                low,
+                high,
+                unit,
+            )
+        )
+    out += [
+        _spec(
+            "IR_CurTIMER_TIME",
+            Table.INPUT_REGISTER,
+            25,
+            Access.READ_ONLY,
+            Kind.TIMER,
+            "Current countdown time of main timer",
+            word_count=2,
+        ),
+        _spec(
+            "IR_CurFILTER_TIMER",
+            Table.INPUT_REGISTER,
+            27,
+            Access.READ_ONLY,
+            Kind.FILTER_TIMER,
+            "Filter replacement timer countdown",
+            word_count=2,
+        ),
+        _spec(
+            "IR_TotalWorkingTime",
+            Table.INPUT_REGISTER,
+            29,
+            Access.READ_ONLY,
+            Kind.RUNTIME,
+            "Motor hours",
+            word_count=2,
+        ),
+        _spec(
+            "IR_StateFILTER",
+            Table.INPUT_REGISTER,
+            31,
+            Access.READ_ONLY,
+            Kind.U8,
+            "Filter condition",
+            0,
+            3,
+            enum={
+                0: "clean",
+                1: "supply clogged",
+                2: "extract clogged",
+                3: "both/timer",
+            },
+        ),
+        _spec(
+            "IR_CurWeekSpeed",
+            Table.INPUT_REGISTER,
+            32,
+            Access.READ_ONLY,
+            Kind.U8,
+            "Weekly schedule speed",
+            0,
+            5,
+        ),
+        _spec(
+            "IR_CurWeekSetTemp",
+            Table.INPUT_REGISTER,
+            33,
+            Access.READ_ONLY,
+            Kind.U8,
+            "Weekly schedule temperature",
+            0,
+            30,
+            "°C",
+        ),
+        _spec(
+            "IR_VerMAIN_FMW",
+            Table.INPUT_REGISTER,
+            34,
+            Access.READ_ONLY,
+            Kind.FIRMWARE,
+            "Firmware version and creation date",
+            word_count=3,
+        ),
+        _spec(
+            "IR_DeviceTYPE",
+            Table.INPUT_REGISTER,
+            37,
+            Access.READ_ONLY,
+            Kind.U16,
+            "Controller type; 1 is A21",
+            0,
+            65535,
+        ),
+        _spec(
+            "IR_ALARM",
+            Table.INPUT_REGISTER,
+            38,
+            Access.READ_ONLY,
+            Kind.U8,
+            "Alarm/warning indicator",
+            0,
+            2,
+            enum={0: "none", 1: "alarm", 2: "warning"},
+        ),
+    ]
+    for address, key in enumerate(
+        [
+            "IR_RH_U",
+            "IR_CO2_U",
+            "IR_PM2_5_U",
+            "IR_VOC_U",
+            "IR_PreHeater_U",
+            "IR_MainHeater_U",
+            "IR_BPS_ROTOR_U",
+            "IR_KKB_U",
+            "IR_ReturnWater_U",
+            "IR_SuAirOutSetTemp",
+            "IR_WaterStandbySetTemp",
+            "IR_WaterStartSetTemp",
+            "IR_StatusBpsRotor",
+            "IR_CurSuFanSpeed",
+            "IR_CurExFanSpeed",
+        ],
+        39,
+    ):
+        kind = Kind.TENTHS_S16 if address in (48, 49, 50) else Kind.U8
+        out.append(
+            _spec(
+                key,
+                Table.INPUT_REGISTER,
+                address,
+                Access.READ_ONLY,
+                kind,
+                key[3:].replace("_", " "),
+            )
+        )
+    hr_names = [
+        "HR_VENTILATION_MODE",
+        "HR_MaxSPEED_MODE",
+        "HR_SPEED_MODE",
+        "HR_MinSPEED",
+        "HR_MaxSPEED",
+        "HR_SuSPEED0",
+        "HR_ExSPEED0",
+        "HR_SuSPEED1",
+        "HR_ExSPEED1",
+        "HR_SuSPEED2",
+        "HR_ExSPEED2",
+        "HR_SuSPEED3",
+        "HR_ExSPEED3",
+        "HR_SuSPEED4",
+        "HR_ExSPEED4",
+        "HR_SuSPEED5",
+        "HR_ExSPEED5",
+        "HR_ManualSPEED",
+        "HR_BlowingSPEED",
+        "HR_Boost_SuSPEED",
+        "HR_Boost_ExSPEED",
+        "HR_FPLC_SuSPEED",
+        "HR_FPLC_ExSPEED",
+        "HR_MinAirFLOW",
+        "HR_MaxAirFLOW",
+    ]
+    hr_names += [
+        f"HR_{side}SPEED{speed}_FLOW" for speed in range(0, 6) for side in ("Su", "Ex")
+    ]
+    hr_names += [
+        "HR_MinAirPRESS",
+        "HR_MaxAirPRESS",
+        "HR_SuSPEED0_PRESS",
+        "HR_ExSPEED0_PRESS",
+        "HR_SuSPEED1_PRESS",
+        "HR_ExSPEED1_PRESS",
+        "HR_OPERATION_MODE",
+        "HR_SetTEMP",
+        "HR_SetRH",
+        "HR_SetCO2",
+        "HR_SetPM2_5",
+        "HR_SetVOC",
+        "HR_TIMER_MODE",
+        "HR_SetTIMER_TEMP",
+        "HR_SetTIMER_TIME",
+        "HR_SetTEMP_WinterSummer",
+        "HR_SelTEMP_SENSOR",
+        "HR_MainHEATER_TYPE",
+        "HR_COOLER_TYPE",
+        "HR_DEF_MODE",
+        "HR_BPS_ROTOR_TYPE",
+        "HR_SetFILTER_TIMER",
+        "HR_BoostDelaySwitchingOff",
+        "HR_BoostDelaySwitchingOn",
+    ]
     for address, key in enumerate(hr_names):
-        ro = address in {0,1,3,4,23,24,37,38,57}; kind = Kind.U16 if address in set(range(23,43)) | {46,58} else Kind.U8
-        low, high = (0,10000) if kind is Kind.U16 else (0,255)
+        ro = address in {0, 1, 3, 4, 23, 24, 37, 38, 57}
+        kind = Kind.U16 if address in set(range(23, 43)) | {46, 58} else Kind.U8
+        low, high = (0, 10000) if kind is Kind.U16 else (0, 255)
         if address == 57:
             # V55-8-1EN-02's maximum column says 4, while its explicit list
             # continues with 5 (three-point bypass).  Preserve that discrepancy
             # instead of silently losing the documented enum member.
             high = 5
-            enum = {0: "not available", 1: "two-point bypass", 2: "analogue bypass", 3: "discrete rotary", 4: "analogue rotary", 5: "three-point bypass"}
+            enum = {
+                0: "not available",
+                1: "two-point bypass",
+                2: "analogue bypass",
+                3: "discrete rotary",
+                4: "analogue rotary",
+                5: "three-point bypass",
+            }
             note = "V55-8-1EN-02 numeric maximum is 4; its prose enum also documents value 5 (three-point bypass)."
         else:
             enum = None
             note = None
-        out.append(_spec(key, Table.HOLDING_REGISTER, address, Access.READ_ONLY if ro else Access.READ_WRITE, kind, key[3:].replace("_", " "), low, high, enum=enum, source_note=note))
-    out += [_spec("HR_RTC_TIME",Table.HOLDING_REGISTER,61,Access.READ_WRITE,Kind.RTC_TIME,"RTC time",word_count=2), _spec("HR_RTC_CALENDAR",Table.HOLDING_REGISTER,63,Access.READ_WRITE,Kind.RTC_CALENDAR,"RTC calendar",word_count=2)]
-    for address, key in enumerate(["HR_MaxCO2_Int","HR_MaxPM2_5_Int","HR_SetMinSuAirOutTEMP","HR_MainHeaterMODE","HR_SetMainHeaterMANUAL","HR_CoolerMODE","HR_SetCoolerMANUAL","HR_PreHeaterMODE","HR_SetPreHeaterMANUAL","HR_BPS_ROTOR_MODE","HR_SetBpsRotorMANUAL"],65): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16 if address<67 else Kind.U8,key[3:].replace("_"," ")))
-    for address, key in enumerate([f"HR_{controller}_{term}" for controller in ("RH","CO2","PM2_5","VOC","PreHeater","MainHeater","BPS_ROTOR","KKB","ReturnWater") for term in ("Kp","Ki","Kd")],76): out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_WRITE,Kind.U16,key[3:].replace("_"," "),0,1000))
-    tail = ["HR_FanAlarmCTRL","HR_SetTimeDetectFanALARM","HR_SetTimeOpenVALVE","HR_SetTimeFanBLOWING","HR_KKB_MinTimeOFF","HR_KKB_MinTimeON","HR_KKB_HYSTERESIS","HR_BPS_Position","HR_TimeOpenBPS","HR_CorrTEMP_SuAirIn","HR_CorrTEMP_SuAirOut","HR_CorrTEMP_ExAirIn","HR_CorrTEMP_ExAirOut","HR_CorrTEMP_Water","HR_CorrTEMP_Ext","HR_WaterValveMinPos","HR_WaterMaxStartTime","HR_WaterMinStartTemp","HR_WaterMaxStartTemp","HR_WaterMinAlarmTemp","HR_WaterMaxAlarmTemp"]
-    for address,key in enumerate(tail,103):
-        ro=address in {103,104,110,111}; kind=Kind.S16 if address in set(range(112,118))|set(range(120,124)) else Kind.U8
-        out.append(_spec(key,Table.HOLDING_REGISTER,address,Access.READ_ONLY if ro else Access.READ_WRITE,kind,key[3:].replace("_"," ")))
-    out.append(_spec("HR_ENGINEER_PWD",Table.HOLDING_REGISTER,124,Access.READ_WRITE,Kind.PASSWORD,"Engineering menu password",48,57,"ASCII",2))
-    days=("Mo","Tu","We","Th","Fr","Sa","Su")
+        out.append(
+            _spec(
+                key,
+                Table.HOLDING_REGISTER,
+                address,
+                Access.READ_ONLY if ro else Access.READ_WRITE,
+                kind,
+                key[3:].replace("_", " "),
+                low,
+                high,
+                enum=enum,
+                source_note=note,
+            )
+        )
+    out += [
+        _spec(
+            "HR_RTC_TIME",
+            Table.HOLDING_REGISTER,
+            61,
+            Access.READ_WRITE,
+            Kind.RTC_TIME,
+            "RTC time",
+            word_count=2,
+        ),
+        _spec(
+            "HR_RTC_CALENDAR",
+            Table.HOLDING_REGISTER,
+            63,
+            Access.READ_WRITE,
+            Kind.RTC_CALENDAR,
+            "RTC calendar",
+            word_count=2,
+        ),
+    ]
+    for address, key in enumerate(
+        [
+            "HR_MaxCO2_Int",
+            "HR_MaxPM2_5_Int",
+            "HR_SetMinSuAirOutTEMP",
+            "HR_MainHeaterMODE",
+            "HR_SetMainHeaterMANUAL",
+            "HR_CoolerMODE",
+            "HR_SetCoolerMANUAL",
+            "HR_PreHeaterMODE",
+            "HR_SetPreHeaterMANUAL",
+            "HR_BPS_ROTOR_MODE",
+            "HR_SetBpsRotorMANUAL",
+        ],
+        65,
+    ):
+        out.append(
+            _spec(
+                key,
+                Table.HOLDING_REGISTER,
+                address,
+                Access.READ_WRITE,
+                Kind.U16 if address < 67 else Kind.U8,
+                key[3:].replace("_", " "),
+            )
+        )
+    for address, key in enumerate(
+        [
+            f"HR_{controller}_{term}"
+            for controller in (
+                "RH",
+                "CO2",
+                "PM2_5",
+                "VOC",
+                "PreHeater",
+                "MainHeater",
+                "BPS_ROTOR",
+                "KKB",
+                "ReturnWater",
+            )
+            for term in ("Kp", "Ki", "Kd")
+        ],
+        76,
+    ):
+        out.append(
+            _spec(
+                key,
+                Table.HOLDING_REGISTER,
+                address,
+                Access.READ_WRITE,
+                Kind.U16,
+                key[3:].replace("_", " "),
+                0,
+                1000,
+            )
+        )
+    tail = [
+        "HR_FanAlarmCTRL",
+        "HR_SetTimeDetectFanALARM",
+        "HR_SetTimeOpenVALVE",
+        "HR_SetTimeFanBLOWING",
+        "HR_KKB_MinTimeOFF",
+        "HR_KKB_MinTimeON",
+        "HR_KKB_HYSTERESIS",
+        "HR_BPS_Position",
+        "HR_TimeOpenBPS",
+        "HR_CorrTEMP_SuAirIn",
+        "HR_CorrTEMP_SuAirOut",
+        "HR_CorrTEMP_ExAirIn",
+        "HR_CorrTEMP_ExAirOut",
+        "HR_CorrTEMP_Water",
+        "HR_CorrTEMP_Ext",
+        "HR_WaterValveMinPos",
+        "HR_WaterMaxStartTime",
+        "HR_WaterMinStartTemp",
+        "HR_WaterMaxStartTemp",
+        "HR_WaterMinAlarmTemp",
+        "HR_WaterMaxAlarmTemp",
+    ]
+    for address, key in enumerate(tail, 103):
+        ro = address in {103, 104, 110, 111}
+        kind = (
+            Kind.S16
+            if address in set(range(112, 118)) | set(range(120, 124))
+            else Kind.U8
+        )
+        out.append(
+            _spec(
+                key,
+                Table.HOLDING_REGISTER,
+                address,
+                Access.READ_ONLY if ro else Access.READ_WRITE,
+                kind,
+                key[3:].replace("_", " "),
+            )
+        )
+    out.append(
+        _spec(
+            "HR_ENGINEER_PWD",
+            Table.HOLDING_REGISTER,
+            124,
+            Access.READ_WRITE,
+            Kind.PASSWORD,
+            "Engineering menu password",
+            48,
+            57,
+            "ASCII",
+            2,
+        )
+    )
+    days = ("Mo", "Tu", "We", "Th", "Fr", "Sa", "Su")
     for day_no, day in enumerate(days):
-        base=126+day_no*8
-        for period in range(1,5):
-            out.append(_spec(f"HR_SetWEEK_{day}_P{period}",Table.HOLDING_REGISTER,base+(period-1)*2,Access.READ_WRITE,Kind.SCHEDULE_SPEED_TEMP,f"{day} period {period}: speed and temperature",word_count=1))
-            end_access=Access.READ_ONLY if period==4 else Access.READ_WRITE
-            out.append(_spec(f"HR_SetWEEK_{day}_P{period}_END",Table.HOLDING_REGISTER,base+(period-1)*2+1,end_access,Kind.SCHEDULE_END,f"{day} period {period} end time",word_count=1))
-    out.append(_spec("HR_DEF_SetTemp",Table.HOLDING_REGISTER,182,Access.READ_ONLY,Kind.U8,"Exhaust air frost-protection temperature",4,10,"°C"))
+        base = 126 + day_no * 8
+        for period in range(1, 5):
+            out.append(
+                _spec(
+                    f"HR_SetWEEK_{day}_P{period}",
+                    Table.HOLDING_REGISTER,
+                    base + (period - 1) * 2,
+                    Access.READ_WRITE,
+                    Kind.SCHEDULE_SPEED_TEMP,
+                    f"{day} period {period}: speed and temperature",
+                    word_count=1,
+                )
+            )
+            end_access = Access.READ_ONLY if period == 4 else Access.READ_WRITE
+            out.append(
+                _spec(
+                    f"HR_SetWEEK_{day}_P{period}_END",
+                    Table.HOLDING_REGISTER,
+                    base + (period - 1) * 2 + 1,
+                    end_access,
+                    Kind.SCHEDULE_END,
+                    f"{day} period {period} end time",
+                    word_count=1,
+                )
+            )
+    out.append(
+        _spec(
+            "HR_DEF_SetTemp",
+            Table.HOLDING_REGISTER,
+            182,
+            Access.READ_ONLY,
+            Kind.U8,
+            "Exhaust air frost-protection temperature",
+            4,
+            10,
+            "°C",
+        )
+    )
     return tuple(out)
 
 
 _ENUMS = {
     "HR_OPERATION_MODE": {0: "ventilation only", 1: "heating", 2: "cooling", 3: "auto"},
-    "HR_TIMER_MODE": {0: "standby", 1: "speed 1", 2: "speed 2", 3: "speed 3", 4: "speed 4", 5: "speed 5"},
-    "HR_SelTEMP_SENSOR": {0: "extract air duct", 1: "external panel sensor", 2: "supply air duct"},
+    "HR_TIMER_MODE": {
+        0: "standby",
+        1: "speed 1",
+        2: "speed 2",
+        3: "speed 3",
+        4: "speed 4",
+        5: "speed 5",
+    },
+    "HR_SelTEMP_SENSOR": {
+        0: "extract air duct",
+        1: "external panel sensor",
+        2: "supply air duct",
+    },
     "HR_MainHEATER_TYPE": {0: "off", 1: "electric", 2: "water"},
     "HR_COOLER_TYPE": {0: "off", 1: "digital", 2: "analogue 0-10 V"},
     "HR_DEF_MODE": {0: "off", 1: "preheating", 2: "bypass/rotor", 3: "fan imbalance"},
-    "HR_MainHeaterMODE": {1: "manual", 2: "auto"}, "HR_CoolerMODE": {1: "manual", 2: "auto"},
-    "HR_PreHeaterMODE": {1: "manual", 2: "auto"}, "HR_BPS_ROTOR_MODE": {0: "closed/start", 1: "open/stop/manual", 2: "auto"},
+    "HR_MainHeaterMODE": {1: "manual", 2: "auto"},
+    "HR_CoolerMODE": {1: "manual", 2: "auto"},
+    "HR_PreHeaterMODE": {1: "manual", 2: "auto"},
+    "HR_BPS_ROTOR_MODE": {0: "closed/start", 1: "open/stop/manual", 2: "auto"},
 }
 
 
 def _published_metadata(spec: RegisterSpec) -> RegisterSpec:
     """Apply every numeric/default field published in V55-8-1EN-02."""
     if spec.table is Table.COIL:
-        defaults = (0, 0, 0, None, None, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, None, None, None, 0, 1, 1, 0, 1, 1)
+        defaults = (
+            0,
+            0,
+            0,
+            None,
+            None,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            0,
+            0,
+            None,
+            None,
+            None,
+            0,
+            1,
+            1,
+            0,
+            1,
+            1,
+        )
         return replace(spec, default=defaults[spec.address])
     if spec.table is Table.INPUT_REGISTER:
         extra = {
-            25: (0, 59, "min/sec + hours", None), 27: (0, 365, "days/hours/min", None), 29: (0, 65535, "days/hours/min", None),
-            31: (0, 3, None, None), 32: (0, 5, None, None), 33: (0, 30, "°C", None), 34: (0, 65535, None, None), 37: (0, 65535, None, None), 38: (0, 2, None, None),
-            39: (0, 100, "%", None), 40: (0, 100, "%", None), 41: (0, 100, "%", None), 42: (0, 100, "%", None),
-            43: (0, 200, "%", None), 44: (0, 200, "%", None), 45: (0, 200, "%", None), 46: (0, 100, "%", None), 47: (0, 100, "%", None),
-            48: (100, 400, "0.1 °C", None), 49: (100, 400, "0.1 °C", None), 50: (300, 600, "0.1 °C", None), 51: (0, 100, "%", None), 52: (0, 100, "%", None), 53: (0, 100, "%", None),
+            25: (0, 59, "min/sec + hours", None),
+            27: (0, 365, "days/hours/min", None),
+            29: (0, 65535, "days/hours/min", None),
+            31: (0, 3, None, None),
+            32: (0, 5, None, None),
+            33: (0, 30, "°C", None),
+            34: (0, 65535, None, None),
+            37: (0, 65535, None, None),
+            38: (0, 2, None, None),
+            39: (0, 100, "%", None),
+            40: (0, 100, "%", None),
+            41: (0, 100, "%", None),
+            42: (0, 100, "%", None),
+            43: (0, 200, "%", None),
+            44: (0, 200, "%", None),
+            45: (0, 200, "%", None),
+            46: (0, 100, "%", None),
+            47: (0, 100, "%", None),
+            48: (100, 400, "0.1 °C", None),
+            49: (100, 400, "0.1 °C", None),
+            50: (300, 600, "0.1 °C", None),
+            51: (0, 100, "%", None),
+            52: (0, 100, "%", None),
+            53: (0, 100, "%", None),
         }
         if spec.address in extra:
             low, high, unit, default = extra[spec.address]
-            return replace(spec, minimum=low, maximum=high, unit=unit or spec.unit, default=default)
+            return replace(
+                spec, minimum=low, maximum=high, unit=unit or spec.unit, default=default
+            )
         return spec
     if spec.table is not Table.HOLDING_REGISTER:
         return spec
     # address: (min, max, default, unit, kind override)
     details = {
-        0:(0,2,1,None,None),1:(3,5,3,None,None),2:(1,255,1,None,None),3:(0,100,30,"%",None),4:(0,100,100,"%",None),
-        43:(0,3,3,None,None),44:(15,30,23,"°C",None),45:(40,80,60,"%RH",None),46:(400,2000,1200,"ppm",Kind.U16),47:(100,1000,400,"µg/m³",Kind.U16),48:(20,100,40,"%",None),49:(0,5,1,None,None),50:(0,30,23,"°C",None),51:(0,23,ScheduleEnd(0,30),"hours/min",Kind.SCHEDULE_END),52:(5,15,7,"°C",None),53:(0,2,2,None,None),54:(0,2,None,None,None),55:(0,2,None,None,None),56:(0,3,None,None,None),57:(0,5,None,None,None),58:(0,365,90,"days",None),59:(0,60,0,"min",None),60:(0,15,0,"min",None),
-        65:(500,10000,2000,"ppm",Kind.U16),66:(500,10000,1000,"µg/m³",Kind.U16),67:(5,12,10,"°C",None),68:(1,2,2,None,None),69:(0,100,50,"%",None),70:(1,2,2,None,None),71:(0,100,0,"%",None),72:(1,2,2,None,None),73:(0,100,50,"%",None),74:(0,2,2,None,None),75:(0,100,100,"%",None),
-        103:(0,255,2,None,None),104:(5,120,30,"sec",None),105:(0,240,0,"sec",None),106:(20,240,120,"sec",None),107:(0,20,3,"min",None),108:(0,20,1,"min",None),109:(1,10,2,"°C",None),110:(0,1,None,None,None),111:(2,300,None,"sec",Kind.U16),
-        112:(-500,500,0,"0.1 °C",Kind.S16),113:(-500,500,0,"0.1 °C",Kind.S16),114:(-500,500,0,"0.1 °C",Kind.S16),115:(-500,500,0,"0.1 °C",Kind.S16),116:(-500,500,0,"0.1 °C",Kind.S16),117:(-500,500,0,"0.1 °C",Kind.S16),118:(0,100,0,"%",None),119:(2,30,5,"min",None),120:(30,60,30,"°C",Kind.S16),121:(30,60,50,"°C",Kind.S16),122:(10,30,12,"°C",Kind.S16),123:(10,30,20,"°C",Kind.S16),124:(48,57,"1111","ASCII",None),182:(4,10,5,"°C",None),
+        0: (0, 2, 1, None, None),
+        1: (3, 5, 3, None, None),
+        2: (1, 255, 1, None, None),
+        3: (0, 100, 30, "%", None),
+        4: (0, 100, 100, "%", None),
+        43: (0, 3, 3, None, None),
+        44: (15, 30, 23, "°C", None),
+        45: (40, 80, 60, "%RH", None),
+        46: (400, 2000, 1200, "ppm", Kind.U16),
+        47: (100, 1000, 400, "µg/m³", Kind.U16),
+        48: (20, 100, 40, "%", None),
+        49: (0, 5, 1, None, None),
+        50: (0, 30, 23, "°C", None),
+        51: (0, 23, ScheduleEnd(0, 30), "hours/min", Kind.SCHEDULE_END),
+        52: (5, 15, 7, "°C", None),
+        53: (0, 2, 2, None, None),
+        54: (0, 2, None, None, None),
+        55: (0, 2, None, None, None),
+        56: (0, 3, None, None, None),
+        57: (0, 5, None, None, None),
+        58: (0, 365, 90, "days", None),
+        59: (0, 60, 0, "min", None),
+        60: (0, 15, 0, "min", None),
+        65: (500, 10000, 2000, "ppm", Kind.U16),
+        66: (500, 10000, 1000, "µg/m³", Kind.U16),
+        67: (5, 12, 10, "°C", None),
+        68: (1, 2, 2, None, None),
+        69: (0, 100, 50, "%", None),
+        70: (1, 2, 2, None, None),
+        71: (0, 100, 0, "%", None),
+        72: (1, 2, 2, None, None),
+        73: (0, 100, 50, "%", None),
+        74: (0, 2, 2, None, None),
+        75: (0, 100, 100, "%", None),
+        103: (0, 255, 2, None, None),
+        104: (5, 120, 30, "sec", None),
+        105: (0, 240, 0, "sec", None),
+        106: (20, 240, 120, "sec", None),
+        107: (0, 20, 3, "min", None),
+        108: (0, 20, 1, "min", None),
+        109: (1, 10, 2, "°C", None),
+        110: (0, 1, None, None, None),
+        111: (2, 300, None, "sec", Kind.U16),
+        112: (-500, 500, 0, "0.1 °C", Kind.S16),
+        113: (-500, 500, 0, "0.1 °C", Kind.S16),
+        114: (-500, 500, 0, "0.1 °C", Kind.S16),
+        115: (-500, 500, 0, "0.1 °C", Kind.S16),
+        116: (-500, 500, 0, "0.1 °C", Kind.S16),
+        117: (-500, 500, 0, "0.1 °C", Kind.S16),
+        118: (0, 100, 0, "%", None),
+        119: (2, 30, 5, "min", None),
+        120: (30, 60, 30, "°C", Kind.S16),
+        121: (30, 60, 50, "°C", Kind.S16),
+        122: (10, 30, 12, "°C", Kind.S16),
+        123: (10, 30, 20, "°C", Kind.S16),
+        124: (48, 57, "1111", "ASCII", None),
+        182: (4, 10, 5, "°C", None),
     }
     if 5 <= spec.address <= 22:
-        defaults=(0,0,40,40,70,70,100,100,100,100,100,100,50,50,100,100,60,40)
-        return replace(spec, minimum=0, maximum=100, default=defaults[spec.address-5], unit="%")
+        defaults = (
+            0,
+            0,
+            40,
+            40,
+            70,
+            70,
+            100,
+            100,
+            100,
+            100,
+            100,
+            100,
+            50,
+            50,
+            100,
+            100,
+            60,
+            40,
+        )
+        return replace(
+            spec, minimum=0, maximum=100, default=defaults[spec.address - 5], unit="%"
+        )
     if 23 <= spec.address <= 42:
-        return replace(spec, minimum=0, maximum=10000, unit="m³/h" if spec.address <= 36 else "Pa")
+        return replace(
+            spec, minimum=0, maximum=10000, unit="m³/h" if spec.address <= 36 else "Pa"
+        )
     if 76 <= spec.address <= 102:
-        defaults=(150,150,0,150,150,0,150,150,0,150,150,0,200,200,500,400,400,600,200,200,500,200,200,500,120,120,350)
-        return replace(spec, minimum=0, maximum=1000, default=defaults[spec.address-76])
+        defaults = (
+            150,
+            150,
+            0,
+            150,
+            150,
+            0,
+            150,
+            150,
+            0,
+            150,
+            150,
+            0,
+            200,
+            200,
+            500,
+            400,
+            400,
+            600,
+            200,
+            200,
+            500,
+            200,
+            200,
+            500,
+            120,
+            120,
+            350,
+        )
+        return replace(
+            spec, minimum=0, maximum=1000, default=defaults[spec.address - 76]
+        )
     if 126 <= spec.address <= 181:
-        period=(spec.address-126)%8
-        default = SchedulePeriod(1,23) if period % 2 == 0 else ScheduleEnd((6,9,19,23)[period//2], 0 if period < 6 else 59)
-        if period == 7: default = ScheduleEnd(23,59)
-        return replace(spec, minimum=0, maximum=30, unit="speed/°C" if period % 2 == 0 else "hours/min", default=default)
+        period = (spec.address - 126) % 8
+        default = (
+            SchedulePeriod(1, 23)
+            if period % 2 == 0
+            else ScheduleEnd((6, 9, 19, 23)[period // 2], 0 if period < 6 else 59)
+        )
+        if period == 7:
+            default = ScheduleEnd(23, 59)
+        return replace(
+            spec,
+            minimum=0,
+            maximum=30,
+            unit="speed/°C" if period % 2 == 0 else "hours/min",
+            default=default,
+        )
     if spec.address in details:
         low, high, default, unit, kind = details[spec.address]
-        return replace(spec, minimum=low, maximum=high, default=default, unit=unit or spec.unit, kind=kind or spec.kind, enum=_ENUMS.get(spec.key, spec.enum))
+        published = replace(
+            spec,
+            minimum=low,
+            maximum=high,
+            default=default,
+            unit=unit or spec.unit,
+            kind=kind or spec.kind,
+            enum=_ENUMS.get(spec.key, spec.enum),
+        )
+        if spec.address == 58:
+            published = replace(published, allowed_ranges=((0, 0), (70, 365)))
+        return published
     return replace(spec, enum=_ENUMS.get(spec.key, spec.enum))
 
 
 REGISTERS = tuple(_published_metadata(spec) for spec in _catalogue())
 
 
-def _indexes(registers: Iterable[RegisterSpec]) -> tuple[dict[str, RegisterSpec], dict[tuple[Table, int], RegisterSpec]]:
-    keys: dict[str, RegisterSpec] = {}; addresses: dict[tuple[Table,int], RegisterSpec] = {}
+def _indexes(
+    registers: Iterable[RegisterSpec],
+) -> tuple[dict[str, RegisterSpec], dict[tuple[Table, int], RegisterSpec]]:
+    keys: dict[str, RegisterSpec] = {}
+    addresses: dict[tuple[Table, int], RegisterSpec] = {}
     for spec in registers:
-        if spec.key in keys: raise ValueError(f"duplicate key {spec.key}")
+        if spec.key in keys:
+            raise ValueError(f"duplicate key {spec.key}")
         keys[spec.key] = spec
         for address in range(spec.address, spec.address + spec.word_count):
-            slot=(spec.table,address)
-            if slot in addresses: raise ValueError(f"overlap at {slot}")
-            addresses[slot]=spec
+            slot = (spec.table, address)
+            if slot in addresses:
+                raise ValueError(f"overlap at {slot}")
+            addresses[slot] = spec
     return keys, addresses
 
 

--- a/custom_components/ecovent_v2/config_flow.py
+++ b/custom_components/ecovent_v2/config_flow.py
@@ -19,6 +19,8 @@ from homeassistant.data_entry_flow import FlowResult
 
 from .const import (
     A21_DEVICE_MODELS,
+    A21_BAUD_RATES,
+    A21_STOP_BITS,
     CONF_AUTO_CLOCK_SYNC,
     CONF_BAUDRATE,
     CONF_DEVICE_MODEL,
@@ -43,13 +45,14 @@ _LOGGER = logging.getLogger(__name__)
 def _common_schema(defaults: dict[str, Any]) -> dict[Any, Any]:
     """Return fields shared by every transport."""
     return {
-        vol.Optional(CONF_NAME, default=defaults.get(CONF_NAME, "Vento Expert Fan")): str,
         vol.Optional(
-            UPDATE_INTERVAL, default=defaults.get(UPDATE_INTERVAL, 30)
-        ): int,
+            CONF_NAME, default=defaults.get(CONF_NAME, "Vento Expert Fan")
+        ): str,
+        vol.Optional(UPDATE_INTERVAL, default=defaults.get(UPDATE_INTERVAL, 30)): int,
         vol.Optional(
             # Legacy initial form default=True; reconfigure uses the saved value.
-            CONF_AUTO_CLOCK_SYNC, default=defaults.get(CONF_AUTO_CLOCK_SYNC, True)
+            CONF_AUTO_CLOCK_SYNC,
+            default=defaults.get(CONF_AUTO_CLOCK_SYNC, True),
         ): bool,
     }
 
@@ -58,9 +61,7 @@ def _bgcp_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     """Return the legacy BGCP-over-UDP form schema."""
     defaults = defaults or {}
     schema = {
-        vol.Required(
-            CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")
-        ): str,
+        vol.Required(CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")): str,
         vol.Optional(CONF_PORT, default=defaults.get(CONF_PORT, 4000)): int,
         vol.Required(CONF_PASSWORD, default=defaults.get(CONF_PASSWORD, "1111")): str,
         **_common_schema(defaults),
@@ -76,11 +77,13 @@ def _modbus_tcp_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     """Return the A21 Modbus TCP form schema."""
     defaults = defaults or {}
     schema = {
-        vol.Required(
-            CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")
-        ): str,
-        vol.Optional(CONF_PORT, default=defaults.get(CONF_PORT, 502)): int,
-        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): int,
+        vol.Required(CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")): str,
+        vol.Optional(CONF_PORT, default=defaults.get(CONF_PORT, 502)): vol.All(
+            int, vol.Range(min=1, max=65535)
+        ),
+        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): vol.All(
+            int, vol.Range(min=1, max=16)
+        ),
         vol.Optional(
             CONF_DEVICE_MODEL,
             default=defaults.get(CONF_DEVICE_MODEL, A21_DEVICE_MODELS[-1]),
@@ -94,17 +97,19 @@ def _modbus_rtu_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
     """Return the A21 Modbus RTU form schema."""
     defaults = defaults or {}
     schema = {
-        vol.Required(
-            CONF_SERIAL_PORT, default=defaults.get(CONF_SERIAL_PORT, "")
-        ): str,
-        vol.Optional(CONF_BAUDRATE, default=defaults.get(CONF_BAUDRATE, 115200)): int,
+        vol.Required(CONF_SERIAL_PORT, default=defaults.get(CONF_SERIAL_PORT, "")): str,
+        vol.Optional(
+            CONF_BAUDRATE, default=defaults.get(CONF_BAUDRATE, 115200)
+        ): vol.In(A21_BAUD_RATES),
         vol.Optional(CONF_PARITY, default=defaults.get(CONF_PARITY, "N")): vol.In(
             ("N", "E", "O")
         ),
-        vol.Optional(CONF_STOPBITS, default=defaults.get(CONF_STOPBITS, 1)): vol.In(
-            (1, 2)
+        vol.Optional(CONF_STOPBITS, default=defaults.get(CONF_STOPBITS, 2)): vol.In(
+            A21_STOP_BITS
         ),
-        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): int,
+        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): vol.All(
+            int, vol.Range(min=1, max=16)
+        ),
         vol.Optional(
             CONF_DEVICE_MODEL,
             default=defaults.get(CONF_DEVICE_MODEL, A21_DEVICE_MODELS[-1]),
@@ -152,8 +157,18 @@ async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str,
                 raise UnsupportedDevice
             raise InvalidAuth
 
+        if (
+            config[CONF_TRANSPORT] == TRANSPORT_BGCP_UDP
+            and getattr(device, "current_wifi_ip", None) is None
+        ):
+            raise InvalidAuth
+
+        title = getattr(device, "name", None) or config[CONF_NAME]
+        if config[CONF_TRANSPORT] == TRANSPORT_BGCP_UDP:
+            title = f"{title} {device_id}"
+
         return {
-            "title": getattr(device, "name", None) or config[CONF_NAME],
+            "title": title,
             "id": device_id,
         }
     except (CannotConnect, InvalidAuth, UnsupportedDevice):
@@ -288,9 +303,7 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
                     _LOGGER.exception("Unexpected exception during device validation")
                     errors["base"] = "unknown"
                 else:
-                    return self.async_update_reload_and_abort(
-                        entry, data_updates=data
-                    )
+                    return self.async_update_reload_and_abort(entry, data_updates=data)
 
         return self.async_show_form(
             step_id="reconfigure",

--- a/custom_components/ecovent_v2/config_flow.py
+++ b/custom_components/ecovent_v2/config_flow.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import logging
 from typing import Any
 
-from .ecoventv2 import Fan
 import voluptuous as vol
 
 from homeassistant import config_entries, exceptions
@@ -18,259 +17,295 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResult
 
-from .const import CONF_AUTO_CLOCK_SYNC, CONF_SILENT_MODE, DOMAIN, UPDATE_INTERVAL
+from .const import (
+    A21_DEVICE_MODELS,
+    CONF_AUTO_CLOCK_SYNC,
+    CONF_BAUDRATE,
+    CONF_DEVICE_MODEL,
+    CONF_PARITY,
+    CONF_SERIAL_PORT,
+    CONF_SILENT_MODE,
+    CONF_STOPBITS,
+    CONF_TRANSPORT,
+    CONF_UNIT_ID,
+    DOMAIN,
+    SUPPORTED_TRANSPORTS,
+    TRANSPORT_BGCP_UDP,
+    TRANSPORT_MODBUS_RTU,
+    TRANSPORT_MODBUS_TCP,
+    UPDATE_INTERVAL,
+)
+from .device_factory import create_device
 
 _LOGGER = logging.getLogger(__name__)
 
-# adjust the data schema to the data that you need
-STEP_USER_DATA_SCHEMA = vol.Schema(
-    {
-        # vol.Required(CONF_IP_ADDRESS, default="<broadcast>"): str,
-        vol.Required(CONF_IP_ADDRESS): str,
-        vol.Optional(CONF_PORT, default=4000): int,
-        # vol.Optional(CONF_DEVICE_ID, default="DEFAULT_DEVICEID"): str,   nothing useful to enter
-        vol.Required(CONF_PASSWORD, default="1111"): str,
-        vol.Optional(CONF_NAME, default="Vento Expert Fan"): str,
-        vol.Optional(UPDATE_INTERVAL, default=30): int,
-        vol.Optional(CONF_AUTO_CLOCK_SYNC, default=True): bool,
-        vol.Optional(CONF_SILENT_MODE, default=False): bool,
+
+def _common_schema(defaults: dict[str, Any]) -> dict[Any, Any]:
+    """Return fields shared by every transport."""
+    return {
+        vol.Optional(CONF_NAME, default=defaults.get(CONF_NAME, "Vento Expert Fan")): str,
+        vol.Optional(
+            UPDATE_INTERVAL, default=defaults.get(UPDATE_INTERVAL, 30)
+        ): int,
+        vol.Optional(
+            # Legacy initial form default=True; reconfigure uses the saved value.
+            CONF_AUTO_CLOCK_SYNC, default=defaults.get(CONF_AUTO_CLOCK_SYNC, True)
+        ): bool,
     }
-)
 
 
-class VentoHub:
-    """Vento Hub Class."""
+def _bgcp_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Return the legacy BGCP-over-UDP form schema."""
+    defaults = defaults or {}
+    schema = {
+        vol.Required(
+            CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")
+        ): str,
+        vol.Optional(CONF_PORT, default=defaults.get(CONF_PORT, 4000)): int,
+        vol.Required(CONF_PASSWORD, default=defaults.get(CONF_PASSWORD, "1111")): str,
+        **_common_schema(defaults),
+        # Legacy initial form default=False; reconfigure uses the saved value.
+        vol.Optional(
+            CONF_SILENT_MODE, default=defaults.get(CONF_SILENT_MODE, False)
+        ): bool,
+    }
+    return vol.Schema(schema)
 
-    def __init__(self, host: str, port: int, fan_id: str, name: str) -> None:
-        """Initialize."""
-        self.host = host
-        self.port = port
-        self.fan_id = fan_id
-        self.fan = None
-        self.name = name
 
-    async def authenticate(self, hass: HomeAssistant, password: str) -> bool:
-        """Authenticate."""
-        self.fan = Fan(self.host, password, self.fan_id, self.name, self.port)
-        await hass.async_add_executor_job(self.fan.init_device)
-        self.fan_id = self.fan.id
-        _LOGGER.info(
-            "Config Flow: Authenticated fan with name:%s ID: %s", self.name, self.fan_id
-        )
-        if self.fan_id is not None:
-            self.name = self.name + " " + self.fan_id
-        return (
-            (self.fan.id != "DEFAULT_DEVICEID")
-            and (self.fan_id is not None)
-            and (self.fan.current_wifi_ip is not None)
-        )
-        # added check for current wifi IP to avoid unvalid fan id. There is no further check elsewhere to prevent progressing with wrong fan id.
+def _modbus_tcp_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Return the A21 Modbus TCP form schema."""
+    defaults = defaults or {}
+    schema = {
+        vol.Required(
+            CONF_IP_ADDRESS, default=defaults.get(CONF_IP_ADDRESS, "")
+        ): str,
+        vol.Optional(CONF_PORT, default=defaults.get(CONF_PORT, 502)): int,
+        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): int,
+        vol.Optional(
+            CONF_DEVICE_MODEL,
+            default=defaults.get(CONF_DEVICE_MODEL, A21_DEVICE_MODELS[-1]),
+        ): vol.In(A21_DEVICE_MODELS),
+        **_common_schema(defaults),
+    }
+    return vol.Schema(schema)
+
+
+def _modbus_rtu_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
+    """Return the A21 Modbus RTU form schema."""
+    defaults = defaults or {}
+    schema = {
+        vol.Required(
+            CONF_SERIAL_PORT, default=defaults.get(CONF_SERIAL_PORT, "")
+        ): str,
+        vol.Optional(CONF_BAUDRATE, default=defaults.get(CONF_BAUDRATE, 115200)): int,
+        vol.Optional(CONF_PARITY, default=defaults.get(CONF_PARITY, "N")): vol.In(
+            ("N", "E", "O")
+        ),
+        vol.Optional(CONF_STOPBITS, default=defaults.get(CONF_STOPBITS, 1)): vol.In(
+            (1, 2)
+        ),
+        vol.Optional(CONF_UNIT_ID, default=defaults.get(CONF_UNIT_ID, 1)): int,
+        vol.Optional(
+            CONF_DEVICE_MODEL,
+            default=defaults.get(CONF_DEVICE_MODEL, A21_DEVICE_MODELS[-1]),
+        ): vol.In(A21_DEVICE_MODELS),
+        **_common_schema(defaults),
+    }
+    return vol.Schema(schema)
+
+
+# Kept for callers/tests that imported the old public schema name.
+STEP_USER_DATA_SCHEMA = _bgcp_schema()
+
+
+def _schema_for_transport(
+    transport: str, defaults: dict[str, Any] | None = None
+) -> vol.Schema:
+    """Return the transport-specific connection schema."""
+    if transport == TRANSPORT_BGCP_UDP:
+        return _bgcp_schema(defaults)
+    if transport == TRANSPORT_MODBUS_TCP:
+        return _modbus_tcp_schema(defaults)
+    if transport == TRANSPORT_MODBUS_RTU:
+        return _modbus_rtu_schema(defaults)
+    raise ValueError(f"Unsupported transport: {transport}")
 
 
 async def validate_input(hass: HomeAssistant, data: dict[str, Any]) -> dict[str, Any]:
-    """Validate the user input allows us to connect.
+    """Validate a device connection and return its stable identity."""
+    config = dict(data)
+    config.setdefault(CONF_TRANSPORT, TRANSPORT_BGCP_UDP)
+    device = create_device(config)
 
-    Data has the keys from STEP_USER_DATA_SCHEMA with values provided by the user.
-    """
+    try:
+        initialized = await hass.async_add_executor_job(device.init_device)
+        if not initialized:
+            if getattr(device, "identity_probe_failed", False):
+                raise UnsupportedDevice
+            if config[CONF_TRANSPORT] == TRANSPORT_BGCP_UDP:
+                raise InvalidAuth
+            raise CannotConnect
 
-    # If your PyPI package is not built with async, pass your methods
-    # to the executor:
-    # await hass.async_add_executor_job(
-    #     your_validate_func, data["username"], data["password"]
-    # )
+        device_id = getattr(device, "id", None)
+        if not device_id or device_id == "DEFAULT_DEVICEID":
+            if getattr(device, "identity_probe_failed", False):
+                raise UnsupportedDevice
+            raise InvalidAuth
 
-    hub = VentoHub(
-        # data[CONF_IP_ADDRESS], data[CONF_PORT], data[CONF_DEVICE_ID], data[CONF_NAME]
-        data[CONF_IP_ADDRESS],
-        data[CONF_PORT],
-        "DEFAULT_DEVICEID",
-        data[CONF_NAME],
-    )
-
-    if not await hub.authenticate(hass, data[CONF_PASSWORD]):
-        raise InvalidAuth
-
-    # If you cannot connect:
-    # throw CannotConnect
-    # If the authentication is wrong:
-    # InvalidAuth
-
-    # Return info that you want to store in the config entry.
-    return {"title": hub.name, "id": hub.fan_id}
+        return {
+            "title": getattr(device, "name", None) or config[CONF_NAME],
+            "id": device_id,
+        }
+    except (CannotConnect, InvalidAuth, UnsupportedDevice):
+        raise
+    except (ConnectionError, OSError) as err:
+        raise CannotConnect from err
+    finally:
+        close = getattr(device, "close", None)
+        if close is not None:
+            await hass.async_add_executor_job(close)
 
 
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for EcoVent_v2."""
 
-    VERSION = 1
-
-    def __init__(self):
-        """Initialite ConfigFlow."""
-        self._fan = Fan(
-            "<broadcast>", "1111", "DEFAULT_DEVICEID", "Vento Express", 4000
-        )
+    VERSION = 2
 
     async def async_step_user(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle the initial step."""
-        if user_input is None:
-            return self.async_show_form(
-                step_id="user", data_schema=STEP_USER_DATA_SCHEMA
+        """Choose a transport before collecting its connection data."""
+        # Existing automations submit the legacy BGCP fields directly to `user`.
+        if user_input is not None and CONF_TRANSPORT not in user_input:
+            return await self._async_create_transport_entry(
+                TRANSPORT_BGCP_UDP, user_input, "user"
             )
 
-        errors = {}
+        if user_input is None:
+            return self.async_show_form(
+                step_id="user",
+                data_schema=vol.Schema(
+                    {
+                        vol.Required(
+                            CONF_TRANSPORT, default=TRANSPORT_BGCP_UDP
+                        ): vol.In(SUPPORTED_TRANSPORTS)
+                    }
+                ),
+            )
 
-        try:
-            """
-            if user_input[CONF_IP_ADDRESS] == "<broadcast>":
-                ip = None
-                ips = await self.hass.async_add_executor_job(
-                    self._fan.search_devices, "0.0.0.0"
-                )
-                # ips = ["10.94.0.105", "10.94.0.106", "10.94.0.107", "10.94.0.108"]
-                unique_ids = []
-                _LOGGER.debug("Config Flow: Found IPs: %s", ips)
-                for entry in self._async_current_entries(include_ignore=True):
-                    unique_ids.append(entry.unique_id)
-                for ip in ips:
-                    self._fan.host = ip
-                    self._fan.id = user_input[CONF_DEVICE_ID]
-                    self._fan.password = user_input[CONF_PASSWORD]
-                    self._fan.name = user_input[CONF_NAME]
-                    self._fan.port = user_input[CONF_PORT]
-                    _LOGGER.debug("Config Flow: Initializing fan at IP: %s", ip)
-                    await self.hass.async_add_executor_job(self._fan.init_device)
-                    if self._fan.id not in unique_ids:
-                        user_input[CONF_IP_ADDRESS] = ip
-                        break
-                if user_input[CONF_IP_ADDRESS] == "<broadcast>":
-                    raise CannotConnect
-                    """
-            if user_input[UPDATE_INTERVAL] < 3:
-                errors[UPDATE_INTERVAL] = (
-                    "update interval must be at least 3 seconds to prevent overloading the device with requests."
-                )
-                raise exceptions.HomeAssistantError("update interval too low")
+        transport = user_input[CONF_TRANSPORT]
+        if transport == TRANSPORT_BGCP_UDP:
+            return await self.async_step_bgcp()
+        if transport == TRANSPORT_MODBUS_TCP:
+            return await self.async_step_modbus_tcp()
+        if transport == TRANSPORT_MODBUS_RTU:
+            return await self.async_step_modbus_rtu()
+        return self.async_abort(reason="unsupported_transport")
 
-            info = await validate_input(self.hass, user_input)
-            await self.async_set_unique_id(info["id"])
-            self._abort_if_unique_id_configured()
-        except CannotConnect:
-            errors["base"] = "cannot_connect"
-        except InvalidAuth:
-            errors["base"] = "invalid_auth"
-        except Exception:  # pylint: disable=broad-except
-            _LOGGER.exception("Unexpected exception")
-            errors["base"] = "unknown"
-        else:
-            return self.async_create_entry(title=info["title"], data=user_input)
+    async def async_step_bgcp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure a legacy BGCP-over-UDP device."""
+        return await self._async_create_transport_entry(
+            TRANSPORT_BGCP_UDP, user_input, "bgcp"
+        )
+
+    async def async_step_modbus_tcp(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure a VENTS A21 controller via Modbus TCP."""
+        return await self._async_create_transport_entry(
+            TRANSPORT_MODBUS_TCP, user_input, "modbus_tcp"
+        )
+
+    async def async_step_modbus_rtu(
+        self, user_input: dict[str, Any] | None = None
+    ) -> FlowResult:
+        """Configure a VENTS A21 controller via Modbus RTU."""
+        return await self._async_create_transport_entry(
+            TRANSPORT_MODBUS_RTU, user_input, "modbus_rtu"
+        )
+
+    async def _async_create_transport_entry(
+        self,
+        transport: str,
+        user_input: dict[str, Any] | None,
+        step_id: str,
+    ) -> FlowResult:
+        """Validate and create an entry for a selected transport."""
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            data = _schema_for_transport(transport)(dict(user_input))
+            data[CONF_TRANSPORT] = transport
+            if data[UPDATE_INTERVAL] < 3:
+                errors[UPDATE_INTERVAL] = "update_interval_too_low"
+            else:
+                try:
+                    info = await validate_input(self.hass, data)
+                    await self.async_set_unique_id(info["id"])
+                    self._abort_if_unique_id_configured()
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except InvalidAuth:
+                    errors["base"] = "invalid_auth"
+                except UnsupportedDevice:
+                    errors["base"] = "unsupported_device"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception during device validation")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_create_entry(title=info["title"], data=data)
 
         return self.async_show_form(
-            step_id="user", data_schema=STEP_USER_DATA_SCHEMA, errors=errors
+            step_id=step_id,
+            data_schema=_schema_for_transport(transport, user_input),
+            errors=errors,
         )
 
     async def async_step_reconfigure(
         self, user_input: dict[str, Any] | None = None
     ) -> FlowResult:
-        """Handle reconfigure step."""
+        """Reconfigure a device without changing its transport."""
+        entry = self._get_reconfigure_entry()
+        transport = entry.data.get(CONF_TRANSPORT, TRANSPORT_BGCP_UDP)
         errors: dict[str, str] = {}
 
-        # _LOGGER.info("Reconfigure called with user input: %s", user_input)
         if user_input is not None:
-            try:
-                """
-                if user_input[CONF_IP_ADDRESS] == "<broadcast>":
-                    ip = None
-                    ips = await self.hass.async_add_executor_job(
-                        self._fan.search_devices, "0.0.0.0"
-                    )
-                    # ips = ["10.94.0.105", "10.94.0.106", "10.94.0.107", "10.94.0.108"]
-                    unique_ids = []
-                    for entry in self._async_current_entries(include_ignore=True):
-                        unique_ids.append(entry.unique_id)
-                    for ip in ips:
-                        self._fan.host = ip
-                        self._fan.id = user_input[CONF_DEVICE_ID]
-                        self._fan.password = user_input[CONF_PASSWORD]
-                        self._fan.name = user_input[CONF_NAME]
-                        self._fan.port = user_input[CONF_PORT]
-                        await self.hass.async_add_executor_job(self._fan.init_device)
-                        if self._fan.id not in unique_ids:
-                            user_input[CONF_IP_ADDRESS] = ip
-                            break
-                    if user_input[CONF_IP_ADDRESS] == "<broadcast>":
-                        raise CannotConnect
-                    """
-                if user_input[UPDATE_INTERVAL] < 3:
-                    errors[UPDATE_INTERVAL] = (
-                        "update interval must be at least 3 seconds to prevent overloading the device with requests."
-                    )
-                    raise exceptions.HomeAssistantError("update interval too low")
-
-                await validate_input(self.hass, user_input)
-            except CannotConnect:
-                errors["base"] = "cannot_connect"
-            except InvalidAuth:
-                errors["base"] = "invalid_auth"
-            except Exception:  # pylint: disable=broad-except
-                _LOGGER.exception("Unexpected exception")
-                errors["base"] = "unknown"
+            data = _schema_for_transport(transport)(dict(user_input))
+            data[CONF_TRANSPORT] = transport
+            if data[UPDATE_INTERVAL] < 3:
+                errors[UPDATE_INTERVAL] = "update_interval_too_low"
             else:
-                return self.async_update_reload_and_abort(
-                    self._get_reconfigure_entry(), data_updates=user_input
-                )
-
-        ip_configured = self._get_reconfigure_entry().data.get(
-            CONF_IP_ADDRESS, "<broadcast>"
-        )
-        port_configured = self._get_reconfigure_entry().data.get(CONF_PORT, 4000)
-        # devId_configured = self._get_reconfigure_entry().data.get(
-        #    CONF_DEVICE_ID, "DEFAULT_DEVICEID"
-        # )
-        password_configured = self._get_reconfigure_entry().data.get(
-            CONF_PASSWORD, "1111"
-        )
-        name_configured = self._get_reconfigure_entry().data.get(
-            CONF_NAME, "Vento Expert Fan"
-        )
-        update_interval_configured = self._get_reconfigure_entry().data.get(
-            UPDATE_INTERVAL, 30
-        )
-        auto_clock_sync_configured = self._get_reconfigure_entry().data.get(
-            CONF_AUTO_CLOCK_SYNC, True
-        )
-        silent_mode_configured = self._get_reconfigure_entry().data.get(
-            CONF_SILENT_MODE, False
-        )
+                try:
+                    await validate_input(self.hass, data)
+                except CannotConnect:
+                    errors["base"] = "cannot_connect"
+                except InvalidAuth:
+                    errors["base"] = "invalid_auth"
+                except UnsupportedDevice:
+                    errors["base"] = "unsupported_device"
+                except Exception:  # pylint: disable=broad-except
+                    _LOGGER.exception("Unexpected exception during device validation")
+                    errors["base"] = "unknown"
+                else:
+                    return self.async_update_reload_and_abort(
+                        entry, data_updates=data
+                    )
 
         return self.async_show_form(
             step_id="reconfigure",
-            data_schema=vol.Schema(
-                {
-                    vol.Required(CONF_IP_ADDRESS, default=ip_configured): str,
-                    vol.Optional(CONF_PORT, default=port_configured): int,
-                    # vol.Optional(CONF_DEVICE_ID, default=devId_configured): str,
-                    vol.Required(CONF_PASSWORD, default=password_configured): str,
-                    vol.Optional(CONF_NAME, default=name_configured): str,
-                    vol.Optional(
-                        UPDATE_INTERVAL, default=update_interval_configured
-                    ): int,
-                    vol.Optional(
-                        CONF_AUTO_CLOCK_SYNC, default=auto_clock_sync_configured
-                    ): bool,
-                    vol.Optional(
-                        CONF_SILENT_MODE, default=silent_mode_configured
-                    ): bool,
-                }
-            ),
+            data_schema=_schema_for_transport(transport, dict(entry.data)),
             errors=errors,
         )
 
 
 class CannotConnect(exceptions.HomeAssistantError):
-    """Error to indicate we cannot connect."""
+    """Error to indicate that a device cannot be reached."""
 
 
 class InvalidAuth(exceptions.HomeAssistantError):
-    """Error to indicate there is invalid auth."""
+    """Error to indicate invalid BGCP authentication or identity."""
+
+
+class UnsupportedDevice(exceptions.HomeAssistantError):
+    """Error to indicate a non-A21 controller answered the identity probe."""

--- a/custom_components/ecovent_v2/const.py
+++ b/custom_components/ecovent_v2/const.py
@@ -4,6 +4,33 @@ DOMAIN = "ecovent_v2"
 UPDATE_INTERVAL = "update_interval"
 CONF_AUTO_CLOCK_SYNC = "auto_clock_sync"
 CONF_SILENT_MODE = "silent_mode"
+CONF_TRANSPORT = "transport"
+CONF_UNIT_ID = "unit_id"
+CONF_SERIAL_PORT = "serial_port"
+CONF_BAUDRATE = "baudrate"
+CONF_PARITY = "parity"
+CONF_STOPBITS = "stopbits"
+CONF_DEVICE_MODEL = "device_model"
+
+TRANSPORT_BGCP_UDP = "bgcp_udp"
+TRANSPORT_MODBUS_TCP = "modbus_tcp"
+TRANSPORT_MODBUS_RTU = "modbus_rtu"
+SUPPORTED_TRANSPORTS = (
+    TRANSPORT_BGCP_UDP,
+    TRANSPORT_MODBUS_TCP,
+    TRANSPORT_MODBUS_RTU,
+)
+A21_BAUD_RATES = (9600, 14400, 19200, 38400, 57600, 115200)
+A21_STOP_BITS = (1, 1.5, 2)
+
+A21_DEVICE_MODELS = (
+    "VENTS VUT 270 V5B EC A21",
+    "ECONOPRIME DF 270 Connect",
+    "ECONOPRIME Zephyr 240 S Connect",
+    "ECONOPRIME Zephyr 270 V Connect R",
+    "ECONOPRIME Zephyr 550 V PH Connect R",
+    "Generic VENTS A21 controller",
+)
 
 SERVICE_FILTER_TIMER_RESET = "filter_timer_reset"
 SERVICE_RESET_ALARMS = "reset_alarms"

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -4,7 +4,7 @@
 from datetime import datetime, timedelta
 import logging
 
-from .ecoventv2 import Fan
+from .device_factory import create_device
 from .schedule_helpers import (
     SCHEDULE_DAY_LABELS,
     SCHEDULE_DAY_OPTIONS,
@@ -14,12 +14,6 @@ from .schedule_helpers import (
 )
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import (
-    CONF_IP_ADDRESS,
-    CONF_NAME,
-    CONF_PASSWORD,
-    CONF_PORT,
-)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
@@ -36,6 +30,7 @@ except ImportError:
     def is_hassio(hass):
         """Return false when HA has no Supervisor helper available."""
         return False
+
 
 from .const import CONF_AUTO_CLOCK_SYNC, CONF_SILENT_MODE, DOMAIN
 
@@ -54,14 +49,7 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         update_seconds: int = 30,
     ) -> None:
         """Initialize global Vento data updater."""
-        self._fan = Fan(
-            config.data[CONF_IP_ADDRESS],
-            config.data[CONF_PASSWORD],
-            # config.data[CONF_DEVICE_ID],
-            "DEFAULT_DEVICEID",
-            config.data[CONF_NAME],
-            config.data[CONF_PORT],
-        )
+        self._fan = create_device(config.data, unique_id=config.unique_id)
         # self._fan.init_device()  is a blocking call cannot be done in constructur ...
         self.fan_initialized = False  # flag to indicate if the fan has been initialized
         self.updateCounter = 0

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -23,6 +23,7 @@ from homeassistant.const import (
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (
     DataUpdateCoordinator,
+    UpdateFailed,
 )
 from homeassistant.util import dt as dt_util
 
@@ -106,10 +107,17 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         if (self.updateCounter % 2 == 0) or (self.updateCounter < 4):
             # every 2nd update do a full update, otherwise a quick update to reduce load on the device
             _LOGGER.debug("EcoVentCoordinator: Starting full data update...")
-            await self.hass.async_add_executor_job(self._fan.update)
+            update_complete = await self.hass.async_add_executor_job(self._fan.update)
         else:
             _LOGGER.debug("EcoVentCoordinator: Starting quick data update...")
-            await self.hass.async_add_executor_job(self._fan.quick_update)
+            update_complete = await self.hass.async_add_executor_job(
+                self._fan.quick_update
+            )
+
+        if not update_complete:
+            raise UpdateFailed(
+                f"Incomplete protocol response from EcoVent device {self._fan.name}"
+            )
 
         if self._should_refresh_schedule_week():
             await self.hass.async_add_executor_job(self._load_schedule_week)

--- a/custom_components/ecovent_v2/device_factory.py
+++ b/custom_components/ecovent_v2/device_factory.py
@@ -1,0 +1,38 @@
+"""Create a protocol-specific ventilation device from a config entry."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.const import CONF_IP_ADDRESS, CONF_NAME, CONF_PASSWORD, CONF_PORT
+
+from .const import (
+    CONF_TRANSPORT,
+    TRANSPORT_BGCP_UDP,
+    TRANSPORT_MODBUS_RTU,
+    TRANSPORT_MODBUS_TCP,
+)
+from .ecoventv2 import Fan
+
+
+def create_device(data: Mapping[str, Any], *, unique_id: str | None = None):
+    """Return the device implementation selected by the config entry."""
+    transport = data.get(CONF_TRANSPORT, TRANSPORT_BGCP_UDP)
+    if transport == TRANSPORT_BGCP_UDP:
+        return Fan(
+            data[CONF_IP_ADDRESS],
+            data[CONF_PASSWORD],
+            "DEFAULT_DEVICEID",
+            data[CONF_NAME],
+            data.get(CONF_PORT, 4000),
+        )
+
+    if transport in {TRANSPORT_MODBUS_TCP, TRANSPORT_MODBUS_RTU}:
+        # Keep pymodbus out of the legacy BGCP import path. Home Assistant installs
+        # manifest requirements before this factory is called.
+        from .a21_modbus import A21ModbusDevice
+
+        return A21ModbusDevice.from_config(data, device_id=unique_id)
+
+    raise ValueError(f"Unsupported EcoVent transport: {transport}")

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -309,6 +309,7 @@ class Fan(
         self._unknown_params = {}
         self.socket = None
         self._bulk_read_supported = None
+        self._last_response_param_ids = None
         self.audible_write_command_count = 0
         self._profile_key = "vento"
         self._set_device_profile("vento")

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -82,7 +82,12 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         self._attr_name = self._fan.name
         self._attr_icon = "mdi:fan"
         self._attr_translation_key = "vent"
-        self._attr_extra_state_attributes = {"ipv4_address": self._fan.current_wifi_ip}
+        transport = getattr(self._fan, "transport", "bgcp_udp")
+        self._attr_extra_state_attributes = {"transport": transport}
+        if self._fan.current_wifi_ip is not None:
+            self._attr_extra_state_attributes["ipv4_address"] = (
+                self._fan.current_wifi_ip
+            )
         self._attr_supported_features = FanEntityFeature(0)
         if self._fan.fan_preset_modes:
             self._attr_supported_features |= FanEntityFeature.PRESET_MODE
@@ -100,10 +105,18 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             identifiers={(DOMAIN, self._fan.id)},
             name=self._fan.name,
             model=self._fan.unit_type,
-            model_id=f"WIFI IP: {self._fan.current_wifi_ip}, {self._fan.wifi_assigned_ip}",
+            model_id=getattr(
+                self._fan,
+                "connection_description",
+                f"WIFI IP: {self._fan.current_wifi_ip}, {self._fan.wifi_assigned_ip}",
+            ),
             sw_version=self._fan.firmware,
-            manufacturer="Blauberg",
-            configuration_url=f"http://{self._fan.current_wifi_ip}",
+            manufacturer=getattr(self._fan, "manufacturer", "Blauberg"),
+            configuration_url=getattr(
+                self._fan,
+                "configuration_url",
+                f"http://{self._fan.current_wifi_ip}",
+            ),
         )
 
     @property
@@ -300,14 +313,17 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
             )
 
         audible_writes_before = self._fan.audible_write_command_count
-        changed = self._set_parameters_if_changed(
-            targets,
-            include_extra_write_parameters=entering_manual_mode,
-        ) or changed
+        changed = (
+            self._set_parameters_if_changed(
+                targets,
+                include_extra_write_parameters=entering_manual_mode,
+            )
+            or changed
+        )
         if targets and not entering_manual_mode and not extra_targets:
-            assert (
-                self._fan.audible_write_command_count == audible_writes_before
-            ), "steady-state silent manual speed update emitted an audible write"
+            assert self._fan.audible_write_command_count == audible_writes_before, (
+                "steady-state silent manual speed update emitted an audible write"
+            )
         self.coordinator.set_silent_preset_mode(preset_mode)
         return changed
 

--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -11,6 +11,7 @@ except ImportError:
 
 
 _LOGGER = logging.getLogger(__name__)
+MAX_BULK_READ_PARAMS = 12
 
 
 class FanProtocolMixin:
@@ -231,6 +232,7 @@ class FanProtocolMixin:
         i = 0
         while not response:
             i = i + 1
+            self._last_response_param_ids = None
             self.send(data)
             response = self.receive()
             if response:
@@ -289,20 +291,52 @@ class FanProtocolMixin:
         return self._read_params(request)
 
     def _read_params(self, request):
-        if self._bulk_read_supported is not False and self.send_command(
-            self.func["read"], request, retries=3
-        ):
-            self._bulk_read_supported = True
-            return True
+        """Read parameters without trusting a valid but incomplete bulk reply.
 
-        self._bulk_read_supported = False
-        success = False
-        for i in range(0, len(request), 4):
-            success = (
-                self.send_command(self.func["read"], request[i : i + 4], retries=1)
-                or success
-            )
-        return success
+        The Smart Home protocol limits a packet to 256 bytes. Keep each request
+        bounded, then retry only parameters omitted from an otherwise valid
+        response. An explicit 0xFD unsupported-parameter marker counts as a
+        response and is not retried.
+        """
+        complete = bool(request)
+        chunk_size = MAX_BULK_READ_PARAMS * 4
+        for start in range(0, len(request), chunk_size):
+            chunk = request[start : start + chunk_size]
+            missing = [chunk[i : i + 4] for i in range(0, len(chunk), 4)]
+
+            if self._bulk_read_supported is not False:
+                self._last_response_param_ids = None
+                if self.send_command(self.func["read"], chunk, retries=3):
+                    self._bulk_read_supported = True
+                    response_ids = self._last_response_param_ids
+                    if response_ids is None:
+                        continue
+                    missing = [
+                        param for param in missing if int(param, 16) not in response_ids
+                    ]
+                    if missing:
+                        _LOGGER.debug(
+                            "Bulk read returned %d of %d requested parameters; "
+                            "retrying %d individually",
+                            len(response_ids),
+                            len(chunk) // 4,
+                            len(missing),
+                        )
+                    else:
+                        continue
+                else:
+                    self._bulk_read_supported = False
+
+            for param in missing:
+                self._last_response_param_ids = None
+                param_complete = self.send_command(
+                    self.func["read"], param, retries=1
+                )
+                response_ids = self._last_response_param_ids
+                if param_complete and response_ids is not None:
+                    param_complete = int(param, 16) in response_ids
+                complete = param_complete and complete
+        return complete
 
     def set_param(self, param, value):
         valpar = self.get_params_values(param, value)

--- a/custom_components/ecovent_v2/fan_protocol_parse.py
+++ b/custom_components/ecovent_v2/fan_protocol_parse.py
@@ -2,6 +2,7 @@
 
 class FanProtocolParseMixin:
     def parse_response(self, data):
+        self._last_response_param_ids = None
         if not self.validate_packet(data):
             return False
         pointer = 2  # discard frame marker
@@ -28,6 +29,7 @@ class FanProtocolParseMixin:
         value_counter = 1
         high_byte_value = 0
         parameter = 1
+        response_param_ids = set()
         for p in payload:
             if parameter and p == 0xFF:
                 ext_function = 0xFF
@@ -46,6 +48,7 @@ class FanProtocolParseMixin:
                     value_counter = p
                     ext_function = 2
                 elif ext_function == 0xFD:
+                    response_param_ids.add((high_byte_value << 8) | p)
                     ext_function = 0
                     response = bytearray()
                 else:
@@ -61,15 +64,18 @@ class FanProtocolParseMixin:
             if value_counter <= 0:
                 parameter = 1
                 value_counter = 1
-                high_byte_value = 0
                 ext_function = 0
                 if len(response) < 2:
                     return False
+                response_param_ids.add(int(response[:2].hex(), 16))
                 self._store_param(response)
                 response = bytearray()
-        return (
+        valid = (
             ext_function == 0 and parameter == 1 and value_counter == 1 and not response
         )
+        if valid:
+            self._last_response_param_ids = response_param_ids
+        return valid
 
     def _store_param(self, response):
         param_id = int(response[:2].hex(), 16)

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -8,5 +8,5 @@
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",
   "iot_class": "local_polling",
   "loggers": ["pyEcoventV2"],
-  "requirements": []
+  "requirements": ["pymodbus==3.13.1", "pyserial==3.5"]
 }

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.16",
+  "version": "1.2.17",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.15",
+  "version": "1.2.16",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/number.py
+++ b/custom_components/ecovent_v2/number.py
@@ -19,7 +19,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN
 from .coordinator import EcoVentCoordinator
 from .entity_naming import StableObjectIdMixin, clean_object_id_suffix
-from .number_helpers import encode_raw_number, encode_speed_percent
+from .number_helpers import encode_number_write_value, encode_speed_percent
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -480,6 +480,12 @@ class VentoNumber(StableObjectIdMixin, CoordinatorEntity, NumberEntity):
         self._value_bytes = value_bytes
         self._write_mode = write_mode
 
+        parameter_range = getattr(self._fan, "parameter_range", None)
+        if callable(parameter_range):
+            device_range = parameter_range(method)
+            if device_range is not None:
+                native_min_value, native_max_value = device_range
+
         if native_min_value is not None:
             self._attr_native_min_value = native_min_value
         if native_max_value is not None:
@@ -519,18 +525,24 @@ class VentoNumber(StableObjectIdMixin, CoordinatorEntity, NumberEntity):
             await self.coordinator.async_refresh()
             return
 
-        if self._write_mode == "speed_percent":
-            value_hex = encode_speed_percent(
+        if self._fan.supports_capability("a21_modbus"):
+            write_value = encode_number_write_value(
+                value, self._value_bytes, native_numeric=True
+            )
+        elif self._write_mode == "speed_percent":
+            write_value = encode_speed_percent(
                 value,
                 self._fan.device_profile.speed_percent_scale,
             )
         else:
-            value_hex = encode_raw_number(value, self._value_bytes)
+            write_value = encode_number_write_value(
+                value, self._value_bytes, native_numeric=False
+            )
 
         await self.hass.async_add_executor_job(
             self._fan.set_param,
             self._func,
-            value_hex,
+            write_value,
         )
         self.async_write_ha_state()
         await self.coordinator.async_refresh()

--- a/custom_components/ecovent_v2/number_helpers.py
+++ b/custom_components/ecovent_v2/number_helpers.py
@@ -13,6 +13,18 @@ def encode_raw_number(value: float, value_bytes: int = 1) -> str:
     return hex(intval).replace("0x", "").zfill(2)
 
 
+def encode_number_write_value(
+    value: float, value_bytes: int, *, native_numeric: bool
+) -> int | str:
+    """Encode a number for BGCP, or keep it numeric for a typed protocol."""
+    if native_numeric:
+        intval = int(value)
+        if intval != value:
+            raise ValueError(f"integer protocol value required, got {value!r}")
+        return intval
+    return encode_raw_number(value, value_bytes)
+
+
 def encode_speed_percent(value: float, speed_percent_scale: str) -> str:
     """Encode a Home Assistant percent value for a speed setpoint row."""
     target = max(0, min(100, int(value)))

--- a/custom_components/ecovent_v2/protocol_metadata.py
+++ b/custom_components/ecovent_v2/protocol_metadata.py
@@ -40,9 +40,26 @@ FRESHPOINT_DATASHEET_URL = (
 FRESHPOINT_USER_MANUAL_URL = (
     "https://blaubergventilatoren.net/download/freshpoint-manual-9552.pdf"
 )
-ECONOPRIME_DF270_LISTING_URL = (
-    "https://www.econology.fr/filtres-vmc-double-flux-paul/"
-    "filtres-vmc-double-flux-econoprime-df270.html"
+ECONOPRIME_DF270_PRODUCT_URL = (
+    "https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html"
+)
+ECONOPRIME_DF270_MANUAL_URL = (
+    "https://www.econology.fr/media/attachment/file_pdf/"
+    "notice_utilisation_df_270_econoprime_v5.pdf"
+)
+ECONOPRIME_DF_CONNECT_APP_MANUAL_URL = (
+    "https://www.econology.fr/media/attachment/file/n/o/"
+    "notice_installateur-application_df_connect5_v3_5.pdf"
+)
+ECONOPRIME_A22_WIFI_PANEL_URL = (
+    "https://www.econology.fr/panneau-de-commande-a22-wifi-vmc-double-flux-"
+    "df-connect-econoprime.html"
+)
+ECONOPRIME_BORA_PRODUCT_URL = (
+    "https://www.econology.fr/bora-extracteur-d-air-double-flux-econoprime.html"
+)
+ECONOPRIME_BORA_MANUAL_URL = (
+    "https://www.econology.fr/media/attachment/file_pdf/notice_utilisateur_bora.pdf"
 )
 VENTS_VUT_270_V5B_EC_A21_URL = (
     "https://ventilation-system.com/product/vut-270-v5b-ec-a21"

--- a/custom_components/ecovent_v2/protocol_metadata.py
+++ b/custom_components/ecovent_v2/protocol_metadata.py
@@ -34,6 +34,31 @@ BREEZY_ECO_MANUAL_URL = (
 FRESHPOINT_MANUAL_URL = (
     "https://blaubergventilatoren.net/download/freshpoint-manual-16999.pdf"
 )
+FRESHPOINT_DATASHEET_URL = (
+    "https://blaubergventilatoren.net/download/freshpoint-datasheet-9055.pdf"
+)
+FRESHPOINT_USER_MANUAL_URL = (
+    "https://blaubergventilatoren.net/download/freshpoint-manual-9552.pdf"
+)
+ECONOPRIME_DF270_LISTING_URL = (
+    "https://www.econology.fr/filtres-vmc-double-flux-paul/"
+    "filtres-vmc-double-flux-econoprime-df270.html"
+)
+VENTS_VUT_270_V5B_EC_A21_URL = (
+    "https://ventilation-system.com/product/vut-270-v5b-ec-a21"
+)
+VENTS_VUT_V5B_EC_DATASHEET_URL = (
+    "https://ventilation-system.com/download/vut-v5b-ec-datasheet-19690.pdf"
+)
+VENTS_VUT_V5B_EC_USER_MANUAL_URL = (
+    "https://ventilation-system.com/download/vut-v5b-ec-manual-19693.pdf"
+)
+VENTS_A21_MODBUS_MANUAL_URL = (
+    "https://ventilation-system.com/download/vut-v5b-ec-manual-19669.pdf"
+)
+VENTS_A21_CONTROL_MANUAL_URL = (
+    "https://ventilation-system.com/download/vut-v5b-ec-manual-19670.pdf"
+)
 FRESHBOX_100_WIFI_MANUAL_URL = (
     "https://blaubergventilatoren.net/download/freshbox-100-wifi-datasheet-7508.pdf"
 )

--- a/custom_components/ecovent_v2/protocol_model_catalog.py
+++ b/custom_components/ecovent_v2/protocol_model_catalog.py
@@ -3,25 +3,84 @@
 try:
     from .protocol_metadata import (
         ARC_SMART_MANUAL_URL,
+        ECONOPRIME_DF270_LISTING_URL,
         O2_SUPREME_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
         TWINFRESH_STYLE_MINI_MANUAL_URL,
+        VENTS_A21_CONTROL_MANUAL_URL,
+        VENTS_A21_MODBUS_MANUAL_URL,
         VENTO_SMART_HOME_MANUAL_URL,
+        VENTS_VUT_270_V5B_EC_A21_URL,
+        VENTS_VUT_V5B_EC_DATASHEET_URL,
+        VENTS_VUT_V5B_EC_USER_MANUAL_URL,
         DeviceModel,
         MarketingName,
     )
 except ImportError:
     from protocol_metadata import (
         ARC_SMART_MANUAL_URL,
+        ECONOPRIME_DF270_LISTING_URL,
         O2_SUPREME_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
         TWINFRESH_STYLE_MINI_MANUAL_URL,
+        VENTS_A21_CONTROL_MANUAL_URL,
+        VENTS_A21_MODBUS_MANUAL_URL,
         VENTO_SMART_HOME_MANUAL_URL,
+        VENTS_VUT_270_V5B_EC_A21_URL,
+        VENTS_VUT_V5B_EC_DATASHEET_URL,
+        VENTS_VUT_V5B_EC_USER_MANUAL_URL,
         DeviceModel,
         MarketingName,
     )
 
 DEVICE_MODELS = {
+    0x0100: DeviceModel(
+        "ECONOPRIME DF270 Connect",
+        aliases=("Econology DF270 Connect",),
+        device_type=1,
+        parser_key=0x0100,
+        manufacturer_group="Unknown (marketed as ECONOPRIME)",
+        official_names=(
+            MarketingName(
+                "ECONOPRIME",
+                "DF270",
+                "ECONOPRIME DF270",
+                "official_listing",
+                (ECONOPRIME_DF270_LISTING_URL,),
+            ),
+            MarketingName(
+                "ECONOPRIME",
+                "DF270",
+                "ECONOPRIME DF270 Connect",
+                "official_listing",
+                (ECONOPRIME_DF270_LISTING_URL,),
+            ),
+        ),
+        relabels=(
+            MarketingName(
+                "Econology",
+                "DF270",
+                "Econology DF270 Connect",
+                "community_tested",
+            ),
+        ),
+        candidates=(
+            MarketingName(
+                "VENTS",
+                "VUT V5B EC",
+                "VENTS VUT 270 V5B EC A21",
+                "candidate",
+                (
+                    VENTS_VUT_270_V5B_EC_A21_URL,
+                    VENTS_VUT_V5B_EC_DATASHEET_URL,
+                    VENTS_VUT_V5B_EC_USER_MANUAL_URL,
+                    VENTS_A21_MODBUS_MANUAL_URL,
+                    VENTS_A21_CONTROL_MANUAL_URL,
+                ),
+            ),
+        ),
+        source_documents=(ECONOPRIME_DF270_LISTING_URL,),
+    ),
     0x0300: DeviceModel(
         "Blauberg VENTO Expert / VENTS TwinFresh Expert",
         device_type=3,

--- a/custom_components/ecovent_v2/protocol_model_catalog.py
+++ b/custom_components/ecovent_v2/protocol_model_catalog.py
@@ -3,7 +3,10 @@
 try:
     from .protocol_metadata import (
         ARC_SMART_MANUAL_URL,
-        ECONOPRIME_DF270_LISTING_URL,
+        ECONOPRIME_A22_WIFI_PANEL_URL,
+        ECONOPRIME_DF_CONNECT_APP_MANUAL_URL,
+        ECONOPRIME_DF270_MANUAL_URL,
+        ECONOPRIME_DF270_PRODUCT_URL,
         O2_SUPREME_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
         TWINFRESH_STYLE_MINI_MANUAL_URL,
@@ -19,7 +22,10 @@ try:
 except ImportError:
     from protocol_metadata import (
         ARC_SMART_MANUAL_URL,
-        ECONOPRIME_DF270_LISTING_URL,
+        ECONOPRIME_A22_WIFI_PANEL_URL,
+        ECONOPRIME_DF_CONNECT_APP_MANUAL_URL,
+        ECONOPRIME_DF270_MANUAL_URL,
+        ECONOPRIME_DF270_PRODUCT_URL,
         O2_SUPREME_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
         TWINFRESH_STYLE_MINI_MANUAL_URL,
@@ -46,14 +52,22 @@ DEVICE_MODELS = {
                 "DF270",
                 "ECONOPRIME DF270",
                 "official_listing",
-                (ECONOPRIME_DF270_LISTING_URL,),
+                (
+                    ECONOPRIME_DF270_PRODUCT_URL,
+                    ECONOPRIME_DF270_MANUAL_URL,
+                ),
             ),
             MarketingName(
                 "ECONOPRIME",
                 "DF270",
                 "ECONOPRIME DF270 Connect",
                 "official_listing",
-                (ECONOPRIME_DF270_LISTING_URL,),
+                (
+                    ECONOPRIME_DF270_PRODUCT_URL,
+                    ECONOPRIME_DF270_MANUAL_URL,
+                    ECONOPRIME_DF_CONNECT_APP_MANUAL_URL,
+                    ECONOPRIME_A22_WIFI_PANEL_URL,
+                ),
             ),
         ),
         relabels=(
@@ -69,8 +83,12 @@ DEVICE_MODELS = {
                 "VENTS",
                 "VUT V5B EC",
                 "VENTS VUT 270 V5B EC A21",
-                "candidate",
+                "documentary_match",
                 (
+                    ECONOPRIME_DF270_PRODUCT_URL,
+                    ECONOPRIME_DF270_MANUAL_URL,
+                    ECONOPRIME_DF_CONNECT_APP_MANUAL_URL,
+                    ECONOPRIME_A22_WIFI_PANEL_URL,
                     VENTS_VUT_270_V5B_EC_A21_URL,
                     VENTS_VUT_V5B_EC_DATASHEET_URL,
                     VENTS_VUT_V5B_EC_USER_MANUAL_URL,
@@ -79,7 +97,12 @@ DEVICE_MODELS = {
                 ),
             ),
         ),
-        source_documents=(ECONOPRIME_DF270_LISTING_URL,),
+        source_documents=(
+            ECONOPRIME_DF270_PRODUCT_URL,
+            ECONOPRIME_DF270_MANUAL_URL,
+            ECONOPRIME_DF_CONNECT_APP_MANUAL_URL,
+            ECONOPRIME_A22_WIFI_PANEL_URL,
+        ),
     ),
     0x0300: DeviceModel(
         "Blauberg VENTO Expert / VENTS TwinFresh Expert",
@@ -217,11 +240,11 @@ DEVICE_MODELS = {
             MarketingName(
                 "Flexit", "Roomie Dual", "Flexit Roomie Dual Wifi", "community_tested"
             ),
-            MarketingName("Flexit", "Roomie Dual", "Roomie Dual WiFi V2", "candidate"),
             MarketingName("DUKA", "DUKA One", "DUKA One S6BW", "community_tested"),
             MarketingName("RL Raumklima", "RL PRO-Serie", "RL 30DVW", "community_tested"),
         ),
         candidates=(
+            MarketingName("Flexit", "Roomie Dual", "Roomie Dual WiFi V2", "candidate"),
             MarketingName("Flexit", "Aura", "Flexit Aura", "candidate"),
             MarketingName("Flexit", "Muto", "Flexit Muto", "candidate"),
             MarketingName("NIBE", "DVC 10", "NIBE DVC 10-D30W", "candidate"),

--- a/custom_components/ecovent_v2/protocol_model_catalog_extra.py
+++ b/custom_components/ecovent_v2/protocol_model_catalog_extra.py
@@ -3,6 +3,8 @@
 try:
     from .protocol_metadata import (
         BREEZY_ECO_MANUAL_URL,
+        ECONOPRIME_BORA_MANUAL_URL,
+        ECONOPRIME_BORA_PRODUCT_URL,
         FRESHBOX_100_WIFI_MANUAL_URL,
         FRESHPOINT_DATASHEET_URL,
         FRESHPOINT_MANUAL_URL,
@@ -18,6 +20,8 @@ try:
 except ImportError:
     from protocol_metadata import (
         BREEZY_ECO_MANUAL_URL,
+        ECONOPRIME_BORA_MANUAL_URL,
+        ECONOPRIME_BORA_PRODUCT_URL,
         FRESHBOX_100_WIFI_MANUAL_URL,
         FRESHPOINT_DATASHEET_URL,
         FRESHPOINT_MANUAL_URL,
@@ -30,6 +34,11 @@ except ImportError:
         DeviceModel,
         MarketingName,
     )
+
+BORA_SOURCE_DOCUMENTS = (
+    ECONOPRIME_BORA_PRODUCT_URL,
+    ECONOPRIME_BORA_MANUAL_URL,
+)
 
 EXTRA_DEVICE_MODELS = {
     0x1100: DeviceModel(
@@ -98,11 +107,33 @@ EXTRA_DEVICE_MODELS = {
                 "official_listing",
             ),
         ),
+        candidates=tuple(
+            MarketingName(
+                "ECONOPRIME",
+                "Bora 160",
+                model,
+                "documentary_match",
+                BORA_SOURCE_DOCUMENTS,
+            )
+            for model in (
+                "Bora 160",
+                "Bora 160 L440",
+                "Bora 160 L550",
+                "Bora 160 L700",
+                "Bora 160 L1000",
+                "Bora 160 Prime L440",
+                "Bora 160 Prime L550",
+                "Bora 160 Prime L700",
+                "Bora 160 Prime L1000",
+            )
+        ),
         source_documents=(
             BREEZY_ECO_MANUAL_URL,
             FRESHPOINT_DATASHEET_URL,
             FRESHPOINT_USER_MANUAL_URL,
             FRESHPOINT_MANUAL_URL,
+            ECONOPRIME_BORA_PRODUCT_URL,
+            ECONOPRIME_BORA_MANUAL_URL,
         ),
     ),
     0x1400: DeviceModel(
@@ -198,11 +229,33 @@ EXTRA_DEVICE_MODELS = {
                 "official_listing",
             ),
         ),
+        candidates=tuple(
+            MarketingName(
+                "ECONOPRIME",
+                "Bora 200",
+                model,
+                "documentary_match",
+                BORA_SOURCE_DOCUMENTS,
+            )
+            for model in (
+                "Bora 200",
+                "Bora 200 L440",
+                "Bora 200 L550",
+                "Bora 200 L700",
+                "Bora 200 L1000",
+                "Bora 200 Prime L440",
+                "Bora 200 Prime L550",
+                "Bora 200 Prime L700",
+                "Bora 200 Prime L1000",
+            )
+        ),
         source_documents=(
             BREEZY_ECO_MANUAL_URL,
             FRESHPOINT_DATASHEET_URL,
             FRESHPOINT_USER_MANUAL_URL,
             FRESHPOINT_MANUAL_URL,
+            ECONOPRIME_BORA_PRODUCT_URL,
+            ECONOPRIME_BORA_MANUAL_URL,
         ),
     ),
     0x1800: DeviceModel(

--- a/custom_components/ecovent_v2/protocol_model_catalog_extra.py
+++ b/custom_components/ecovent_v2/protocol_model_catalog_extra.py
@@ -4,7 +4,9 @@ try:
     from .protocol_metadata import (
         BREEZY_ECO_MANUAL_URL,
         FRESHBOX_100_WIFI_MANUAL_URL,
+        FRESHPOINT_DATASHEET_URL,
         FRESHPOINT_MANUAL_URL,
+        FRESHPOINT_USER_MANUAL_URL,
         MICRA_100_WIFI_MANUAL_URL,
         SMART_WIFI_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
@@ -17,7 +19,9 @@ except ImportError:
     from protocol_metadata import (
         BREEZY_ECO_MANUAL_URL,
         FRESHBOX_100_WIFI_MANUAL_URL,
+        FRESHPOINT_DATASHEET_URL,
         FRESHPOINT_MANUAL_URL,
+        FRESHPOINT_USER_MANUAL_URL,
         MICRA_100_WIFI_MANUAL_URL,
         SMART_WIFI_MANUAL_URL,
         TWINFRESH_STYLE_MANUAL_URL,
@@ -48,6 +52,36 @@ EXTRA_DEVICE_MODELS = {
             MarketingName(
                 "Blauberg Ventilatoren",
                 "Freshpoint",
+                "Freshpoint 160-E",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 160-E L055",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 160-E L07",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 160-E L1",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 160-E Pro",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
                 "Freshpoint 160-E Pro L055",
                 "official_listing",
             ),
@@ -66,6 +100,8 @@ EXTRA_DEVICE_MODELS = {
         ),
         source_documents=(
             BREEZY_ECO_MANUAL_URL,
+            FRESHPOINT_DATASHEET_URL,
+            FRESHPOINT_USER_MANUAL_URL,
             FRESHPOINT_MANUAL_URL,
         ),
     ),
@@ -116,6 +152,36 @@ EXTRA_DEVICE_MODELS = {
             MarketingName(
                 "Blauberg Ventilatoren",
                 "Freshpoint",
+                "Freshpoint 200-E",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 200-E L055",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 200-E L07",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 200-E L1",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
+                "Freshpoint 200-E Pro",
+                "official_listing",
+            ),
+            MarketingName(
+                "Blauberg Ventilatoren",
+                "Freshpoint",
                 "Freshpoint 200-E Pro L055",
                 "official_listing",
             ),
@@ -134,6 +200,8 @@ EXTRA_DEVICE_MODELS = {
         ),
         source_documents=(
             BREEZY_ECO_MANUAL_URL,
+            FRESHPOINT_DATASHEET_URL,
+            FRESHPOINT_USER_MANUAL_URL,
             FRESHPOINT_MANUAL_URL,
         ),
     ),

--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -57,7 +57,9 @@ DEVICE_PROFILES = {
         key="breezy",
         params_name="breezy_params",
         write_params_name="breezy_write_params",
-        quick_update_request="0007000B00250027004A004B0081008300840129030B0320",
+        quick_update_request=(
+            "0007000B001F00200021002200250027004A004B0081008300840129030B0320"
+        ),
         preset_modes=("off", "low", "medium", "high", "speed_4", "speed_5", "manual"),
         boost_statuses_name="statuses",
         humidity_sensor_states_name="states",

--- a/custom_components/ecovent_v2/strings.json
+++ b/custom_components/ecovent_v2/strings.json
@@ -3,6 +3,24 @@
         "step": {
             "user": {
                 "data": {
+                    "transport": "Connection type",
+                    "ip_address": "IP address",
+                    "port": "[%key:common::config_flow::data::port%]",
+                    "password": "[%key:common::config_flow::data::password%]",
+                    "name": "[%key:common::config_flow::data::name%]",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically",
+                    "silent_mode": "Use silent manual-speed mode",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "serial_port": "Serial port",
+                    "baudrate": "Baud rate",
+                    "parity": "Parity",
+                    "stopbits": "Stop bits"
+                }
+            },
+            "bgcp": {
+                "data": {
                     "ip_address": "IP address",
                     "port": "[%key:common::config_flow::data::port%]",
                     "password": "[%key:common::config_flow::data::password%]",
@@ -10,6 +28,30 @@
                     "update_interval": "Update interval",
                     "auto_clock_sync": "Sync device clock automatically",
                     "silent_mode": "Use silent manual-speed mode"
+                }
+            },
+            "modbus_tcp": {
+                "data": {
+                    "ip_address": "IP address",
+                    "port": "[%key:common::config_flow::data::port%]",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "name": "[%key:common::config_flow::data::name%]",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically"
+                }
+            },
+            "modbus_rtu": {
+                "data": {
+                    "serial_port": "Serial port",
+                    "baudrate": "Baud rate",
+                    "parity": "Parity",
+                    "stopbits": "Stop bits",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "name": "[%key:common::config_flow::data::name%]",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically"
                 }
             },
             "reconfigure": {
@@ -20,13 +62,20 @@
                     "name": "[%key:common::config_flow::data::name%]",
                     "update_interval": "Update interval",
                     "auto_clock_sync": "Sync device clock automatically",
-                    "silent_mode": "Use silent manual-speed mode"
+                    "silent_mode": "Use silent manual-speed mode",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "serial_port": "Serial port",
+                    "baudrate": "Baud rate",
+                    "parity": "Parity",
+                    "stopbits": "Stop bits"
                 }
             }
         },
         "error": {
             "cannot_connect": "[%key:common::config_flow::error::cannot_connect%]",
             "invalid_auth": "[%key:common::config_flow::error::invalid_auth%]",
+            "unsupported_device": "The controller did not identify itself as VENTS A21.",
             "unknown": "[%key:common::config_flow::error::unknown%]"
         },
         "abort": {

--- a/custom_components/ecovent_v2/translations/be.json
+++ b/custom_components/ecovent_v2/translations/be.json
@@ -22,9 +22,21 @@
                     "silent_mode": "Ціхі рэжым ручной хуткасці"
                 }
             },
-            "bgcp": {"data": {"ip_address": "IP-адрас", "password": "Пароль", "port": "Порт", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады", "silent_mode": "Ціхі рэжым ручной хуткасці"}},
-            "modbus_tcp": {"data": {"ip_address": "IP-адрас", "port": "Порт", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"}},
-            "modbus_rtu": {"data": {"serial_port": "Паслядоўны порт", "baudrate": "Хуткасць перадачы", "parity": "Цотнасць", "stopbits": "Стопавыя біты", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"}},
+            "bgcp": {
+                "data": {
+                    "ip_address": "IP-адрас", "password": "Пароль", "port": "Порт", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады", "silent_mode": "Ціхі рэжым ручной хуткасці"
+                }
+            },
+            "modbus_tcp": {
+                "data": {
+                    "ip_address": "IP-адрас", "port": "Порт", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"
+                }
+            },
+            "modbus_rtu": {
+                "data": {
+                    "serial_port": "Паслядоўны порт", "baudrate": "Хуткасць перадачы", "parity": "Цотнасць", "stopbits": "Стопавыя біты", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"
+                }
+            },
             "reconfigure": {
                 "data": {
                     "ip_address": "IP-адрас",

--- a/custom_components/ecovent_v2/translations/be.json
+++ b/custom_components/ecovent_v2/translations/be.json
@@ -6,11 +6,13 @@
         "error": {
             "cannot_connect": "Не ўдалося падключыцца.",
             "invalid_auth": "Няправільныя ўліковыя даныя.",
+            "unsupported_device": "Кантролер не пацвердзіў тып VENTS A21.",
             "unknown": "Невядомая памылка."
         },
         "step": {
             "user": {
                 "data": {
+                    "transport": "Тып падключэння",
                     "ip_address": "IP-адрас",
                     "password": "Пароль",
                     "port": "Порт",
@@ -20,6 +22,9 @@
                     "silent_mode": "Ціхі рэжым ручной хуткасці"
                 }
             },
+            "bgcp": {"data": {"ip_address": "IP-адрас", "password": "Пароль", "port": "Порт", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады", "silent_mode": "Ціхі рэжым ручной хуткасці"}},
+            "modbus_tcp": {"data": {"ip_address": "IP-адрас", "port": "Порт", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"}},
+            "modbus_rtu": {"data": {"serial_port": "Паслядоўны порт", "baudrate": "Хуткасць перадачы", "parity": "Цотнасць", "stopbits": "Стопавыя біты", "unit_id": "ID прылады Modbus", "device_model": "Мадэль прылады", "name": "Назва", "update_interval": "Інтэрвал абнаўлення", "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады"}},
             "reconfigure": {
                 "data": {
                     "ip_address": "IP-адрас",
@@ -28,7 +33,13 @@
                     "name": "Назва",
                     "update_interval": "Інтэрвал абнаўлення",
                     "auto_clock_sync": "Аўтаматычна сінхранізаваць гадзіннік прылады",
-                    "silent_mode": "Ціхі рэжым ручной хуткасці"
+                    "silent_mode": "Ціхі рэжым ручной хуткасці",
+                    "unit_id": "ID прылады Modbus",
+                    "device_model": "Мадэль прылады",
+                    "serial_port": "Паслядоўны порт",
+                    "baudrate": "Хуткасць перадачы",
+                    "parity": "Цотнасць",
+                    "stopbits": "Стопавыя біты"
                 }
             }
         }

--- a/custom_components/ecovent_v2/translations/de.json
+++ b/custom_components/ecovent_v2/translations/de.json
@@ -6,11 +6,13 @@
         "error": {
             "cannot_connect": "Es kann keine Verbindung zum Lüfter aufgebaut werden.",
             "invalid_auth": "Ungültige Zugangsdaten.",
+            "unsupported_device": "Der Controller hat sich nicht als VENTS A21 identifiziert.",
             "unknown": "Unbekannter Fehler."
         },
         "step": {
             "user": {
                 "data": {
+                    "transport": "Verbindungstyp",
                     "ip_address": "IP-Adresse",
                     "password": "Passwort",
                     "port": "Port",
@@ -20,6 +22,9 @@
                     "silent_mode": "Leiser manueller Geschwindigkeitsmodus"
                 }
             },
+            "bgcp": {"data": {"ip_address": "IP-Adresse", "password": "Passwort", "port": "Port", "name": "Name", "update_interval": "Aktualisierungsintervall", "auto_clock_sync": "Geräteuhr automatisch synchronisieren", "silent_mode": "Leiser manueller Geschwindigkeitsmodus"}},
+            "modbus_tcp": {"data": {"ip_address": "IP-Adresse", "port": "Port", "unit_id": "Modbus-Geräte-ID", "device_model": "Gerätemodell", "name": "Name", "update_interval": "Aktualisierungsintervall", "auto_clock_sync": "Geräteuhr automatisch synchronisieren"}},
+            "modbus_rtu": {"data": {"serial_port": "Serieller Anschluss", "baudrate": "Baudrate", "parity": "Parität", "stopbits": "Stoppbits", "unit_id": "Modbus-Geräte-ID", "device_model": "Gerätemodell", "name": "Name", "update_interval": "Aktualisierungsintervall", "auto_clock_sync": "Geräteuhr automatisch synchronisieren"}},
             "reconfigure": {
                 "data": {
                     "ip_address": "IP-Adresse",
@@ -28,7 +33,13 @@
                     "name": "Name",
                     "update_interval": "Aktualisierungsintervall",
                     "auto_clock_sync": "Geräteuhr automatisch synchronisieren",
-                    "silent_mode": "Leiser manueller Geschwindigkeitsmodus"
+                    "silent_mode": "Leiser manueller Geschwindigkeitsmodus",
+                    "unit_id": "Modbus-Geräte-ID",
+                    "device_model": "Gerätemodell",
+                    "serial_port": "Serieller Anschluss",
+                    "baudrate": "Baudrate",
+                    "parity": "Parität",
+                    "stopbits": "Stoppbits"
                 }
             }
         }

--- a/custom_components/ecovent_v2/translations/en.json
+++ b/custom_components/ecovent_v2/translations/en.json
@@ -6,10 +6,23 @@
         "error": {
             "cannot_connect": "Failed to connect",
             "invalid_auth": "Invalid authentication",
+            "unsupported_device": "The controller did not identify itself as VENTS A21.",
             "unknown": "Unexpected error"
         },
         "step": {
             "user": {
+                "data": {
+                    "transport": "Connection type",
+                    "ip_address": "IP address",
+                    "name": "Name",
+                    "password": "Password",
+                    "port": "Port",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically",
+                    "silent_mode": "Use silent manual-speed mode"
+                }
+            },
+            "bgcp": {
                 "data": {
                     "ip_address": "IP address",
                     "name": "Name",
@@ -20,6 +33,30 @@
                     "silent_mode": "Use silent manual-speed mode"
                 }
             },
+            "modbus_tcp": {
+                "data": {
+                    "ip_address": "IP address",
+                    "port": "Port",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "name": "Name",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically"
+                }
+            },
+            "modbus_rtu": {
+                "data": {
+                    "serial_port": "Serial port",
+                    "baudrate": "Baud rate",
+                    "parity": "Parity",
+                    "stopbits": "Stop bits",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "name": "Name",
+                    "update_interval": "Update interval",
+                    "auto_clock_sync": "Sync device clock automatically"
+                }
+            },
             "reconfigure": {
                 "data": {
                     "ip_address": "IP address",
@@ -28,7 +65,13 @@
                     "port": "Port",
                     "update_interval": "Update interval",
                     "auto_clock_sync": "Sync device clock automatically",
-                    "silent_mode": "Use silent manual-speed mode"
+                    "silent_mode": "Use silent manual-speed mode",
+                    "unit_id": "Modbus unit ID",
+                    "device_model": "Device model",
+                    "serial_port": "Serial port",
+                    "baudrate": "Baud rate",
+                    "parity": "Parity",
+                    "stopbits": "Stop bits"
                 }
             }
         }

--- a/custom_components/ecovent_v2/translations/pl.json
+++ b/custom_components/ecovent_v2/translations/pl.json
@@ -6,11 +6,13 @@
         "error": {
             "cannot_connect": "Nie udało się połączyć.",
             "invalid_auth": "Nieprawidłowe dane logowania.",
+            "unsupported_device": "Kontroler nie zidentyfikował się jako VENTS A21.",
             "unknown": "Nieoczekiwany błąd."
         },
         "step": {
             "user": {
                 "data": {
+                    "transport": "Typ połączenia",
                     "ip_address": "Host",
                     "password": "Hasło",
                     "port": "Port",
@@ -20,6 +22,9 @@
                     "silent_mode": "Cichy tryb ręcznej prędkości"
                 }
             },
+            "bgcp": {"data": {"ip_address": "Host", "password": "Hasło", "port": "Port", "name": "Nazwa", "update_interval": "Interwał aktualizacji", "auto_clock_sync": "Automatycznie synchronizuj zegar urządzenia", "silent_mode": "Cichy tryb ręcznej prędkości"}},
+            "modbus_tcp": {"data": {"ip_address": "Host", "port": "Port", "unit_id": "ID urządzenia Modbus", "device_model": "Model urządzenia", "name": "Nazwa", "update_interval": "Interwał aktualizacji", "auto_clock_sync": "Automatycznie synchronizuj zegar urządzenia"}},
+            "modbus_rtu": {"data": {"serial_port": "Port szeregowy", "baudrate": "Szybkość transmisji", "parity": "Parzystość", "stopbits": "Bity stopu", "unit_id": "ID urządzenia Modbus", "device_model": "Model urządzenia", "name": "Nazwa", "update_interval": "Interwał aktualizacji", "auto_clock_sync": "Automatycznie synchronizuj zegar urządzenia"}},
             "reconfigure": {
                 "data": {
                     "ip_address": "Host",
@@ -28,7 +33,13 @@
                     "name": "Nazwa",
                     "update_interval": "Interwał aktualizacji",
                     "auto_clock_sync": "Automatycznie synchronizuj zegar urządzenia",
-                    "silent_mode": "Cichy tryb ręcznej prędkości"
+                    "silent_mode": "Cichy tryb ręcznej prędkości",
+                    "unit_id": "ID urządzenia Modbus",
+                    "device_model": "Model urządzenia",
+                    "serial_port": "Port szeregowy",
+                    "baudrate": "Szybkość transmisji",
+                    "parity": "Parzystość",
+                    "stopbits": "Bity stopu"
                 }
             }
         }

--- a/custom_components/ecovent_v2/translations/ru.json
+++ b/custom_components/ecovent_v2/translations/ru.json
@@ -6,10 +6,23 @@
         "error": {
             "cannot_connect": "Не удалось подключиться.",
             "invalid_auth": "Неверные учётные данные.",
+            "unsupported_device": "Контроллер не подтвердил тип VENTS A21.",
             "unknown": "Неизвестная ошибка."
         },
         "step": {
             "user": {
+                "data": {
+                    "transport": "Тип подключения",
+                    "ip_address": "IP-адрес",
+                    "password": "Пароль",
+                    "port": "Порт",
+                    "name": "Название",
+                    "update_interval": "Интервал обновления",
+                    "auto_clock_sync": "Автоматически синхронизировать часы устройства",
+                    "silent_mode": "Тихий режим ручной скорости"
+                }
+            },
+            "bgcp": {
                 "data": {
                     "ip_address": "IP-адрес",
                     "password": "Пароль",
@@ -20,6 +33,30 @@
                     "silent_mode": "Тихий режим ручной скорости"
                 }
             },
+            "modbus_tcp": {
+                "data": {
+                    "ip_address": "IP-адрес",
+                    "port": "Порт",
+                    "unit_id": "ID устройства Modbus",
+                    "device_model": "Модель устройства",
+                    "name": "Название",
+                    "update_interval": "Интервал обновления",
+                    "auto_clock_sync": "Автоматически синхронизировать часы устройства"
+                }
+            },
+            "modbus_rtu": {
+                "data": {
+                    "serial_port": "Последовательный порт",
+                    "baudrate": "Скорость передачи",
+                    "parity": "Чётность",
+                    "stopbits": "Стоповые биты",
+                    "unit_id": "ID устройства Modbus",
+                    "device_model": "Модель устройства",
+                    "name": "Название",
+                    "update_interval": "Интервал обновления",
+                    "auto_clock_sync": "Автоматически синхронизировать часы устройства"
+                }
+            },
             "reconfigure": {
                 "data": {
                     "ip_address": "IP-адрес",
@@ -28,7 +65,13 @@
                     "name": "Название",
                     "update_interval": "Интервал обновления",
                     "auto_clock_sync": "Автоматически синхронизировать часы устройства",
-                    "silent_mode": "Тихий режим ручной скорости"
+                    "silent_mode": "Тихий режим ручной скорости",
+                    "unit_id": "ID устройства Modbus",
+                    "device_model": "Модель устройства",
+                    "serial_port": "Последовательный порт",
+                    "baudrate": "Скорость передачи",
+                    "parity": "Чётность",
+                    "stopbits": "Стоповые биты"
                 }
             }
         }

--- a/custom_components/ecovent_v2/translations/sl.json
+++ b/custom_components/ecovent_v2/translations/sl.json
@@ -6,11 +6,13 @@
         "error": {
             "cannot_connect": "Povezava ni uspela.",
             "invalid_auth": "Neveljavni podatki za prijavo.",
+            "unsupported_device": "Krmilnik se ni identificiral kot VENTS A21.",
             "unknown": "Nepričakovana napaka."
         },
         "step": {
             "user": {
                 "data": {
+                    "transport": "Vrsta povezave",
                     "ip_address": "IP",
                     "password": "Geslo",
                     "port": "Vrata",
@@ -20,6 +22,9 @@
                     "silent_mode": "Tihi način ročne hitrosti"
                 }
             },
+            "bgcp": {"data": {"ip_address": "IP", "password": "Geslo", "port": "Vrata", "name": "Naziv", "update_interval": "Interval posodabljanja", "auto_clock_sync": "Samodejno sinhroniziraj uro naprave", "silent_mode": "Tihi način ročne hitrosti"}},
+            "modbus_tcp": {"data": {"ip_address": "IP", "port": "Vrata", "unit_id": "ID naprave Modbus", "device_model": "Model naprave", "name": "Naziv", "update_interval": "Interval posodabljanja", "auto_clock_sync": "Samodejno sinhroniziraj uro naprave"}},
+            "modbus_rtu": {"data": {"serial_port": "Serijska vrata", "baudrate": "Hitrost prenosa", "parity": "Pariteta", "stopbits": "Stop biti", "unit_id": "ID naprave Modbus", "device_model": "Model naprave", "name": "Naziv", "update_interval": "Interval posodabljanja", "auto_clock_sync": "Samodejno sinhroniziraj uro naprave"}},
             "reconfigure": {
                 "data": {
                     "ip_address": "IP",
@@ -28,7 +33,13 @@
                     "name": "Naziv",
                     "update_interval": "Interval posodabljanja",
                     "auto_clock_sync": "Samodejno sinhroniziraj uro naprave",
-                    "silent_mode": "Tihi način ročne hitrosti"
+                    "silent_mode": "Tihi način ročne hitrosti",
+                    "unit_id": "ID naprave Modbus",
+                    "device_model": "Model naprave",
+                    "serial_port": "Serijska vrata",
+                    "baudrate": "Hitrost prenosa",
+                    "parity": "Pariteta",
+                    "stopbits": "Stop biti"
                 }
             }
         }

--- a/protocol.md
+++ b/protocol.md
@@ -27,8 +27,14 @@ Source PDFs:
 - [Arc Smart Smart House CO2 connection guide](https://ventilation-system.com/download/arc-smart-manual-21863.pdf)
 - [O2 Supreme Smart Home connection guide B255-1EN-01](https://blaubergventilatoren.net/download/o2-supreme-manual-15274.pdf)
 
-Candidate OEM research sources (these document the VENTS product, not an
-ECONOPRIME-to-VENTS relationship):
+Cross-brand and candidate OEM research sources:
+
+- [ECONOPRIME DF 270 Connect product page](https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html)
+- [ECONOPRIME DF 270 / DF 270 Connect manual](https://www.econology.fr/media/attachment/file_pdf/notice_utilisation_df_270_econoprime_v5.pdf)
+- [ECONOPRIME DF Connect / Blauberg Home application manual](https://www.econology.fr/media/attachment/file/n/o/notice_installateur-application_df_connect5_v3_5.pdf)
+- [ECONOPRIME A22 WiFi panel page](https://www.econology.fr/panneau-de-commande-a22-wifi-vmc-double-flux-df-connect-econoprime.html)
+- [ECONOPRIME Bora family page](https://www.econology.fr/bora-extracteur-d-air-double-flux-econoprime.html)
+- [ECONOPRIME Bora 160/200 manual](https://www.econology.fr/media/attachment/file_pdf/notice_utilisateur_bora.pdf)
 
 - [VENTS VUT 270 V5B EC A21 product page](https://ventilation-system.com/product/vut-270-v5b-ec-a21)
 - [VENTS VUT/VUE V5B EC datasheet 19690](https://ventilation-system.com/download/vut-v5b-ec-datasheet-19690.pdf)
@@ -55,7 +61,9 @@ The code keeps these layers separate:
 - `device_type`: native BGCP value from parameter `0x00B9`.
 - `parser_key`: byte-swapped integer used by this parser.
 - `evidence`: `official_group`, `official_listing`, `protocol_pdf`,
-  `community_tested`, `observed`, `app_by_blauberg`, or `candidate`.
+  `community_tested`, `observed`, `app_by_blauberg`, `documentary_match`, or
+  `candidate`. A `documentary_match` remains a candidate until its BGCP unit
+  type is captured or documented.
 
 Only concise primary names and explicit compatibility aliases are used for the
 parser-facing Home Assistant unit-type string. The structured `official_names`,
@@ -65,7 +73,7 @@ candidates are not shown as confirmed model names until a device reports
 
 | Unit type | Primary name | Official same-group names | External relabel/candidate notes |
 | -- | -- | -- | -- |
-| `0x0100` | ECONOPRIME DF270 Connect | ECONOPRIME DF270; ECONOPRIME DF270 Connect | A reported unit identifies as `256` and works with the `vento` profile. Econology is the French seller spelling seen in the report. VENTS VUT 270 V5B EC A21 remains an unconfirmed candidate, not a confirmed relabel. |
+| `0x0100` | ECONOPRIME DF270 Connect | ECONOPRIME DF270; ECONOPRIME DF270 Connect | A reported unit identifies as `256` and works with the `vento` profile. Detailed first-party product/manual/A22 evidence makes VENTS VUT 270 V5B EC A21 a `documentary_match`, but A21 publishes Modbus rather than a BGCP `0x00B9` bridge. |
 | `0x0200` | Blauberg Freshbox 100 WiFi / VENTS Micra 100 WiFi | Freshbox 100 WiFi/ERV/E/E2 variants; Vents Micra 100 WiFi/ERV/E/E2 variants | Dedicated `freshbox` AHU profile |
 | `0x0300` | Blauberg VENTO Expert / VENTS TwinFresh Expert | VENTO Expert A50/A85/A100 V.2; VENTO Expert A50 V.3; TwinFresh Expert RW1-50/85/100 V.2; TwinFresh Expert RW1-50 V.3 | SIKU RV 50, DUKA One S6W, RL 50RVW, and Winzel RW1-50 are tracked as relabels; Flexit Roomie One, DUKA One Pro 50, and NIBE DVC 10-50W remain candidates |
 | `0x0400` | Blauberg VENTO Expert Duo / VENTS TwinFresh Expert Duo | VENTO Expert DUO A30 V.2; TwinFresh Expert Duo RW1-30 V.2 | SIKU RV 30 DW, Flexit Roomie Dual, DUKA One S6BW, and RL 30DVW are tracked as relabel/candidate evidence |
@@ -73,9 +81,9 @@ candidates are not shown as confirmed model names until a device reports
 | `0x0600` | Blauberg Smart Wi-Fi / VENTS iFan Wi-Fi | Smart Wi-Fi; Smart IR Wi-Fi; Vents iFan Wi-Fi; Vents iFan Move Wi-Fi | Dedicated `extract_fan` profile |
 | `0x0D00` | VENTS Arc Smart / Blauberg O2 Supreme | Vents Arc Smart white/black; Blauberg O2 Supreme white/black | Dedicated `arc` profile |
 | `0x0E00` | VENTS TwinFresh Style Wi-Fi | TwinFresh Style Wi-Fi/Frost/mini | OXXIFY.smart 50 is kept as observed relabel evidence on this unit type; Oxxify.smart 30 and 50k remain candidates |
-| `0x1100` | VENTS Breezy 160 / Blauberg Freshpoint 160 | Breezy 160/E/Smart; Freshpoint 160 and package variants | Dedicated `breezy` profile |
+| `0x1100` | VENTS Breezy 160 / Blauberg Freshpoint 160 | Breezy 160/E/Smart; Freshpoint 160 and package variants | Dedicated `breezy` profile. ECONOPRIME Bora 160/Prime wall-length variants are documentary candidates, not parser aliases. |
 | `0x1400` | VENTS Breezy Eco 160 / Blauberg Freshpoint Eco 160 | Breezy Eco 160/E; Freshpoint Eco 160 and package variants | Dedicated `breezy` profile |
-| `0x1600` | VENTS Breezy 200 / Blauberg Freshpoint 200 | Breezy 200-E/Smart; Freshpoint 200 and package variants | Dedicated `breezy` profile |
+| `0x1600` | VENTS Breezy 200 / Blauberg Freshpoint 200 | Breezy 200-E/Smart; Freshpoint 200 and package variants | Dedicated `breezy` profile. ECONOPRIME Bora 200/Prime wall-length variants are documentary candidates, not parser aliases. |
 | `0x1800` | VENTS Breezy Eco 200 / Blauberg Freshpoint Eco 200 | Breezy Eco 200; Freshpoint Eco 200 | Dedicated `breezy` profile |
 | `0x1A00` | VENTO inHome old / TwinFresh Atmo old | VENTO inHome; TwinFresh Atmo | Same `vento` profile |
 | `0x1B00` | VENTO inHome 100 / TwinFresh Atmo 100 | VENTO inHome mini/W; TwinFresh Atmo mini/Wi-Fi | Same `vento` profile |
@@ -85,27 +93,58 @@ No reviewed manufacturer PDF documents device type `7` / parser key `0x0700`.
 Rows such as `0x0007` in the source tables are timer/status parameters, not
 unit-type values.
 
-### ECONOPRIME DF270 research (`0x0100`)
+### ECONOPRIME / Econology catalogue research
 
-The [French ECONOPRIME compatibility listing](https://www.econology.fr/filtres-vmc-double-flux-paul/filtres-vmc-double-flux-econoprime-df270.html)
-names both `ECONOPRIME DF270` and `ECONOPRIME DF270 Connect`. It is a filter
-listing rather than a controller specification: it publishes 335 x 295 x 24 mm
-filter dimensions and F7/ISO ePM2.5 70% plus G4/ISO coarse 60% filter classes,
-but no BGCP register table or OEM declaration.
+The live Econology sitemap, dated 2026-07-12 when reviewed, contains 240 URLs
+with `ECONOPRIME` in the product path. Most are filters, ducts, plenums,
+controllers, or other accessories. The public README indexes the distinct
+parent ventilation-unit names while keeping their protocol status separate.
 
-Issue #64 supplies the protocol evidence used by the integration: the live unit
-reported parameter `0x00B9` as integer `256` (`0x0100` in the parser), and the
-existing `vento` profile successfully controlled fixed presets and manual speed
-with matching RPM feedback. That is sufficient to name and map `0x0100`; it is
-not sufficient to identify the factory.
+Issue #64 remains the only BGCP proof for the DF series: the reported
+`ECONOPRIME DF270 Connect` returned parameter `0x00B9` as integer `256`
+(`0x0100` in this parser), and the existing `vento` profile controlled fixed
+presets and manual speed with matching RPM feedback. That observation is enough
+to map `0x0100`; it does not automatically map other ECONOPRIME devices.
 
-The reported VENTS candidate has a current official product page and four
-current downloads: a VUT/VUE V5B EC datasheet, product user manual, A21 Modbus
-table, and A21 wireless-control manual. The product page lists 300 m³/h maximum
-airflow, G4 supply/extract filters (optional F8 supply), and Modbus BMS control.
-Those are useful comparison specifications, but they do not document BGCP unit
-type `0x0100` or name ECONOPRIME. The catalogue therefore keeps `VENTS VUT 270
-V5B EC A21` in `candidates`, outside the confirmed parser-facing name.
+The direct [DF 270 Connect product page](https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html)
+and manual materially strengthen the physical OEM research. A cross-document
+comparison of ECONOPRIME DF27021 and VENTS VUT 270 V5B EC A21 found alignment
+on the 300 m³/h class, power/current/noise, EPP cabinet and duct dimensions,
+filter arrangement, heat exchanger, A21-style wiring, and optional A22 WiFi
+controller. The ECONOPRIME [A22 panel page](https://www.econology.fr/panneau-de-commande-a22-wifi-vmc-double-flux-df-connect-econoprime.html)
+also resembles the official VENTS A22 ecosystem. This makes the VENTS model a
+targeted `documentary_match`; neither manufacturer explicitly states the
+cross-brand relationship or documents a BGCP unit type for it.
+
+It is not a manufacturer-backed BGCP bridge. The official VENTS A21 documents
+publish Modbus RTU/TCP (Wi-Fi TCP port 502), and their controller device type
+`1 = A21` is not BGCP parameter `0x00B9`. The catalogue therefore keeps `VENTS
+VUT 270 V5B EC A21` under `candidates`; the reported `0x0100`/`vento` behavior
+remains a separate live observation.
+
+Two additional groups are worth targeted device captures:
+
+* `DF 180 Flat Connect` (`DFF18021`) and `DF 350 Connect` (`DF35021`) link the
+  same first-party DF Connect application guide, which explicitly names the
+  Blauberg Home app. No reviewed source gives either model a BGCP unit type.
+* A cross-document comparison of the ECONOPRIME [Bora manual](https://www.econology.fr/media/attachment/file_pdf/notice_utilisateur_bora.pdf)
+  and Blauberg Freshpoint manuals found the same 160/200 duct sizes,
+  440/550/700/1000 mm wall variants, performance tables, Pro/Prime VOC/CO2
+  sensor package, Wi-Fi provisioning (`FAN:` plus a 16-character ID, default
+  `11111111`), and application behavior. This suggests a potential
+  protocol-family lead; neither manufacturer identifies Bora as
+  Freshpoint/Breezy or documents Bora's `0x00B9`. Bora 160 and Bora 200 variants
+  are therefore candidates near `0x1100` and `0x1600`, respectively, and stay
+  outside the parser-facing display name.
+
+Other current ECONOPRIME product families are indexed for search but excluded
+from runtime mapping on current evidence:
+
+| Family | Reviewed names | Current protocol evidence |
+| -- | -- | -- |
+| A14 / A21 / Modbus | Zephyr 240 S/A14, Zephyr 240 S Connect/A21, Zephyr 270 V R/Connect R, Zephyr 550 V PH Connect R | A14/A21 controller variants or explicit Modbus RTU/TCP/IP; no BGCP unit type |
+| PremAIR / GatePass | URC 250, URHF 150/200, URHFCF 150/200, URH 350 | PremAIR application and GatePass bridge; no BGCP evidence |
+| Local/IR only in reviewed manuals | Zephyr 100 S, Airion 100/150 | no compatible local-network protocol documented |
 
 ### TwinFresh Style Wi-Fi / TwinFresh Atmo notes
 

--- a/protocol.md
+++ b/protocol.md
@@ -20,16 +20,29 @@ Source PDFs:
 - [TwinFresh Style Wi-Fi mini manual 19765](https://ventilation-system.com/download/twinfresh-style-wi-fi-mini-manual-19765.pdf)
 - [Breezy Eco manual 21433](https://ventilation-system.com/download/breezy-eco-manual-21433.pdf)
 - [Freshpoint manual 16999](https://blaubergventilatoren.net/download/freshpoint-manual-16999.pdf)
+- [Freshpoint 160/200-E (Pro) datasheet 9055](https://blaubergventilatoren.net/download/freshpoint-datasheet-9055.pdf)
+- [Freshpoint 160/200-E (Pro) user manual 9552](https://blaubergventilatoren.net/download/freshpoint-manual-9552.pdf)
 - [Freshbox 100 WiFi connection guide B73-9-1EN-01](https://blaubergventilatoren.net/download/freshbox-100-wifi-datasheet-7508.pdf)
 - [Micra 100 WiFi Smart Home connection guide V73-9-1EN-01](https://ventilation-system.com/download/micra-100-wifi-manual-19886.pdf)
 - [Arc Smart Smart House CO2 connection guide](https://ventilation-system.com/download/arc-smart-manual-21863.pdf)
 - [O2 Supreme Smart Home connection guide B255-1EN-01](https://blaubergventilatoren.net/download/o2-supreme-manual-15274.pdf)
 
+Candidate OEM research sources (these document the VENTS product, not an
+ECONOPRIME-to-VENTS relationship):
+
+- [VENTS VUT 270 V5B EC A21 product page](https://ventilation-system.com/product/vut-270-v5b-ec-a21)
+- [VENTS VUT/VUE V5B EC datasheet 19690](https://ventilation-system.com/download/vut-v5b-ec-datasheet-19690.pdf)
+- [VENTS VUT/VUE V5(B) EC user manual V170-1EN-09](https://ventilation-system.com/download/vut-v5b-ec-manual-19693.pdf)
+- [A21 Modbus table V55-8-1EN-02](https://ventilation-system.com/download/vut-v5b-ec-manual-19669.pdf)
+- [A21 wireless control system manual V55-8EN-05](https://ventilation-system.com/download/vut-v5b-ec-manual-19670.pdf)
+
 ### Model lineage names
 
-These manuals describe one Blauberg Group / VENTS platform across sibling
+The confirmed Blauberg and VENTS manuals describe one platform across sibling
 brands, official family names, external relabels, and candidate OEM names.
 VENTS is treated as an official sibling brand, not as a Blauberg relabel.
+ECONOPRIME is tracked separately because its unit type and working VENTO profile
+are community-tested, while its physical OEM remains unconfirmed.
 
 The code keeps these layers separate:
 
@@ -52,6 +65,7 @@ candidates are not shown as confirmed model names until a device reports
 
 | Unit type | Primary name | Official same-group names | External relabel/candidate notes |
 | -- | -- | -- | -- |
+| `0x0100` | ECONOPRIME DF270 Connect | ECONOPRIME DF270; ECONOPRIME DF270 Connect | A reported unit identifies as `256` and works with the `vento` profile. Econology is the French seller spelling seen in the report. VENTS VUT 270 V5B EC A21 remains an unconfirmed candidate, not a confirmed relabel. |
 | `0x0200` | Blauberg Freshbox 100 WiFi / VENTS Micra 100 WiFi | Freshbox 100 WiFi/ERV/E/E2 variants; Vents Micra 100 WiFi/ERV/E/E2 variants | Dedicated `freshbox` AHU profile |
 | `0x0300` | Blauberg VENTO Expert / VENTS TwinFresh Expert | VENTO Expert A50/A85/A100 V.2; VENTO Expert A50 V.3; TwinFresh Expert RW1-50/85/100 V.2; TwinFresh Expert RW1-50 V.3 | SIKU RV 50, DUKA One S6W, RL 50RVW, and Winzel RW1-50 are tracked as relabels; Flexit Roomie One, DUKA One Pro 50, and NIBE DVC 10-50W remain candidates |
 | `0x0400` | Blauberg VENTO Expert Duo / VENTS TwinFresh Expert Duo | VENTO Expert DUO A30 V.2; TwinFresh Expert Duo RW1-30 V.2 | SIKU RV 30 DW, Flexit Roomie Dual, DUKA One S6BW, and RL 30DVW are tracked as relabel/candidate evidence |
@@ -70,6 +84,28 @@ candidates are not shown as confirmed model names until a device reports
 No reviewed manufacturer PDF documents device type `7` / parser key `0x0700`.
 Rows such as `0x0007` in the source tables are timer/status parameters, not
 unit-type values.
+
+### ECONOPRIME DF270 research (`0x0100`)
+
+The [French ECONOPRIME compatibility listing](https://www.econology.fr/filtres-vmc-double-flux-paul/filtres-vmc-double-flux-econoprime-df270.html)
+names both `ECONOPRIME DF270` and `ECONOPRIME DF270 Connect`. It is a filter
+listing rather than a controller specification: it publishes 335 x 295 x 24 mm
+filter dimensions and F7/ISO ePM2.5 70% plus G4/ISO coarse 60% filter classes,
+but no BGCP register table or OEM declaration.
+
+Issue #64 supplies the protocol evidence used by the integration: the live unit
+reported parameter `0x00B9` as integer `256` (`0x0100` in the parser), and the
+existing `vento` profile successfully controlled fixed presets and manual speed
+with matching RPM feedback. That is sufficient to name and map `0x0100`; it is
+not sufficient to identify the factory.
+
+The reported VENTS candidate has a current official product page and four
+current downloads: a VUT/VUE V5B EC datasheet, product user manual, A21 Modbus
+table, and A21 wireless-control manual. The product page lists 300 m³/h maximum
+airflow, G4 supply/extract filters (optional F8 supply), and Modbus BMS control.
+Those are useful comparison specifications, but they do not document BGCP unit
+type `0x0100` or name ECONOPRIME. The catalogue therefore keeps `VENTS VUT 270
+V5B EC A21` in `candidates`, outside the confirmed parser-facing name.
 
 ### TwinFresh Style Wi-Fi / TwinFresh Atmo notes
 
@@ -127,6 +163,23 @@ names differ. They diverge from the base `vento` profile enough to use a
 dedicated `breezy` profile instead of enabling every row as a Vento feature:
 Breezy/Freshpoint adds CO2/VOC/screen/heater rows, while Vento has several
 sensor rows that these manuals do not document.
+
+The separate Freshpoint product datasheet and user manual cover both 160 and
+200 sizes, standard and Pro sensor packages, and L055/L07/L1 wall-length
+variants. Both standard and Pro units have relative-humidity and four built-in
+temperature sensors (outdoor, supply, exhaust inlet, and exhaust outlet). Only
+the Pro package has the tVOC/CO2eq air-quality sensor; `L07` describes the
+700 mm wall-length package, not a different sensor set.
+
+The Freshpoint Smart Home guide limits each packet to 256 bytes. Full profile
+polls contain more registers than one response can safely carry on every
+firmware. A valid but incomplete response previously counted as success and
+could leave omitted fields stale. The implementation therefore sends at most 12
+read parameters per bulk request, records every returned or explicitly
+unsupported (`0xFD`) parameter, and retries only omitted parameters
+individually. Quick polling also includes humidity plus all four temperature
+rows. The response parser keeps the current `0xFF` high-byte page until another
+page marker changes it, as required by the guide's packet example.
 
 Documented unit type values from parameter `0x00B9`:
 

--- a/protocol.md
+++ b/protocol.md
@@ -117,10 +117,21 @@ targeted `documentary_match`; neither manufacturer explicitly states the
 cross-brand relationship or documents a BGCP unit type for it.
 
 It is not a manufacturer-backed BGCP bridge. The official VENTS A21 documents
-publish Modbus RTU/TCP (Wi-Fi TCP port 502), and their controller device type
-`1 = A21` is not BGCP parameter `0x00B9`. The catalogue therefore keeps `VENTS
-VUT 270 V5B EC A21` under `candidates`; the reported `0x0100`/`vento` behavior
-remains a separate live observation.
+publish Modbus RTU/TCP (Wi-Fi TCP port 502), and controller value `1` in input
+register `37` is not BGCP parameter `0x00B9`. The integration implements that
+A21 table as a separate transport and accepts it only after this read-only
+identity check. The reported `0x0100`/`vento` behavior remains the runtime
+evidence for the specific DF270 Connect device; it does not prove that DF270
+and VUT 270 are the same model.
+
+The A21 implementation covers the complete published address surface: coils
+`0..25`, discrete inputs `0..71`, input registers `0..53`, and holding
+registers `0..182`, including multi-register timers, firmware, RTC, engineering
+password encoding, and the seven-day schedule. Automatic polling excludes the
+three write-only action coils and the engineering password; both remain
+available through the typed protocol API. A controller that does not return
+`1` from input register `37` is rejected instead of being guessed from its
+marketing name.
 
 Two additional groups are worth targeted device captures:
 

--- a/tests/test_a21_config_flow.py
+++ b/tests/test_a21_config_flow.py
@@ -1,0 +1,65 @@
+"""Static regressions for the A21 transport config flow."""
+
+from __future__ import annotations
+
+import ast
+import json
+from pathlib import Path
+import unittest
+
+
+COMPONENT = Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"
+CONFIG_FLOW = COMPONENT / "config_flow.py"
+
+
+class A21ConfigFlowTest(unittest.TestCase):
+    """Keep the non-BGCP onboarding boundary explicit."""
+
+    def test_config_flow_has_three_transport_paths_and_migration_version(self):
+        source = CONFIG_FLOW.read_text()
+        tree = ast.parse(source)
+
+        self.assertIn("VERSION = 2", source)
+        self.assertIn("TRANSPORT_BGCP_UDP", source)
+        self.assertIn("TRANSPORT_MODBUS_TCP", source)
+        self.assertIn("TRANSPORT_MODBUS_RTU", source)
+        self.assertIn("CONF_TRANSPORT not in user_input", source)
+        self.assertIn("create_device(config)", source)
+        self.assertIn("identity_probe_failed", source)
+        self.assertIn("UnsupportedDevice", source)
+        self.assertTrue(
+            any(
+                isinstance(node, ast.AsyncFunctionDef)
+                and node.name == "async_step_modbus_tcp"
+                for node in ast.walk(tree)
+            )
+        )
+
+    def test_all_translations_label_every_new_transport_form(self):
+        expected_steps = {"user", "bgcp", "modbus_tcp", "modbus_rtu", "reconfigure"}
+        expected_modbus_fields = {
+            "unit_id",
+            "device_model",
+            "serial_port",
+            "baudrate",
+            "parity",
+            "stopbits",
+        }
+
+        for path in [COMPONENT / "strings.json", *(COMPONENT / "translations").glob("*.json")]:
+            with self.subTest(path=path.name):
+                config = json.loads(path.read_text())["config"]
+                steps = config["step"]
+                self.assertTrue(expected_steps <= steps.keys())
+                self.assertEqual(
+                    set(steps["modbus_tcp"]["data"]) & {"unit_id", "device_model"},
+                    {"unit_id", "device_model"},
+                )
+                self.assertTrue(
+                    expected_modbus_fields <= steps["reconfigure"]["data"].keys()
+                )
+                self.assertIn("unsupported_device", config["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_a21_config_flow.py
+++ b/tests/test_a21_config_flow.py
@@ -27,6 +27,11 @@ class A21ConfigFlowTest(unittest.TestCase):
         self.assertIn("create_device(config)", source)
         self.assertIn("identity_probe_failed", source)
         self.assertIn("UnsupportedDevice", source)
+        self.assertIn("current_wifi_ip", source)
+        self.assertIn("A21_BAUD_RATES", source)
+        self.assertIn("A21_STOP_BITS", source)
+        self.assertIn("vol.Range(min=1, max=16)", source)
+        self.assertIn("defaults.get(CONF_STOPBITS, 2)", source)
         self.assertTrue(
             any(
                 isinstance(node, ast.AsyncFunctionDef)
@@ -46,7 +51,10 @@ class A21ConfigFlowTest(unittest.TestCase):
             "stopbits",
         }
 
-        for path in [COMPONENT / "strings.json", *(COMPONENT / "translations").glob("*.json")]:
+        for path in [
+            COMPONENT / "strings.json",
+            *(COMPONENT / "translations").glob("*.json"),
+        ]:
             with self.subTest(path=path.name):
                 config = json.loads(path.read_text())["config"]
                 steps = config["step"]

--- a/tests/test_a21_modbus.py
+++ b/tests/test_a21_modbus.py
@@ -1,0 +1,382 @@
+"""Protocol-level tests for the VENTS A21 Modbus transport."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import importlib
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+COMPONENT_PATH = (
+    Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"
+)
+PACKAGE = "ecovent_v2_a21_test"
+
+package = types.ModuleType(PACKAGE)
+package.__path__ = [str(COMPONENT_PATH)]
+sys.modules.setdefault(PACKAGE, package)
+
+a21_modbus = importlib.import_module(f"{PACKAGE}.a21_modbus")
+a21_registers = importlib.import_module(f"{PACKAGE}.a21_registers")
+number_helpers = importlib.import_module(f"{PACKAGE}.number_helpers")
+schedule_helpers = importlib.import_module(f"{PACKAGE}.schedule_helpers")
+
+A21ModbusDevice = a21_modbus.A21ModbusDevice
+A21ModbusError = a21_modbus.A21ModbusError
+Table = a21_registers.Table
+WeeklyScheduleRecord = schedule_helpers.WeeklyScheduleRecord
+
+
+class Response:
+    def __init__(self, *, registers=None, bits=None, error=False, exception_code=None):
+        self.registers = registers
+        self.bits = bits
+        self._error = error
+        self.exception_code = exception_code
+
+    def isError(self):
+        return self._error
+
+
+class FakeModbusClient:
+    def __init__(self, *, identity=1, fail_slots=()):
+        self.connected = False
+        self.closed = False
+        self.calls = []
+        self.fail_slots = set(fail_slots)
+        self.coils = [False] * 26
+        self.discrete_inputs = [False] * 72
+        self.input_registers = [0] * 54
+        self.holding_registers = [0] * 183
+        self.input_registers[0:5] = [230, 50, 210, 220, 70]
+        self.input_registers[9:18] = [3000, 55, 0, 900, 0, 12, 0, 37, 0]
+        self.input_registers[23:25] = [1234, 1200]
+        self.input_registers[25:27] = [0x0506, 4]
+        self.input_registers[27:29] = [0x173B, 365]
+        self.input_registers[29:31] = [0x173B, 42]
+        self.input_registers[31:39] = [0, 1, 23, 0x0102, 0x0304, 2026, identity, 0]
+        self.holding_registers[2] = 1
+        self.holding_registers[5:18] = [
+            0,
+            0,
+            40,
+            40,
+            70,
+            70,
+            100,
+            100,
+            100,
+            100,
+            100,
+            100,
+            50,
+        ]
+        self.holding_registers[44:61] = [
+            23,
+            60,
+            1200,
+            400,
+            40,
+            1,
+            23,
+            0x001E,
+            7,
+            2,
+            0,
+            0,
+            0,
+            0,
+            90,
+            0,
+            0,
+        ]
+        self.holding_registers[61:65] = [0x0506, 4, 0x1004, 0x071A]
+        for day in range(7):
+            base = 126 + day * 8
+            self.holding_registers[base : base + 8] = [
+                0x0117,
+                0x0600,
+                0x0217,
+                0x0900,
+                0x0317,
+                0x1300,
+                0x0417,
+                0x173B,
+            ]
+
+    def connect(self):
+        self.calls.append(("connect",))
+        self.connected = True
+        return True
+
+    def close(self):
+        self.calls.append(("close",))
+        self.closed = True
+        self.connected = False
+
+    def _read(self, name, values, address, count, device_id):
+        self.calls.append((name, address, count, device_id))
+        slots = {(name, slot) for slot in range(address, address + count)}
+        if slots & self.fail_slots:
+            return Response(error=True, exception_code=2)
+        payload = values[address : address + count]
+        if name in {"read_coils", "read_discrete_inputs"}:
+            return Response(bits=payload)
+        return Response(registers=payload)
+
+    def read_coils(self, address, *, count, device_id):
+        return self._read("read_coils", self.coils, address, count, device_id)
+
+    def read_discrete_inputs(self, address, *, count, device_id):
+        return self._read(
+            "read_discrete_inputs", self.discrete_inputs, address, count, device_id
+        )
+
+    def read_input_registers(self, address, *, count, device_id):
+        return self._read(
+            "read_input_registers", self.input_registers, address, count, device_id
+        )
+
+    def read_holding_registers(self, address, *, count, device_id):
+        return self._read(
+            "read_holding_registers", self.holding_registers, address, count, device_id
+        )
+
+    def write_coil(self, address, value, *, device_id):
+        self.calls.append(("write_coil", address, value, device_id))
+        self.coils[address] = value
+        return Response()
+
+    def write_coils(self, address, values, *, device_id):
+        self.calls.append(("write_coils", address, list(values), device_id))
+        self.coils[address : address + len(values)] = values
+        return Response()
+
+    def write_register(self, address, value, *, device_id):
+        self.calls.append(("write_register", address, value, device_id))
+        self.holding_registers[address] = value
+        return Response()
+
+    def write_registers(self, address, values, *, device_id):
+        self.calls.append(("write_registers", address, list(values), device_id))
+        self.holding_registers[address : address + len(values)] = values
+        return Response()
+
+
+def device(client=None, **kwargs):
+    return A21ModbusDevice(
+        transport="modbus_tcp",
+        endpoint="192.0.2.10",
+        port=502,
+        unit_id=7,
+        name="Test A21",
+        model="VENTS VUT 270 V5B EC A21",
+        client=client or FakeModbusClient(),
+        **kwargs,
+    )
+
+
+def test_identity_gate_rejects_non_a21_before_any_write():
+    client = FakeModbusClient(identity=2)
+    fan = device(client)
+
+    assert fan.init_device() is False
+    assert fan.identity_probe_failed is True
+    assert fan.id == "DEFAULT_DEVICEID"
+    assert [call[0] for call in client.calls] == ["connect", "read_input_registers"]
+
+
+def test_init_reads_complete_non_sensitive_surface_and_populates_semantics():
+    client = FakeModbusClient()
+    fan = device(client)
+
+    assert fan.init_device() is True
+    assert fan.id == "a21-modbus_tcp-192.0.2.10-502-7"
+    assert fan.state == "off"
+    assert fan.speed == "speed_1"
+    assert fan.man_speed == 50
+    assert fan.temperature == 23.0
+    assert fan.room_temperature == 22.0
+    assert fan.outdoor_temperature == 5.0
+    assert fan.humidity == 55
+    assert fan.co2 == 900
+    assert fan.fan1_speed == 1234
+    assert fan.fan2_speed == 1200
+    assert fan.firmware == "1.2 2026-04-03"
+    assert fan.rtc_time == "04:05:06"
+    assert fan.rtc_date == "2026-07-16"
+    assert fan.filter_timer_countdown == "365d 23h 59m "
+    assert fan.machine_hours == "42d 23h 59m "
+    assert fan.unavailable_addresses == frozenset()
+
+    holding_reads = [
+        call for call in client.calls if call[0] == "read_holding_registers"
+    ]
+    assert holding_reads
+    assert all(
+        not ({124, 125} & set(range(address, address + count)))
+        for _, address, count, _ in holding_reads
+    )
+    assert not any(call[0].startswith("write_") for call in client.calls)
+
+
+def test_configured_device_id_survives_endpoint_reconfiguration():
+    fan = device(device_id="a21-original-endpoint-502-7")
+
+    assert fan.init_device() is True
+    assert fan.id == "a21-original-endpoint-502-7"
+
+
+def test_raw_api_uses_all_published_modbus_function_shapes():
+    client = FakeModbusClient()
+    fan = device(client)
+
+    assert fan.read_raw(Table.COIL, 0) == (0,)
+    assert fan.read_raw(Table.DISCRETE_INPUT, 0) == (0,)
+    assert fan.read_raw(Table.INPUT_REGISTER, 37) == (1,)
+    assert fan.read_raw(Table.HOLDING_REGISTER, 2) == (1,)
+    assert fan.write_raw(Table.COIL, 0, (True,))
+    assert fan.write_raw(Table.COIL, 5, (True, False))
+    assert fan.write_raw(Table.HOLDING_REGISTER, 2, (3,))
+    assert fan.write_raw(Table.HOLDING_REGISTER, 61, (0x0102, 3))
+
+    names = {call[0] for call in client.calls}
+    assert {
+        "read_coils",
+        "read_discrete_inputs",
+        "read_input_registers",
+        "read_holding_registers",
+        "write_coil",
+        "write_coils",
+        "write_register",
+        "write_registers",
+    } <= names
+    assert all(call[-1] == 7 for call in client.calls if call[0] != "connect")
+
+
+def test_write_permissions_ranges_and_enum_are_enforced():
+    fan = device(FakeModbusClient())
+
+    with pytest.raises(PermissionError):
+        fan.write_raw(Table.INPUT_REGISTER, 37, (1,))
+    with pytest.raises(PermissionError):
+        fan.write_raw(Table.HOLDING_REGISTER, 0, (1,))
+    with pytest.raises(ValueError, match="coil values"):
+        fan.write_raw(Table.COIL, 0, (2,))
+    with pytest.raises(PermissionError):
+        fan.write_register("IR_DeviceTYPE", 1)
+    with pytest.raises(ValueError):
+        fan.write_register("HR_SetTEMP", 99)
+    with pytest.raises(ValueError, match="enum value"):
+        fan.write_register("HR_OPERATION_MODE", 9)
+    with pytest.raises(ValueError, match="documented range"):
+        fan.write_register("CL_RESET_FILTER_TIMER", False)
+    with pytest.raises(ValueError, match="allowed ranges"):
+        fan.write_register("HR_SetFILTER_TIMER", 69)
+    assert fan.write_register("HR_SetFILTER_TIMER", 0)
+    assert fan.write_register("HR_SetFILTER_TIMER", 70)
+
+
+def test_resilient_full_poll_records_one_missing_optional_address():
+    client = FakeModbusClient(fail_slots={("read_holding_registers", 150)})
+    fan = device(client)
+    fan.read_register("IR_DeviceTYPE")
+
+    assert fan.update() is True
+    assert fan.last_poll_complete is False
+    assert (Table.HOLDING_REGISTER, 150) in fan.unavailable_addresses
+    assert fan.state == "off"
+    assert fan.id == "DEFAULT_DEVICEID"
+
+
+def test_poll_fails_when_a_required_operational_address_is_missing():
+    client = FakeModbusClient(fail_slots={("read_coils", 0)})
+    fan = device(client)
+    fan.read_register("IR_DeviceTYPE")
+
+    assert fan.update() is False
+    assert fan.last_poll_complete is False
+    assert (Table.COIL, 0) in fan.unavailable_addresses
+
+
+def test_transport_wide_error_fails_fast_without_recursive_address_splitting():
+    class FailedServerClient(FakeModbusClient):
+        def read_coils(self, address, *, count, device_id):
+            self.calls.append(("read_coils", address, count, device_id))
+            return Response(error=True, exception_code=4)
+
+    client = FailedServerClient()
+    fan = device(client)
+
+    with pytest.raises(A21ModbusError, match="failed"):
+        fan.update()
+    assert [call[0] for call in client.calls] == ["connect", "read_coils"]
+
+
+def test_illegal_address_scan_has_a_hard_request_budget():
+    class RejectAllAddressesClient(FakeModbusClient):
+        def read_holding_registers(self, address, *, count, device_id):
+            self.calls.append(("read_holding_registers", address, count, device_id))
+            return Response(error=True, exception_code=2)
+
+    client = RejectAllAddressesClient()
+
+    with pytest.raises(A21ModbusError, match="too many illegal-address"):
+        device(client).update()
+    reads = [call for call in client.calls if call[0] == "read_holding_registers"]
+    assert len(reads) <= 34
+
+
+def test_ha_number_values_stay_numeric_and_use_a21_ranges():
+    client = FakeModbusClient()
+    fan = device(client)
+    encode = number_helpers.encode_number_write_value
+
+    assert fan.parameter_range("temperature_treshold") == (15, 30)
+    assert fan.parameter_range("filter_timer_setpoint") == (70, 365)
+    assert fan.parameter_range("voc_treshold") == (20, 100)
+    assert fan.parameter_range("supply_speed_low") == (0, 100)
+
+    assert fan.set_param("filter_timer_setpoint", encode(90, 2, native_numeric=True))
+    assert fan.set_param("co2_treshold", encode(1200, 2, native_numeric=True))
+    assert fan.set_param("voc_treshold", encode(60, 2, native_numeric=True))
+    assert client.holding_registers[58] == 90
+    assert client.holding_registers[46] == 1200
+    assert client.holding_registers[48] == 60
+
+
+def test_semantic_writes_schedule_and_rtc_preserve_a21_encoding():
+    client = FakeModbusClient()
+    fan = device(client)
+    fan.read_all_registers()
+
+    assert fan.set_param("state", "on")
+    assert fan.set_param("speed", "manual")
+    assert fan.set_man_speed_percent(63)
+    assert client.coils[0] is True
+    assert client.holding_registers[2] == 255
+    assert client.holding_registers[17] == 63
+
+    monday = fan.read_weekly_schedule_day(1)
+    assert monday[2].speed == "speed_2"
+    assert monday[2].reserved == 23
+    assert fan.write_weekly_schedule_record(
+        WeeklyScheduleRecord(1, 2, "speed_5", 10, 30, reserved=24)
+    )
+    assert client.holding_registers[128:130] == [0x0518, 0x0A1E]
+
+    assert fan.set_rtc_datetime(datetime(2026, 7, 16, 12, 34, 56))
+    assert client.holding_registers[61:65] == [0x2238, 12, 0x1004, 0x071A]
+
+
+def test_short_or_error_response_is_not_accepted_as_success():
+    class ShortClient(FakeModbusClient):
+        def read_input_registers(self, address, *, count, device_id):
+            return Response(registers=[])
+
+    with pytest.raises(A21ModbusError, match="short"):
+        device(ShortClient()).read_raw(Table.INPUT_REGISTER, 37)

--- a/tests/test_a21_registers.py
+++ b/tests/test_a21_registers.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"))
+
+from a21_registers import (
+    A21_IDENTITY_REGISTER, A21_IDENTITY_VALUE, Access, FilterTimer, Firmware,
+    Kind, REGISTERS, RtcCalendar, RtcTime, Runtime, ScheduleEnd, SchedulePeriod,
+    Table, Timer, _indexes, decode, encode, get_by_address, get_register,
+)
+
+
+def test_complete_published_surface_and_identity():
+    assert A21_IDENTITY_REGISTER.table is Table.INPUT_REGISTER
+    assert (A21_IDENTITY_REGISTER.address, A21_IDENTITY_VALUE) == (37, 1)
+    expected = {Table.COIL: range(26), Table.DISCRETE_INPUT: range(72), Table.INPUT_REGISTER: range(54), Table.HOLDING_REGISTER: range(183)}
+    for table, addresses in expected.items():
+        assert {a for (t, a) in __import__("a21_registers").BY_TABLE_ADDRESS if t is table} == set(addresses)
+    assert len([r for r in REGISTERS if r.table is Table.COIL]) == 26
+    assert len([r for r in REGISTERS if r.table is Table.DISCRETE_INPUT]) == 72
+    assert get_by_address(Table.HOLDING_REGISTER, 125).key == "HR_ENGINEER_PWD"
+    assert get_register("DI_AlarmCODE52").address == 71
+    assert get_register("HR_SetWEEK_Su_P4_END").address == 181
+
+
+@pytest.mark.parametrize("kind,value,words", [
+    (Kind.BOOL, True, (1,)), (Kind.U8, 255, (255,)), (Kind.U16, 65535, (65535,)),
+    (Kind.S16, -2, (65534,)), (Kind.TENTHS_S16, -25.0, (65286,)), (Kind.BYTE_PAIR, (12, 34), (3106,)),
+    (Kind.TIMER, Timer(4, 5, 6), (1286, 4)), (Kind.FILTER_TIMER, FilterTimer(365, 23, 59), (5947, 365)),
+    (Kind.RUNTIME, Runtime(42, 23, 59), (5947, 42)), (Kind.FIRMWARE, Firmware(1,2,3,4,2026), (258,772,2026)),
+    (Kind.RTC_TIME, RtcTime(23, 59, 58), (15162,23)), (Kind.RTC_CALENDAR, RtcCalendar(31,7,12,26), (7943,3098)),
+    (Kind.PASSWORD, "1234", (12594,13108)), (Kind.SCHEDULE_SPEED_TEMP, SchedulePeriod(5,23), (1303,)), (Kind.SCHEDULE_END, ScheduleEnd(23,59), (5947,)),
+])
+def test_all_pure_codecs_roundtrip(kind, value, words):
+    assert encode(kind, value) == words
+    assert decode(kind, words) == value
+
+
+def test_permissions_ranges_and_bad_records_reject():
+    with pytest.raises(PermissionError): get_register("IR_DeviceTYPE").encode(1)
+    with pytest.raises(PermissionError): get_register("HR_DEF_SetTemp").encode(5)
+    with pytest.raises(ValueError): get_register("HR_SetTEMP").encode(999)
+    with pytest.raises(ValueError): encode(Kind.PASSWORD, "ABCDE")
+    with pytest.raises(ValueError): encode(Kind.RTC_TIME, RtcTime(24, 0, 0))
+    with pytest.raises(ValueError): decode(Kind.BOOL, (2,))
+
+
+def test_index_validation_rejects_duplicates_and_overlaps():
+    one = get_register("CL_POWER")
+    with pytest.raises(ValueError, match="duplicate key"):
+        _indexes((one, one))
+    overlap = one.__class__("other", Table.COIL, 0, Access.READ_ONLY, Kind.BOOL, "overlap")
+    with pytest.raises(ValueError, match="overlap"):
+        _indexes((one, overlap))

--- a/tests/test_a21_registers.py
+++ b/tests/test_a21_registers.py
@@ -47,6 +47,13 @@ def test_permissions_ranges_and_bad_records_reject():
     with pytest.raises(ValueError): decode(Kind.BOOL, (2,))
 
 
+def test_bypass_rotor_type_preserves_the_pdf_maximum_discrepancy():
+    spec = get_register("HR_BPS_ROTOR_TYPE")
+    assert spec.maximum == 5
+    assert spec.enum[5] == "three-point bypass"
+    assert "numeric maximum is 4" in spec.source_note
+
+
 def test_index_validation_rejects_duplicates_and_overlaps():
     one = get_register("CL_POWER")
     with pytest.raises(ValueError, match="duplicate key"):

--- a/tests/test_a21_registers.py
+++ b/tests/test_a21_registers.py
@@ -3,21 +3,46 @@ from pathlib import Path
 
 import pytest
 
-sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2"))
+sys.path.insert(
+    0, str(Path(__file__).resolve().parents[1] / "custom_components" / "ecovent_v2")
+)
 
 from a21_registers import (
-    A21_IDENTITY_REGISTER, A21_IDENTITY_VALUE, Access, FilterTimer, Firmware,
-    Kind, REGISTERS, RtcCalendar, RtcTime, Runtime, ScheduleEnd, SchedulePeriod,
-    Table, Timer, _indexes, decode, encode, get_by_address, get_register,
+    A21_IDENTITY_REGISTER,
+    A21_IDENTITY_VALUE,
+    Access,
+    FilterTimer,
+    Firmware,
+    Kind,
+    REGISTERS,
+    RtcCalendar,
+    RtcTime,
+    Runtime,
+    ScheduleEnd,
+    SchedulePeriod,
+    Table,
+    Timer,
+    _indexes,
+    decode,
+    encode,
+    get_by_address,
+    get_register,
 )
 
 
 def test_complete_published_surface_and_identity():
     assert A21_IDENTITY_REGISTER.table is Table.INPUT_REGISTER
     assert (A21_IDENTITY_REGISTER.address, A21_IDENTITY_VALUE) == (37, 1)
-    expected = {Table.COIL: range(26), Table.DISCRETE_INPUT: range(72), Table.INPUT_REGISTER: range(54), Table.HOLDING_REGISTER: range(183)}
+    expected = {
+        Table.COIL: range(26),
+        Table.DISCRETE_INPUT: range(72),
+        Table.INPUT_REGISTER: range(54),
+        Table.HOLDING_REGISTER: range(183),
+    }
     for table, addresses in expected.items():
-        assert {a for (t, a) in __import__("a21_registers").BY_TABLE_ADDRESS if t is table} == set(addresses)
+        assert {
+            a for (t, a) in __import__("a21_registers").BY_TABLE_ADDRESS if t is table
+        } == set(addresses)
     assert len([r for r in REGISTERS if r.table is Table.COIL]) == 26
     assert len([r for r in REGISTERS if r.table is Table.DISCRETE_INPUT]) == 72
     assert get_by_address(Table.HOLDING_REGISTER, 125).key == "HR_ENGINEER_PWD"
@@ -25,26 +50,44 @@ def test_complete_published_surface_and_identity():
     assert get_register("HR_SetWEEK_Su_P4_END").address == 181
 
 
-@pytest.mark.parametrize("kind,value,words", [
-    (Kind.BOOL, True, (1,)), (Kind.U8, 255, (255,)), (Kind.U16, 65535, (65535,)),
-    (Kind.S16, -2, (65534,)), (Kind.TENTHS_S16, -25.0, (65286,)), (Kind.BYTE_PAIR, (12, 34), (3106,)),
-    (Kind.TIMER, Timer(4, 5, 6), (1286, 4)), (Kind.FILTER_TIMER, FilterTimer(365, 23, 59), (5947, 365)),
-    (Kind.RUNTIME, Runtime(42, 23, 59), (5947, 42)), (Kind.FIRMWARE, Firmware(1,2,3,4,2026), (258,772,2026)),
-    (Kind.RTC_TIME, RtcTime(23, 59, 58), (15162,23)), (Kind.RTC_CALENDAR, RtcCalendar(31,7,12,26), (7943,3098)),
-    (Kind.PASSWORD, "1234", (12594,13108)), (Kind.SCHEDULE_SPEED_TEMP, SchedulePeriod(5,23), (1303,)), (Kind.SCHEDULE_END, ScheduleEnd(23,59), (5947,)),
-])
+@pytest.mark.parametrize(
+    "kind,value,words",
+    [
+        (Kind.BOOL, True, (1,)),
+        (Kind.U8, 255, (255,)),
+        (Kind.U16, 65535, (65535,)),
+        (Kind.S16, -2, (65534,)),
+        (Kind.TENTHS_S16, -25.0, (65286,)),
+        (Kind.BYTE_PAIR, (12, 34), (3106,)),
+        (Kind.TIMER, Timer(4, 5, 6), (1286, 4)),
+        (Kind.FILTER_TIMER, FilterTimer(365, 23, 59), (5947, 365)),
+        (Kind.RUNTIME, Runtime(42, 23, 59), (5947, 42)),
+        (Kind.FIRMWARE, Firmware(1, 2, 3, 4, 2026), (258, 772, 2026)),
+        (Kind.RTC_TIME, RtcTime(23, 59, 58), (15162, 23)),
+        (Kind.RTC_CALENDAR, RtcCalendar(31, 7, 12, 26), (7943, 3098)),
+        (Kind.PASSWORD, "1234", (12594, 13108)),
+        (Kind.SCHEDULE_SPEED_TEMP, SchedulePeriod(5, 23), (1303,)),
+        (Kind.SCHEDULE_END, ScheduleEnd(23, 59), (5947,)),
+    ],
+)
 def test_all_pure_codecs_roundtrip(kind, value, words):
     assert encode(kind, value) == words
     assert decode(kind, words) == value
 
 
 def test_permissions_ranges_and_bad_records_reject():
-    with pytest.raises(PermissionError): get_register("IR_DeviceTYPE").encode(1)
-    with pytest.raises(PermissionError): get_register("HR_DEF_SetTemp").encode(5)
-    with pytest.raises(ValueError): get_register("HR_SetTEMP").encode(999)
-    with pytest.raises(ValueError): encode(Kind.PASSWORD, "ABCDE")
-    with pytest.raises(ValueError): encode(Kind.RTC_TIME, RtcTime(24, 0, 0))
-    with pytest.raises(ValueError): decode(Kind.BOOL, (2,))
+    with pytest.raises(PermissionError):
+        get_register("IR_DeviceTYPE").encode(1)
+    with pytest.raises(PermissionError):
+        get_register("HR_DEF_SetTemp").encode(5)
+    with pytest.raises(ValueError):
+        get_register("HR_SetTEMP").encode(999)
+    with pytest.raises(ValueError):
+        encode(Kind.PASSWORD, "ABCDE")
+    with pytest.raises(ValueError):
+        encode(Kind.RTC_TIME, RtcTime(24, 0, 0))
+    with pytest.raises(ValueError):
+        decode(Kind.BOOL, (2,))
 
 
 def test_bypass_rotor_type_preserves_the_pdf_maximum_discrepancy():
@@ -57,7 +100,11 @@ def test_bypass_rotor_type_preserves_the_pdf_maximum_discrepancy():
 def test_pdf_specific_holding_metadata_has_no_generic_fallback_ranges():
     # 0..255 is published only for speed mode and fan-alarm control, not a
     # generic default for the many byte-sized holding registers.
-    generic = [spec.key for spec in REGISTERS if spec.table is Table.HOLDING_REGISTER and spec.maximum == 255]
+    generic = [
+        spec.key
+        for spec in REGISTERS
+        if spec.table is Table.HOLDING_REGISTER and spec.maximum == 255
+    ]
     assert generic == ["HR_SPEED_MODE", "HR_FanAlarmCTRL"]
     temp = get_register("HR_SetTEMP")
     assert (temp.minimum, temp.maximum, temp.default, temp.unit) == (15, 30, 23, "°C")
@@ -69,6 +116,8 @@ def test_index_validation_rejects_duplicates_and_overlaps():
     one = get_register("CL_POWER")
     with pytest.raises(ValueError, match="duplicate key"):
         _indexes((one, one))
-    overlap = one.__class__("other", Table.COIL, 0, Access.READ_ONLY, Kind.BOOL, "overlap")
+    overlap = one.__class__(
+        "other", Table.COIL, 0, Access.READ_ONLY, Kind.BOOL, "overlap"
+    )
     with pytest.raises(ValueError, match="overlap"):
         _indexes((one, overlap))

--- a/tests/test_a21_registers.py
+++ b/tests/test_a21_registers.py
@@ -54,6 +54,17 @@ def test_bypass_rotor_type_preserves_the_pdf_maximum_discrepancy():
     assert "numeric maximum is 4" in spec.source_note
 
 
+def test_pdf_specific_holding_metadata_has_no_generic_fallback_ranges():
+    # 0..255 is published only for speed mode and fan-alarm control, not a
+    # generic default for the many byte-sized holding registers.
+    generic = [spec.key for spec in REGISTERS if spec.table is Table.HOLDING_REGISTER and spec.maximum == 255]
+    assert generic == ["HR_SPEED_MODE", "HR_FanAlarmCTRL"]
+    temp = get_register("HR_SetTEMP")
+    assert (temp.minimum, temp.maximum, temp.default, temp.unit) == (15, 30, 23, "°C")
+    assert get_register("HR_SetCO2").maximum == 2000
+    assert get_register("HR_RTC_TIME").default is None
+
+
 def test_index_validation_rejects_duplicates_and_overlaps():
     one = get_register("CL_POWER")
     with pytest.raises(ValueError, match="duplicate key"):

--- a/tests/test_ecovent_metadata.py
+++ b/tests/test_ecovent_metadata.py
@@ -56,6 +56,24 @@ class ParseResponseTest(unittest.TestCase):
             self.assertIn(mode, preset_icons)
 
     def test_unit_type_metadata_selects_device_profiles(self):
+        econoprime = Fan.device_models[0x0100]
+        self.assertEqual(econoprime.name, "ECONOPRIME DF270 Connect")
+        self.assertEqual(econoprime.profile_key, "vento")
+        self.assertEqual(econoprime.device_type, 1)
+        self.assertEqual(econoprime.parser_key, 0x0100)
+        self.assertEqual(
+            econoprime.manufacturer_group,
+            "Unknown (marketed as ECONOPRIME)",
+        )
+        self.assertIn("Econology DF270 Connect", econoprime.aliases)
+        self.assertIn(
+            "ECONOPRIME DF270 Connect",
+            {marketing.model for marketing in econoprime.official_names},
+        )
+        self.assertEqual(
+            {marketing.model for marketing in econoprime.candidates},
+            {"VENTS VUT 270 V5B EC A21"},
+        )
         self.assertEqual(
             Fan.device_models[0x1A00].name,
             "VENTO inHome old / TwinFresh Atmo old",
@@ -88,6 +106,9 @@ class ParseResponseTest(unittest.TestCase):
             marketing.model for marketing in Fan.device_models[0x1100].official_names
         }
         self.assertIn("Vents Breezy 160-E", breezy_160_names)
+        self.assertIn("Freshpoint 160-E", breezy_160_names)
+        self.assertIn("Freshpoint 160-E L07", breezy_160_names)
+        self.assertIn("Freshpoint 160-E Pro", breezy_160_names)
         self.assertIn("Freshpoint 160-E Pro L055", breezy_160_names)
         self.assertEqual(Fan.device_models[0x1100].profile_key, "breezy")
         breezy_eco_names = {
@@ -99,6 +120,9 @@ class ParseResponseTest(unittest.TestCase):
             marketing.model for marketing in Fan.device_models[0x1600].official_names
         }
         self.assertIn("Vents Breezy 200-E Smart", breezy_200_names)
+        self.assertIn("Freshpoint 200-E", breezy_200_names)
+        self.assertIn("Freshpoint 200-E L07", breezy_200_names)
+        self.assertIn("Freshpoint 200-E Pro", breezy_200_names)
         self.assertEqual(
             Fan.device_models[0x1800].name,
             "VENTS Breezy Eco 200 / Blauberg Freshpoint Eco 200",
@@ -160,6 +184,19 @@ class ParseResponseTest(unittest.TestCase):
         self.assertNotIn("Flexit Roomie One WiFi V2", expert.display_name)
 
     def test_unit_type_metadata_keeps_source_documents_with_models(self):
+        self.assertIn(
+            "https://www.econology.fr/filtres-vmc-double-flux-paul/"
+            "filtres-vmc-double-flux-econoprime-df270.html",
+            Fan.device_models[0x0100].source_documents,
+        )
+        self.assertIn(
+            "https://ventilation-system.com/download/vut-v5b-ec-manual-19669.pdf",
+            Fan.device_models[0x0100].candidates[0].source_documents,
+        )
+        self.assertIn(
+            "https://blaubergventilatoren.net/download/freshpoint-datasheet-9055.pdf",
+            Fan.device_models[0x1100].source_documents,
+        )
         self.assertIn(
             "https://blaubergventilatoren.net/download/vento-inhome-manual-14758.pdf",
             Fan.device_models[0x0300].source_documents,

--- a/tests/test_ecovent_metadata.py
+++ b/tests/test_ecovent_metadata.py
@@ -5,6 +5,22 @@ import unittest
 
 from ecovent_test_helpers import COMPONENT_PATH, Fan, PROTOCOL_REFERENCE_PATH
 
+README_PATH = COMPONENT_PATH.parents[1] / "README.md"
+LEGACY_README_SEARCH_ALIASES = (
+    "Blauberg VENTO Expert DUO A30-1 W V.2",
+    "Blauberg VENTO Expert A30 W V.2",
+    "Blauberg Freshbox 100 WiFi",
+    "Freshbox E1-100 WiFi",
+    "VENTS Micra 100 WiFi",
+    "Micra 100 E1 WiFi",
+    "VENTS Breezy",
+    "VENTS Arc Smart",
+    "DUKA One S4 Wi-Fi",
+    "DUKA One S6 Wi-Fi",
+    "Winzel V.2",
+    "Roomie One Wifi V2",
+)
+
 
 class ParseResponseTest(unittest.TestCase):
     def test_entity_platforms_do_not_branch_on_profile_names(self):
@@ -183,10 +199,108 @@ class ParseResponseTest(unittest.TestCase):
         self.assertEqual(candidates["NIBE DVC 10-50W"], "candidate")
         self.assertNotIn("Flexit Roomie One WiFi V2", expert.display_name)
 
+        duo = Fan.device_models[0x0400]
+        duo_relabels = {marketing.model for marketing in duo.relabels}
+        duo_candidates = {marketing.model for marketing in duo.candidates}
+        self.assertIn("Flexit Roomie Dual Wifi", duo_relabels)
+        self.assertIn("Roomie Dual WiFi V2", duo_candidates)
+        self.assertNotIn("Roomie Dual WiFi V2", duo_relabels)
+
+    def test_econoprime_documentary_matches_stay_candidate_only(self):
+        econoprime = Fan.device_models[0x0100]
+        vut = econoprime.candidates[0]
+        self.assertEqual(vut.model, "VENTS VUT 270 V5B EC A21")
+        self.assertEqual(vut.evidence, "documentary_match")
+        self.assertIn(
+            "https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html",
+            vut.source_documents,
+        )
+        self.assertNotIn(vut.model, econoprime.display_name)
+
+        bora_manual = (
+            "https://www.econology.fr/media/attachment/file_pdf/"
+            "notice_utilisateur_bora.pdf"
+        )
+        for parser_key, size in ((0x1100, 160), (0x1600, 200)):
+            model = Fan.device_models[parser_key]
+            bora_candidates = {
+                candidate.model: candidate
+                for candidate in model.candidates
+                if candidate.brand == "ECONOPRIME"
+            }
+            self.assertIn(f"Bora {size}", bora_candidates)
+            self.assertIn(f"Bora {size} Prime L1000", bora_candidates)
+            for candidate in bora_candidates.values():
+                self.assertEqual(candidate.evidence, "documentary_match")
+                self.assertIn(bora_manual, candidate.source_documents)
+                self.assertNotIn(candidate.model, model.display_name)
+
+    def test_readme_search_index_covers_catalog_names_and_statuses(self):
+        readme = README_PATH.read_text()
+        search_index = readme.split("## Device and brand search index", 1)[1].split(
+            "# Hardware smoke-tested", 1
+        )[0]
+        official_section = search_index.split(
+            "### Protocol-mapped official names", 1
+        )[1].split("### Reported/relabel evidence", 1)[0]
+        relabel_section = search_index.split("### Reported/relabel evidence", 1)[
+            1
+        ].split("### Candidate relationships", 1)[0]
+        candidate_section = search_index.split("### Candidate relationships", 1)[
+            1
+        ].split("### Econology / ECONOPRIME catalogue research", 1)[0]
+
+        all_marketing_names = []
+        for parser_key, model in Fan.device_models.items():
+            official = {entry.model for entry in model.official_names}
+            relabels = {entry.model for entry in model.relabels}
+            candidates = {entry.model for entry in model.candidates}
+            self.assertTrue(official.isdisjoint(relabels))
+            self.assertTrue(official.isdisjoint(candidates))
+            self.assertTrue(relabels.isdisjoint(candidates))
+
+            official_row = next(
+                line
+                for line in official_section.splitlines()
+                if line.startswith(
+                    f"| `0x{parser_key:04X}` / `{model.profile_key}` |"
+                )
+            )
+            for name in official:
+                self.assertIn(f"`{name}`", official_row)
+
+            if relabels:
+                relabel_row = next(
+                    line
+                    for line in relabel_section.splitlines()
+                    if line.startswith(f"| `0x{parser_key:04X}` |")
+                )
+                for name in relabels:
+                    self.assertIn(f"`{name}`", relabel_row)
+
+            if candidates:
+                candidate_row = next(
+                    line
+                    for line in candidate_section.splitlines()
+                    if line.startswith(f"| near `0x{parser_key:04X}` |")
+                )
+            for name in candidates:
+                self.assertIn(f"`{name}`", candidate_row)
+                self.assertNotIn(f"`{name}`", official_section)
+                self.assertNotIn(f"`{name}`", relabel_section)
+            all_marketing_names.extend(
+                (*model.official_names, *model.relabels, *model.candidates)
+            )
+
+        for brand in {entry.brand for entry in all_marketing_names}:
+            self.assertIn(f"`{brand}`", search_index)
+        for alias in LEGACY_README_SEARCH_ALIASES:
+            self.assertIn(f"`{alias}`", search_index)
+
     def test_unit_type_metadata_keeps_source_documents_with_models(self):
         self.assertIn(
-            "https://www.econology.fr/filtres-vmc-double-flux-paul/"
-            "filtres-vmc-double-flux-econoprime-df270.html",
+            "https://www.econology.fr/"
+            "df-270-connect-econoprime-vmc-double-flux.html",
             Fan.device_models[0x0100].source_documents,
         )
         self.assertIn(

--- a/tests/test_ecovent_metadata.py
+++ b/tests/test_ecovent_metadata.py
@@ -6,20 +6,25 @@ import unittest
 from ecovent_test_helpers import COMPONENT_PATH, Fan, PROTOCOL_REFERENCE_PATH
 
 README_PATH = COMPONENT_PATH.parents[1] / "README.md"
-LEGACY_README_SEARCH_ALIASES = (
-    "Blauberg VENTO Expert DUO A30-1 W V.2",
-    "Blauberg VENTO Expert A30 W V.2",
-    "Blauberg Freshbox 100 WiFi",
-    "Freshbox E1-100 WiFi",
-    "VENTS Micra 100 WiFi",
-    "Micra 100 E1 WiFi",
-    "VENTS Breezy",
-    "VENTS Arc Smart",
-    "DUKA One S4 Wi-Fi",
-    "DUKA One S6 Wi-Fi",
-    "Winzel V.2",
-    "Roomie One Wifi V2",
-)
+LEGACY_README_OFFICIAL_ALIASES = {
+    0x0200: (
+        "Blauberg Freshbox 100 WiFi",
+        "Freshbox E1-100 WiFi",
+        "VENTS Micra 100 WiFi",
+        "Micra 100 E1 WiFi",
+    ),
+    0x0400: ("Blauberg VENTO Expert DUO A30-1 W V.2",),
+    0x0500: ("Blauberg VENTO Expert A30 W V.2",),
+}
+LEGACY_README_CANDIDATE_ALIASES = {
+    0x0300: (
+        "Roomie One Wifi V2",
+        "DUKA One S4 Wi-Fi",
+        "DUKA One S6 Wi-Fi",
+        "Winzel V.2",
+    ),
+}
+LEGACY_README_FAMILY_TERMS = ("VENTS Breezy", "VENTS Arc Smart")
 
 
 class ParseResponseTest(unittest.TestCase):
@@ -268,6 +273,7 @@ class ParseResponseTest(unittest.TestCase):
             )
             for name in official:
                 self.assertIn(f"`{name}`", official_row)
+            self.assertEqual(official_row.count("|"), 4)
 
             if relabels:
                 relabel_row = next(
@@ -292,10 +298,32 @@ class ParseResponseTest(unittest.TestCase):
                 (*model.official_names, *model.relabels, *model.candidates)
             )
 
+        brand_section = search_index.split("### Protocol-mapped official names", 1)[0]
         for brand in {entry.brand for entry in all_marketing_names}:
             self.assertIn(f"`{brand}`", search_index)
-        for alias in LEGACY_README_SEARCH_ALIASES:
-            self.assertIn(f"`{alias}`", search_index)
+        for term in LEGACY_README_FAMILY_TERMS:
+            self.assertIn(f"`{term}`", brand_section)
+
+        for parser_key, aliases in LEGACY_README_OFFICIAL_ALIASES.items():
+            row = next(
+                line
+                for line in official_section.splitlines()
+                if line.startswith(f"| `0x{parser_key:04X}` /")
+            )
+            for alias in aliases:
+                self.assertIn(f"`{alias}`", row)
+
+        for parser_key, aliases in LEGACY_README_CANDIDATE_ALIASES.items():
+            row = next(
+                line
+                for line in candidate_section.splitlines()
+                if line.startswith(f"| near `0x{parser_key:04X}` |")
+            )
+            for alias in aliases:
+                self.assertIn(f"`{alias}`", row)
+                self.assertIn(f"`{alias}` — `legacy_search`", row)
+
+        self.assertNotIn("### Legacy discovery aliases", search_index)
 
     def test_unit_type_metadata_keeps_source_documents_with_models(self):
         self.assertIn(

--- a/tests/test_ecovent_metadata.py
+++ b/tests/test_ecovent_metadata.py
@@ -6,25 +6,44 @@ import unittest
 from ecovent_test_helpers import COMPONENT_PATH, Fan, PROTOCOL_REFERENCE_PATH
 
 README_PATH = COMPONENT_PATH.parents[1] / "README.md"
-LEGACY_README_OFFICIAL_ALIASES = {
-    0x0200: (
-        "Blauberg Freshbox 100 WiFi",
-        "Freshbox E1-100 WiFi",
-        "VENTS Micra 100 WiFi",
-        "Micra 100 E1 WiFi",
-    ),
-    0x0400: ("Blauberg VENTO Expert DUO A30-1 W V.2",),
-    0x0500: ("Blauberg VENTO Expert A30 W V.2",),
-}
-LEGACY_README_CANDIDATE_ALIASES = {
-    0x0300: (
-        "Roomie One Wifi V2",
-        "DUKA One S4 Wi-Fi",
-        "DUKA One S6 Wi-Fi",
-        "Winzel V.2",
-    ),
-}
-LEGACY_README_FAMILY_TERMS = ("VENTS Breezy", "VENTS Arc Smart")
+ECONOPRIME_README_ONLY_NAMES = (
+    "DF 180 Flat",
+    "DF 180 Flat Connect",
+    "DFF18021",
+    "DF 270",
+    "DF27014",
+    "DF 270 Connect",
+    "DF27021",
+    "DF 350",
+    "DF 350 Connect",
+    "DF35021",
+    "Zephyr 100 S",
+    "ZEPH100",
+    "Zephyr 240 S",
+    "ZEPH240A14",
+    "Zephyr 240 S Connect",
+    "ZEPH240A21",
+    "Zephyr 270 V R",
+    "114800001",
+    "Zephyr 270 V Connect R",
+    "114800002",
+    "Zephyr 550 V PH Connect R",
+    "114800003",
+    "URC 250",
+    "URC250",
+    "URHF 150",
+    "URHF150",
+    "URHFCF 150",
+    "URHFCF150",
+    "URHF 200",
+    "URHF200",
+    "URHFCF 200",
+    "URHFCF200",
+    "URH 350",
+    "URH350",
+    "Airion 100",
+    "Airion 150",
+)
 
 
 class ParseResponseTest(unittest.TestCase):
@@ -242,88 +261,29 @@ class ParseResponseTest(unittest.TestCase):
 
     def test_readme_search_index_covers_catalog_names_and_statuses(self):
         readme = README_PATH.read_text()
-        search_index = readme.split("## Device and brand search index", 1)[1].split(
-            "# Hardware smoke-tested", 1
+        search_index = readme.split("## Device names and search keywords", 1)[1].split(
+            "# Tested on:", 1
         )[0]
-        official_section = search_index.split(
-            "### Protocol-mapped official names", 1
-        )[1].split("### Reported/relabel evidence", 1)[0]
-        relabel_section = search_index.split("### Reported/relabel evidence", 1)[
-            1
-        ].split("### Candidate relationships", 1)[0]
-        candidate_section = search_index.split("### Candidate relationships", 1)[
-            1
-        ].split("### Econology / ECONOPRIME catalogue research", 1)[0]
+        official_section, external_section = search_index.split(
+            "External relabels and OEM names tracked as evidence or candidates:", 1
+        )
 
         all_marketing_names = []
-        for parser_key, model in Fan.device_models.items():
-            official = {entry.model for entry in model.official_names}
-            relabels = {entry.model for entry in model.relabels}
-            candidates = {entry.model for entry in model.candidates}
-            self.assertTrue(official.isdisjoint(relabels))
-            self.assertTrue(official.isdisjoint(candidates))
-            self.assertTrue(relabels.isdisjoint(candidates))
-
-            official_row = next(
-                line
-                for line in official_section.splitlines()
-                if line.startswith(
-                    f"| `0x{parser_key:04X}` / `{model.profile_key}` |"
-                )
-            )
-            for name in official:
-                self.assertIn(f"`{name}`", official_row)
-            self.assertEqual(official_row.count("|"), 4)
-
-            if relabels:
-                relabel_row = next(
-                    line
-                    for line in relabel_section.splitlines()
-                    if line.startswith(f"| `0x{parser_key:04X}` |")
-                )
-                for name in relabels:
-                    self.assertIn(f"`{name}`", relabel_row)
-
-            if candidates:
-                candidate_row = next(
-                    line
-                    for line in candidate_section.splitlines()
-                    if line.startswith(f"| near `0x{parser_key:04X}` |")
-                )
-            for name in candidates:
-                self.assertIn(f"`{name}`", candidate_row)
-                self.assertNotIn(f"`{name}`", official_section)
-                self.assertNotIn(f"`{name}`", relabel_section)
+        for model in Fan.device_models.values():
+            for name in (*model.relabels, *model.candidates):
+                self.assertIn(name.model, external_section)
+                self.assertNotIn(name.model, official_section)
             all_marketing_names.extend(
                 (*model.official_names, *model.relabels, *model.candidates)
             )
 
-        brand_section = search_index.split("### Protocol-mapped official names", 1)[0]
         for brand in {entry.brand for entry in all_marketing_names}:
-            self.assertIn(f"`{brand}`", search_index)
-        for term in LEGACY_README_FAMILY_TERMS:
-            self.assertIn(f"`{term}`", brand_section)
+            self.assertIn(brand, search_index)
+        for name in ECONOPRIME_README_ONLY_NAMES:
+            self.assertIn(name, external_section)
 
-        for parser_key, aliases in LEGACY_README_OFFICIAL_ALIASES.items():
-            row = next(
-                line
-                for line in official_section.splitlines()
-                if line.startswith(f"| `0x{parser_key:04X}` /")
-            )
-            for alias in aliases:
-                self.assertIn(f"`{alias}`", row)
-
-        for parser_key, aliases in LEGACY_README_CANDIDATE_ALIASES.items():
-            row = next(
-                line
-                for line in candidate_section.splitlines()
-                if line.startswith(f"| near `0x{parser_key:04X}` |")
-            )
-            for alias in aliases:
-                self.assertIn(f"`{alias}`", row)
-                self.assertIn(f"`{alias}` — `legacy_search`", row)
-
-        self.assertNotIn("### Legacy discovery aliases", search_index)
+        self.assertNotIn("## Device and brand search index", readme)
+        self.assertNotIn("| Unit type / profile |", readme)
 
     def test_unit_type_metadata_keeps_source_documents_with_models(self):
         self.assertIn(

--- a/tests/test_ecovent_number_helpers.py
+++ b/tests/test_ecovent_number_helpers.py
@@ -4,7 +4,11 @@ import ast
 import unittest
 
 from ecovent_test_helpers import COMPONENT_PATH, Fan  # noqa: F401  Sets module path.
-from number_helpers import encode_raw_number, encode_speed_percent
+from number_helpers import (
+    encode_number_write_value,
+    encode_raw_number,
+    encode_speed_percent,
+)
 
 
 NUMBER_PATH = COMPONENT_PATH / "number.py"
@@ -40,6 +44,14 @@ class NumberHelperTest(unittest.TestCase):
     def test_raw_number_encoder_keeps_little_endian_multibyte_values(self):
         self.assertEqual(encode_raw_number(45), "2d")
         self.assertEqual(encode_raw_number(365, 2), "6d01")
+
+    def test_typed_protocol_numbers_are_not_bgcp_byte_strings(self):
+        self.assertEqual(encode_number_write_value(1200, 2, native_numeric=True), 1200)
+        self.assertEqual(
+            encode_number_write_value(1200, 2, native_numeric=False), "b004"
+        )
+        with self.assertRaises(ValueError):
+            encode_number_write_value(1.5, 2, native_numeric=True)
 
     def test_manual_speed_number_is_visible_configuration_entity(self):
         manual_specs = [

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -4,6 +4,7 @@ from datetime import datetime
 import unittest
 
 from ecovent_test_helpers import Fan, packet_with_payload
+from fan_protocol import MAX_BULK_READ_PARAMS
 
 
 class PacketBuilderTest(unittest.TestCase):
@@ -40,7 +41,7 @@ class PacketBuilderTest(unittest.TestCase):
 
         fan.send_command = send_command
         self.assertTrue(fan.update())
-        _, params, _ = calls[0]
+        params = "".join(call[1] for call in calls)
         self.assertNotIn("0065", params)
         self.assertNotIn("0080", params)
 
@@ -57,9 +58,59 @@ class PacketBuilderTest(unittest.TestCase):
 
         fan.send_command = send_command
         self.assertTrue(fan.update())
-        _, params, _ = calls[0]
+        params = "".join(call[1] for call in calls)
         self.assertIn("0072", params)
         self.assertNotIn("0077", params)
+
+    def test_update_bounds_bulk_reads_to_protocol_safe_chunks(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+        fan.params = {
+            param: ["state", fan.states]
+            for param in range(1, MAX_BULK_READ_PARAMS * 2 + 2)
+        }
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            fan._last_response_param_ids = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertEqual([len(param) // 4 for param, _ in calls], [12, 12, 1])
+        self.assertEqual(
+            "".join(param for param, _ in calls),
+            "".join(f"{param:04x}" for param in fan.params),
+        )
+
+    def test_update_retries_params_missing_from_valid_bulk_response(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+        fan.params = {
+            0x0001: ["state", fan.states],
+            0x0002: ["speed", fan.speeds],
+            0x0025: ["humidity", None],
+        }
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            if len(param) > 4:
+                fan._last_response_param_ids = {0x0001}
+            else:
+                fan._last_response_param_ids = {int(param, 16)}
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertEqual(
+            calls,
+            [("000100020025", 3), ("0002", 1), ("0025", 1)],
+        )
+        self.assertTrue(fan._bulk_read_supported)
 
     def test_update_falls_back_to_individual_reads_after_bulk_failure(self):
         fan = Fan("192.0.2.1")
@@ -67,7 +118,7 @@ class PacketBuilderTest(unittest.TestCase):
 
         def send_command(func, param, value="", retries=10):
             calls.append((param, retries))
-            return len(param) == 4 and param == "0001"
+            return len(param) == 4
 
         fan.params = {0x0001: ["state", fan.states], 0x0002: ["speed", fan.speeds]}
         fan.send_command = send_command
@@ -75,6 +126,23 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertTrue(fan.update())
         self.assertEqual(calls, [("00010002", 3), ("0001", 1), ("0002", 1)])
         self.assertFalse(fan._bulk_read_supported)
+
+    def test_update_fails_when_missing_param_retry_fails(self):
+        fan = Fan("192.0.2.1")
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            if len(param) > 4:
+                fan._last_response_param_ids = {0x0001}
+                return True
+            return False
+
+        fan.params = {0x0001: ["state", fan.states], 0x0002: ["speed", fan.speeds]}
+        fan.send_command = send_command
+
+        self.assertFalse(fan.update())
+        self.assertEqual(calls, [("00010002", 3), ("0002", 1)])
 
     def test_vento_update_reads_humidity_in_bulk_request(self):
         fan = Fan("192.0.2.1")
@@ -87,7 +155,23 @@ class PacketBuilderTest(unittest.TestCase):
         fan.send_command = send_command
 
         self.assertTrue(fan.update())
-        self.assertIn("0025", calls[0][0])
+        self.assertIn("0025", "".join(param for param, _ in calls))
+
+    def test_breezy_quick_update_reads_humidity_and_all_four_temperatures(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.quick_update())
+        requested = "".join(param for param, _ in calls)
+        for param in ("001f", "0020", "0021", "0022", "0025"):
+            self.assertIn(param, requested.lower())
 
     def test_extract_fan_update_uses_profile_specific_parameters(self):
         fan = Fan("192.0.2.1")
@@ -101,8 +185,8 @@ class PacketBuilderTest(unittest.TestCase):
         fan.send_command = send_command
 
         self.assertTrue(fan.update())
-        params, retries = calls[0]
-        self.assertEqual(retries, 3)
+        params = "".join(param for param, _ in calls)
+        self.assertTrue(all(retries == 3 for _, retries in calls))
         self.assertIn("002e", params)
         self.assertIn("0031", params)
         self.assertIn("00b9", params)

--- a/tests/test_ecovent_parsing.py
+++ b/tests/test_ecovent_parsing.py
@@ -10,7 +10,9 @@ class ParseRobustnessTest(unittest.TestCase):
         fan = Fan("192.0.2.1")
         self.assertTrue(
             fan.parse_response(
-                packet_with_payload([0xFF, 0x12, 0x34, 0xAB, 0x01, 0x01])
+                packet_with_payload(
+                    [0xFF, 0x12, 0x34, 0xAB, 0xFF, 0x00, 0x01, 0x01]
+                )
             )
         )
         self.assertEqual(fan.unknown_params, {0x1234: "ab"})
@@ -100,3 +102,37 @@ class ParseRobustnessTest(unittest.TestCase):
         )
         self.assertEqual(fan.unknown_params, {})
         self.assertEqual(fan.state, "on")
+        self.assertEqual(fan._last_response_param_ids, {0x0065, 0x0001})
+
+    def test_parse_response_records_present_and_unsupported_parameter_ids(self):
+        fan = Fan("192.0.2.1")
+
+        self.assertTrue(
+            fan.parse_response(packet_with_payload([0x25, 0x32, 0xFD, 0x27]))
+        )
+
+        self.assertEqual(fan.humidity, "50")
+        self.assertEqual(fan._last_response_param_ids, {0x0025, 0x0027})
+
+    def test_parse_response_applies_page_to_unsupported_parameter_id(self):
+        fan = Fan("192.0.2.1")
+
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload([0xFF, 0x01, 0xFD, 0x01, 0x04, 0x05])
+            )
+        )
+
+        self.assertEqual(fan._last_response_param_ids, {0x0101, 0x0104})
+
+    def test_parse_response_keeps_page_for_following_parameters(self):
+        fan = Fan("192.0.2.1")
+
+        self.assertTrue(
+            fan.parse_response(
+                packet_with_payload([0xFF, 0x01, 0x04, 0x05, 0x05, 0x06])
+            )
+        )
+
+        self.assertEqual(fan.unknown_params, {0x0104: "05", 0x0105: "06"})
+        self.assertEqual(fan._last_response_param_ids, {0x0104, 0x0105})

--- a/tests/test_ecovent_profiles.py
+++ b/tests/test_ecovent_profiles.py
@@ -7,6 +7,14 @@ from ecovent_test_helpers import Fan, packet_with_payload
 
 
 class ProfileParseTest(unittest.TestCase):
+    def test_parse_response_names_econoprime_df270_unit_type(self):
+        fan = Fan("192.0.2.1")
+        self.assertTrue(
+            fan.parse_response(packet_with_payload([0xFE, 0x02, 0xB9, 0x01, 0x00]))
+        )
+        self.assertEqual(fan.unit_type, Fan.device_models[0x0100].display_name)
+        self.assertEqual(fan.profile_key, "vento")
+
     def test_parse_response_names_shared_oxxify_unit_type(self):
         fan = Fan("192.0.2.1")
         self.assertTrue(

--- a/tests/test_issue63_regressions.py
+++ b/tests/test_issue63_regressions.py
@@ -1,0 +1,51 @@
+"""Structural regression checks for complete protocol refreshes."""
+
+import ast
+from pathlib import Path
+import unittest
+
+
+COORDINATOR_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "custom_components"
+    / "ecovent_v2"
+    / "coordinator.py"
+)
+
+
+class Issue63RegressionTest(unittest.TestCase):
+    def test_coordinator_rejects_incomplete_protocol_refresh(self):
+        tree = ast.parse(COORDINATOR_PATH.read_text())
+        coordinator = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "EcoVentCoordinator"
+        )
+        update = next(
+            node
+            for node in coordinator.body
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == "_async_update_data"
+        )
+
+        assigned_names = {
+            target.id
+            for node in ast.walk(update)
+            if isinstance(node, ast.Assign)
+            for target in node.targets
+            if isinstance(target, ast.Name)
+        }
+        raised_names = {
+            node.exc.func.id
+            for node in ast.walk(update)
+            if isinstance(node, ast.Raise)
+            and isinstance(node.exc, ast.Call)
+            and isinstance(node.exc.func, ast.Name)
+        }
+
+        self.assertIn("update_complete", assigned_names)
+        self.assertIn("UpdateFailed", raised_names)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Fix Freshpoint 160 humidity and temperature entities that can remain `unknown`: keep bulk reads within the documented 256-byte protocol limit, verify which registers were actually returned, retry omitted registers individually, preserve the active high-byte parameter page, and reject an incomplete refresh instead of publishing it as successful.
- Refresh humidity plus all four built-in Freshpoint temperature registers in the quick poll. Standard Freshpoint models intentionally keep VOC/CO2eq optional because the manufacturer documents that sensor only for Pro variants.
- Map reported unit type `256` / parser key `0x0100` to `ECONOPRIME DF270 Connect` with the reporter-tested `vento` profile. Keep every cross-brand relationship separate from that live protocol observation.
- Add a separate VENTS A21 Modbus TCP/RTU transport: require input register `37 == 1`, cover the complete published register table and supported function codes, expose RTC and weekly schedule operations, and preserve config-entry identity across reconfiguration.
- Extend the existing README device-name list with searchable ECONOPRIME/Econology catalogue and candidate terms while keeping unverified devices out of BGCP runtime mappings.
- Close the older Smart Wi-Fi request as implementation-complete: the dedicated `0x0600` extract-fan profile and its regression coverage already landed in gody01/ecovent_v2#44. No post-merge hardware report exists, so this PR does not claim a live Smart Wi-Fi smoke test.

Fixes https://github.com/gody01/ecovent_v2/issues/63

Fixes https://github.com/gody01/ecovent_v2/issues/64

Closes https://github.com/gody01/ecovent_v2/issues/11

## Root cause and behavior

The client previously accepted any checksum-valid bulk response as complete. The Freshpoint Smart Home guide limits packets to 256 bytes, while a full Breezy/Freshpoint profile requests dozens of registers. If a valid response omitted a register, the integration never retried it and the corresponding Home Assistant entity could stay stale or `unknown` indefinitely.

Reads are now split into bounded groups of 12 parameters. The parser records every returned register and every explicit `0xFD` unsupported-register marker. Only omitted registers are retried individually, and Home Assistant receives `UpdateFailed` if any requested register still cannot be accounted for.

## VENTS A21 Modbus transport

The [official VENTS A21 Modbus table](https://ventilation-system.com/download/vut-v5b-ec-manual-19669.pdf) describes a protocol separate from BGCP. The new transport supports Modbus TCP and RTU functions `1`, `2`, `3`, `4`, `5`, `6`, `15`, and `16`, with the complete published address surface: 26 coils, 72 discrete inputs, 54 input registers, and 183 holding registers.

Onboarding first reads input register `37` and rejects the device unless it returns the published A21 identity value `1`. Selecting a marketing model in the form never bypasses this gate. Automatic polling excludes the three write-only action coils and engineering password, performs no startup writes, fails fast on transport errors, and bounds optional-address probing. Explicit typed reads and validated writes remain available for the published table, including RTC, engineering password, and all seven schedule days.

The RTU form uses the documented baud-rate set, address range `1..16`, and factory defaults `115200`, 8 data bits, no parity, and 2 stop bits. Existing version-1 config entries migrate explicitly to the unchanged BGCP/UDP transport. A21 reconfiguration retains the original Home Assistant device identity even if its endpoint changes.

No A21 unit was available for a hardware smoke test in this change. The implementation is validated against the published register table, exact manifest-pinned `pymodbus 3.13.1` call signatures, and protocol-level fake-client tests; it does not claim unperformed hardware validation.

## Model and document research

- The direct [ECONOPRIME DF 270 Connect product page](https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html), [DF 270 manual](https://www.econology.fr/media/attachment/file_pdf/notice_utilisation_df_270_econoprime_v5.pdf), [DF Connect application guide](https://www.econology.fr/media/attachment/file/n/o/notice_installateur-application_df_connect5_v3_5.pdf), and [A22 WiFi panel page](https://www.econology.fr/panneau-de-commande-a22-wifi-vmc-double-flux-df-connect-econoprime.html) replace the former dead filter-listing URL. The reported device itself remains the protocol evidence for `0x0100` and the working `vento` profile.
- A cross-document comparison identifies [VENTS VUT 270 V5B EC A21](https://ventilation-system.com/product/vut-270-v5b-ec-a21) as the relevant published A21/Modbus model. It is now supported through the separate A21 transport, but neither manufacturer states that it is a DF270 relabel or documents a BGCP unit type for it. The reported DF270 `0x0100` behavior therefore remains a separate live observation.
- The Econology catalogue also exposes DF 180/350, Zephyr, URC/URHF/URH, Airion, and associated Connect variants. Their exact names are indexed for discovery. Zephyr A21 labels may use the generic A21 transport only when the controller passes the register-37 identity gate; the reviewed PremAIR/GatePass and Airion documents do not publish a compatible local register or wire protocol.
- A comparison of the [ECONOPRIME Bora 160/200 manual](https://www.econology.fr/media/attachment/file_pdf/notice_utilisateur_bora.pdf) with Blauberg Freshpoint documents found matching sizes, wall-length variants, performance tables, sensor packages, Wi-Fi provisioning, and control behavior. This is an inference for targeted testing, not a manufacturer-stated relabel: Bora 160 and Bora 200 remain documentary candidates near `0x1100` and `0x1600` until a real device reports `0x00B9`.
- Current Freshpoint product documents add the standard and Pro 160/200 variants plus L055/L07/L1 lengths. The [datasheet](https://blaubergventilatoren.net/download/freshpoint-datasheet-9055.pdf) confirms humidity and four temperature sensors on both packages, with tVOC/CO2eq only on Pro; the [user manual](https://blaubergventilatoren.net/download/freshpoint-manual-9552.pdf) and [Smart Home guide](https://blaubergventilatoren.net/download/freshpoint-manual-16999.pdf) are linked from the catalogue and protocol reference.

The README keeps its existing device-name list layout and adds searchable Econology/ECONOPRIME candidate and catalogue names without presenting them as BGCP runtime mappings.

## Validation

- `python3 -m pytest -q -p no:cacheprovider` — 162 passed, 132 subtests passed
- Focused A21 tests under manifest-pinned `pymodbus 3.13.1` — 34 passed, 7 subtests passed
- `ruff check .`
- `python3 -m compileall -q custom_components tests`
- `git diff --check`
- All component JSON and translation files parse successfully
- GitHub GFM preserves the existing device-name bullet list and `Tested on` heading; no catalogue tables are introduced
