### PR TITLE
Fix Freshpoint 160-E setup after 1.2.17

### DIFF
--- a/README.md
+++ b/README.md
@@ -486,3 +486,9 @@ Version 1.2.17
 * Add separate VENTS A21 Modbus TCP and RTU transports with a read-only
   controller identity check, the complete published register table, RTC and
   weekly schedule support, and legacy BGCP config-entry migration.
+
+Version 1.2.18
+* Restore setup for standard Freshpoint 160-E devices whose non-Pro CO2/VOC
+  probes are legitimately absent. Missing optional variant registers are still
+  retried, while humidity and all four documented temperature registers remain
+  required for a successful Freshpoint refresh.

--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -296,9 +296,13 @@ class FanProtocolMixin:
         The Smart Home protocol limits a packet to 256 bytes. Keep each request
         bounded, then retry only parameters omitted from an otherwise valid
         response. An explicit 0xFD unsupported-parameter marker counts as a
-        response and is not retried.
+        response and is not retried. Profiles that cover multiple hardware
+        variants may identify the parameters that must complete a poll; missing
+        optional probes are retried but do not make the whole device unavailable.
         """
         complete = bool(request)
+        received_response = False
+        optional_params = self.device_profile.optional_read_params
         chunk_size = MAX_BULK_READ_PARAMS * 4
         for start in range(0, len(request), chunk_size):
             chunk = request[start : start + chunk_size]
@@ -307,6 +311,7 @@ class FanProtocolMixin:
             if self._bulk_read_supported is not False:
                 self._last_response_param_ids = None
                 if self.send_command(self.func["read"], chunk, retries=3):
+                    received_response = True
                     self._bulk_read_supported = True
                     response_ids = self._last_response_param_ids
                     if response_ids is None:
@@ -333,10 +338,18 @@ class FanProtocolMixin:
                     self.func["read"], param, retries=1
                 )
                 response_ids = self._last_response_param_ids
+                received_response = param_complete or received_response
                 if param_complete and response_ids is not None:
                     param_complete = int(param, 16) in response_ids
-                complete = param_complete and complete
-        return complete
+                if not param_complete:
+                    param_id = int(param, 16)
+                    if param_id not in optional_params:
+                        complete = False
+                    else:
+                        _LOGGER.debug(
+                            "Optional parameter 0x%04X did not respond", param_id
+                        )
+        return complete and received_response
 
     def set_param(self, param, value):
         valpar = self.get_params_values(param, value)

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.17",
+  "version": "1.2.18",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/protocol_metadata.py
+++ b/custom_components/ecovent_v2/protocol_metadata.py
@@ -109,6 +109,7 @@ class DeviceProfile:
     uses_operating_mode_presets: bool = False
     speed_percent_scale: str = "byte"
     supports_percentage_control: bool = True
+    optional_read_params: frozenset[int] = frozenset()
 
 
 @dataclass(frozen=True)

--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -85,6 +85,16 @@ DEVICE_PROFILES = {
         supports_oscillation=True,
         supports_preset_speed_settings=True,
         speed_percent_scale="percent",
+        optional_read_params=frozenset(
+            {
+                0x0011,
+                0x001A,
+                0x0027,
+                0x0315,
+                0x031F,
+                0x0320,
+            }
+        ),
     ),
     "freshbox": DeviceProfile(
         key="freshbox",

--- a/protocol.md
+++ b/protocol.md
@@ -227,9 +227,12 @@ firmware. A valid but incomplete response previously counted as success and
 could leave omitted fields stale. The implementation therefore sends at most 12
 read parameters per bulk request, records every returned or explicitly
 unsupported (`0xFD`) parameter, and retries only omitted parameters
-individually. Quick polling also includes humidity plus all four temperature
-rows. The response parser keeps the current `0xFF` high-byte page until another
-page marker changes it, as required by the guide's packet example.
+individually. The standard and Pro variants share one unit type, so missing
+CO2/VOC package probes do not fail the whole poll after their individual retry;
+humidity and the four documented temperature rows remain required. Quick
+polling includes those five required sensor rows. The response parser keeps the
+current `0xFF` high-byte page until another page marker changes it, as required
+by the guide's packet example.
 
 Documented unit type values from parameter `0x00B9`:
 

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -144,6 +144,68 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertFalse(fan.update())
         self.assertEqual(calls, [("00010002", 3), ("0002", 1)])
 
+    def test_freshpoint_update_allows_missing_variant_only_sensor_params(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        optional = fan.device_profile.optional_read_params
+        self.assertEqual(
+            optional,
+            {0x0011, 0x001A, 0x0027, 0x0315, 0x031F, 0x0320},
+        )
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - optional
+                return True
+            param_id = int(param, 16)
+            if param_id not in optional:
+                fan._last_response_param_ids = {param_id}
+                return True
+            return False
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        retried = {int(param, 16) for param, retries in calls if retries == 1}
+        self.assertIn(0x0027, retried)
+        self.assertIn(0x0320, retried)
+
+    def test_freshpoint_update_still_fails_when_required_sensor_is_missing(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        optional = fan.device_profile.optional_read_params
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            returned = requested - optional - {0x0025}
+            fan._last_response_param_ids = returned
+            return bool(returned) or len(param) > 4
+
+        fan.send_command = send_command
+
+        self.assertFalse(fan.update())
+
+    def test_freshpoint_non_poll_read_still_requires_every_requested_param(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+
+        def send_command(func, param, value="", retries=10):
+            if len(param) > 4:
+                fan._last_response_param_ids = {0x003A}
+                return True
+            return False
+
+        fan.send_command = send_command
+
+        self.assertFalse(fan.update_preset_speed_settings())
+
     def test_vento_update_reads_humidity_in_bulk_request(self):
         fan = Fan("192.0.2.1")
         calls = []


### PR DESCRIPTION
## Summary

- Restore setup for standard Freshpoint 160-E devices when their Pro-only CO2/VOC registers are absent.
- Keep the 1.2.17 completeness guard for humidity, all four documented temperature registers, and every non-optional BGCP register.
- Continue retrying omitted CO2/VOC registers individually so Pro devices still populate them when present.
- Bump the integration version and changelog to 1.2.18.

Fixes https://github.com/gody01/ecovent_v2/issues/66

## Root cause

The completeness handling merged in https://github.com/gody01/ecovent_v2/pull/65 correctly retries registers omitted from a valid bulk response, but it treated every register in the shared Breezy/Freshpoint profile as mandatory.

Freshpoint 160-E and 160-E Pro report the same unit type. The standard model legitimately lacks the Pro sensor package, so individual reads of the six CO2/VOC control, threshold, and value registers can remain unanswered. One of those expected omissions made the whole refresh return false, and Home Assistant then reported `Incomplete protocol response` for an otherwise reachable device.

The profile now marks only those six variant-specific registers as optional. They are still retried, but their absence no longer fails the refresh. Missing humidity, temperature, or any other requested register remains an incomplete refresh.

## Validation

- `python3 -m pytest -q -p no:cacheprovider` — 165 passed, 132 subtests passed
- `ruff check .`
- `python3 -m compileall -q custom_components tests`
- JSON parse check for all component metadata and translations
- `git diff --check`

No Freshpoint hardware was available locally. The regression test models the standard-unit response contract from the issue and manufacturer-documented standard/Pro sensor split; reporter hardware confirmation remains necessary before claiming a live-device smoke test.
