### PR TITLE
Fix Freshpoint 160-E partial protocol polling

### DIFF
--- a/README.md
+++ b/README.md
@@ -492,3 +492,25 @@ Version 1.2.18
   probes are legitimately absent. Missing optional variant registers are still
   retried, while humidity and all four documented temperature registers remain
   required for a successful Freshpoint refresh.
+
+Version 1.2.19
+* Restore Freshpoint 160-E polling when sensor/feature rows remain unavailable
+  after retry. Older 1.2.15 polling silently tolerated those omitted rows, while
+  1.2.16/1.2.17 made any omission fatal. Breezy/Freshpoint polls now require
+  only `0x0001` state, `0x0002` speed, and `0x0044` manual speed to prove the
+  device itself is reachable.
+* Treat explicit `0xFD` unsupported-register markers as unavailable data rather
+  than fresh values. Missing or unsupported optional rows are cleared, backed off
+  for ten poll cycles, and exposed as unknown/unavailable instead of stale or
+  false HA states.
+* Skip automatic full weekly-schedule cache reads while the lightweight
+  `0x0072` schedule-state row is unavailable, avoiding setup/reload delays on
+  Freshpoint variants that do not answer the optional schedule rows.
+* Add debug logging for incomplete BGCP/UDP refreshes after individual register
+  retries. The log now lists the missing required register addresses and any
+  non-critical poll registers that stayed unavailable or unsupported, making
+  Freshpoint hardware reports actionable without a local test device.
+* Note for HACS downgrades: entries migrated by 1.2.16/1.2.17 use config-entry
+  version 2. Home Assistant cannot load those entries with older 1.2.15 code;
+  delete and re-add the integration entries or restore a full Home Assistant
+  backup before downgrading to 1.2.15.

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -132,11 +132,20 @@ class EcoVentCoordinator(DataUpdateCoordinator):
 
     def _should_refresh_schedule_week(self) -> bool:
         """Return whether full weekly schedule reads are useful right now."""
-        return self._fan.supports_parameter("weekly_schedule_setup") and (
-            not self._weekly_schedule
-            or (
-                self._fan.weekly_schedule_state == "on" and self.updateCounter % 10 == 0
+        if not self._fan.supports_parameter("weekly_schedule_setup"):
+            return False
+
+        state = self._fan.weekly_schedule_state
+        if state not in ("on", "off"):
+            _LOGGER.debug(
+                "EcoVentCoordinator: skipping weekly schedule read for %s "
+                "because schedule state is unavailable",
+                self._fan.name,
             )
+            return False
+
+        return not self._weekly_schedule or (
+            state == "on" and self.updateCounter % 10 == 0
         )
 
     def _load_schedule_week(self) -> None:

--- a/custom_components/ecovent_v2/fan.py
+++ b/custom_components/ecovent_v2/fan.py
@@ -135,14 +135,18 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         return self._fan.id
 
     @property
-    def is_on(self) -> bool:
+    def is_on(self) -> bool | None:
         """Return state."""
-        return self._fan.state == "on"
+        state = self._fan.state
+        return None if state is None else state == "on"
 
     @property
     def percentage(self) -> int | None:
         """Return the current speed."""
-        if self._fan.state == "off":
+        state = self._fan.state
+        if state is None:
+            return None
+        if state == "off":
             return 0
         return self._fan.preset_speed_percent(self._fan.speed)
 
@@ -371,16 +375,24 @@ class VentoExpertFan(CoordinatorEntity, FanEntity):
         """Fan direction."""
         if not self._fan.supports_direction:
             return None
-        if self._fan.airflow == "air_supply":
+        airflow = self._fan.airflow
+        if airflow is None:
+            return None
+        if airflow == "air_supply":
             return "reverse"
-        return "forward"
+        if airflow in ("ventilation", "heat_recovery"):
+            return "forward"
+        return None
 
     @property
-    def oscillating(self) -> bool:
+    def oscillating(self) -> bool | None:
         """Oscillating."""
         if not self._fan.supports_oscillation:
             return False
-        return self._fan.airflow == "heat_recovery"
+        airflow = self._fan.airflow
+        if airflow not in ("ventilation", "heat_recovery", "air_supply"):
+            return None
+        return airflow == "heat_recovery"
 
     @property
     def boost_time(self) -> int:

--- a/custom_components/ecovent_v2/fan_capabilities.py
+++ b/custom_components/ecovent_v2/fan_capabilities.py
@@ -164,6 +164,7 @@ class FanCapabilitiesMixin:
         self._write_only_params = set(self.write_params)
         if previous_profile != profile_key:
             self._bulk_read_supported = None
+            self._optional_read_backoff = {}
 
     def _apply_device_profile(self):
         """Select parameter meanings after reading the model id."""

--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -12,9 +12,46 @@ except ImportError:
 
 _LOGGER = logging.getLogger(__name__)
 MAX_BULK_READ_PARAMS = 12
+OPTIONAL_PARAM_RETRY_BACKOFF_READS = 10
+PRESERVE_ON_SOFT_MISS_PARAMS = frozenset(
+    {
+        0x007C,  # device_search
+        0x0086,  # firmware
+        0x009C,  # wifi_assigned_ip
+        0x00A3,  # current_wifi_ip
+        0x00B9,  # unit_type/profile identity
+    }
+)
+
+
+def _format_param_ids(param_ids):
+    """Return protocol parameter ids in the format users see in docs/logs."""
+    if not param_ids:
+        return "none"
+    return ", ".join(f"0x{param_id:04X}" for param_id in sorted(param_ids))
+
+
+def _request_param_ids(request):
+    """Return parameter ids encoded in a read request string."""
+    return {int(request[i : i + 4], 16) for i in range(0, len(request), 4)}
 
 
 class FanProtocolMixin:
+    @property
+    def last_missing_required_params(self):
+        """Return required parameters missing from the last protocol read."""
+        return getattr(self, "_last_missing_required_params", frozenset())
+
+    @property
+    def last_missing_optional_params(self):
+        """Return optional parameters missing from the last protocol read."""
+        return getattr(self, "_last_missing_optional_params", frozenset())
+
+    @property
+    def last_unsupported_params(self):
+        """Return parameters explicitly rejected by the last protocol read."""
+        return getattr(self, "_last_unsupported_params", frozenset())
+
     def search_devices(self, addr="0.0.0.0", port=4000):
         sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
         try:
@@ -233,6 +270,7 @@ class FanProtocolMixin:
         while not response:
             i = i + 1
             self._last_response_param_ids = None
+            self._last_unsupported_param_ids = None
             self.send(data)
             response = self.receive()
             if response:
@@ -267,7 +305,10 @@ class FanProtocolMixin:
             if definition[0] == "weekly_schedule_setup":
                 continue
             request += hex(param).replace("0x", "").zfill(4)
-        success = self._read_params(request)
+        success = self._read_params(
+            request,
+            required_params=self.device_profile.poll_required_params,
+        )
         return success
 
     def quick_update(self):
@@ -281,7 +322,10 @@ class FanProtocolMixin:
         # 0x004B: ["fan2_speed", None],
         # 0x0304: ["humidity_status", statuses],
         # 0x0305: ["analogV_status", statuses],
-        return self._read_params(self.device_profile.quick_update_request)
+        return self._read_params(
+            self.device_profile.quick_update_request,
+            required_params=self.device_profile.poll_required_params,
+        )
 
     def update_preset_speed_settings(self):
         if not self.supports_preset_speed_settings:
@@ -290,42 +334,119 @@ class FanProtocolMixin:
         request = "003A003B003C003D003E003F"
         return self._read_params(request)
 
-    def _read_params(self, request):
+    def _mark_param_unavailable(self, param_id):
+        """Clear a missing soft-poll value so Home Assistant does not keep stale data."""
+        if param_id in PRESERVE_ON_SOFT_MISS_PARAMS:
+            return
+
+        definition = self.params.get(param_id)
+        if definition is None:
+            return
+
+        setattr(self, f"_{definition[0]}", None)
+
+    def _optional_param_backoff(self):
+        backoff = getattr(self, "_optional_read_backoff", None)
+        if backoff is None:
+            backoff = {}
+            self._optional_read_backoff = backoff
+        return backoff
+
+    def _mark_param_available_for_retry(self, param_id):
+        self._optional_param_backoff().pop(param_id, None)
+
+    def _delay_optional_param_retry(self, param_id):
+        self._optional_param_backoff()[param_id] = OPTIONAL_PARAM_RETRY_BACKOFF_READS
+
+    def _optional_param_retry_delayed(self, param_id):
+        backoff = self._optional_param_backoff()
+        remaining = backoff.get(param_id, 0)
+        if remaining <= 0:
+            return False
+
+        remaining -= 1
+        if remaining:
+            backoff[param_id] = remaining
+        else:
+            backoff.pop(param_id, None)
+        return True
+
+    def _read_params(self, request, *, required_params=None):
         """Read parameters without trusting a valid but incomplete bulk reply.
 
         The Smart Home protocol limits a packet to 256 bytes. Keep each request
         bounded, then retry only parameters omitted from an otherwise valid
-        response. An explicit 0xFD unsupported-parameter marker counts as a
-        response and is not retried. Profiles that cover multiple hardware
-        variants may identify the parameters that must complete a poll; missing
-        optional probes are retried but do not make the whole device unavailable.
+        response. An explicit 0xFD unsupported-parameter marker proves the
+        device answered, but it is still treated as unavailable data: required
+        rows fail the read, while optional rows are cleared and backed off.
+        Poll callers may identify the parameters that prove the device itself
+        is healthy; missing non-critical probes are retried and logged but do
+        not make the whole device unavailable.
         """
+        requested_params = _request_param_ids(request)
+        if required_params is None:
+            required_param_ids = requested_params
+        else:
+            required_param_ids = requested_params & set(required_params)
         complete = bool(request)
         received_response = False
-        optional_params = self.device_profile.optional_read_params
+        missing_required_params = set()
+        missing_optional_params = set()
+        unsupported_params = set()
+        self._last_missing_required_params = frozenset()
+        self._last_missing_optional_params = frozenset()
+        self._last_unsupported_params = frozenset()
         chunk_size = MAX_BULK_READ_PARAMS * 4
+
+        def mark_unavailable(param_id, *, delay_optional_retry=False):
+            nonlocal complete
+            if param_id in required_param_ids:
+                complete = False
+                missing_required_params.add(param_id)
+                return
+
+            missing_optional_params.add(param_id)
+            self._mark_param_unavailable(param_id)
+            if delay_optional_retry:
+                self._delay_optional_param_retry(param_id)
+
         for start in range(0, len(request), chunk_size):
             chunk = request[start : start + chunk_size]
             missing = [chunk[i : i + 4] for i in range(0, len(chunk), 4)]
+            chunk_param_ids = {int(param, 16) for param in missing}
 
             if self._bulk_read_supported is not False:
                 self._last_response_param_ids = None
+                self._last_unsupported_param_ids = None
                 if self.send_command(self.func["read"], chunk, retries=3):
                     received_response = True
                     self._bulk_read_supported = True
                     response_ids = self._last_response_param_ids
-                    if response_ids is None:
+                    unsupported_ids = self._last_unsupported_param_ids
+                    if response_ids is None and unsupported_ids is None:
                         continue
+                    response_ids = set(response_ids or ()) & chunk_param_ids
+                    unsupported_ids = set(unsupported_ids or ()) & chunk_param_ids
+                    for param_id in response_ids:
+                        self._mark_param_available_for_retry(param_id)
+                    for param_id in unsupported_ids:
+                        unsupported_params.add(param_id)
+                        mark_unavailable(param_id, delay_optional_retry=True)
                     missing = [
-                        param for param in missing if int(param, 16) not in response_ids
+                        param
+                        for param in missing
+                        if int(param, 16) not in response_ids | unsupported_ids
                     ]
                     if missing:
                         _LOGGER.debug(
                             "Bulk read returned %d of %d requested parameters; "
-                            "retrying %d individually",
+                            "retrying %d individually: %s",
                             len(response_ids),
                             len(chunk) // 4,
                             len(missing),
+                            _format_param_ids(
+                                int(param, 16) for param in missing
+                            ),
                         )
                     else:
                         continue
@@ -333,22 +454,57 @@ class FanProtocolMixin:
                     self._bulk_read_supported = False
 
             for param in missing:
+                param_id = int(param, 16)
+                if (
+                    param_id not in required_param_ids
+                    and self._optional_param_retry_delayed(param_id)
+                ):
+                    missing_optional_params.add(param_id)
+                    self._mark_param_unavailable(param_id)
+                    _LOGGER.debug(
+                        "Optional parameter 0x%04X still unavailable; "
+                        "skipping individual retry during backoff",
+                        param_id,
+                    )
+                    continue
+
                 self._last_response_param_ids = None
+                self._last_unsupported_param_ids = None
                 param_complete = self.send_command(
                     self.func["read"], param, retries=1
                 )
                 response_ids = self._last_response_param_ids
+                unsupported_ids = set(self._last_unsupported_param_ids or ())
                 received_response = param_complete or received_response
+                if param_complete and param_id in unsupported_ids:
+                    unsupported_params.add(param_id)
+                    mark_unavailable(param_id, delay_optional_retry=True)
+                    continue
                 if param_complete and response_ids is not None:
-                    param_complete = int(param, 16) in response_ids
+                    param_complete = param_id in response_ids
+                if param_complete:
+                    self._mark_param_available_for_retry(param_id)
                 if not param_complete:
-                    param_id = int(param, 16)
-                    if param_id not in optional_params:
-                        complete = False
-                    else:
+                    mark_unavailable(param_id, delay_optional_retry=True)
+                    if param_id not in required_param_ids:
                         _LOGGER.debug(
                             "Optional parameter 0x%04X did not respond", param_id
                         )
+        self._last_missing_required_params = frozenset(missing_required_params)
+        self._last_missing_optional_params = frozenset(missing_optional_params)
+        self._last_unsupported_params = frozenset(unsupported_params)
+        if missing_required_params or missing_optional_params or unsupported_params:
+            _LOGGER.debug(
+                "EcoVent protocol read incomplete for %s at %s using %s profile; "
+                "missing required parameters: %s; optional unavailable parameters: %s; "
+                "unsupported parameters: %s",
+                self.name,
+                self.host,
+                self.device_profile.key,
+                _format_param_ids(missing_required_params),
+                _format_param_ids(missing_optional_params),
+                _format_param_ids(unsupported_params),
+            )
         return complete and received_response
 
     def set_param(self, param, value):

--- a/custom_components/ecovent_v2/fan_protocol_parse.py
+++ b/custom_components/ecovent_v2/fan_protocol_parse.py
@@ -3,6 +3,7 @@
 class FanProtocolParseMixin:
     def parse_response(self, data):
         self._last_response_param_ids = None
+        self._last_unsupported_param_ids = None
         if not self.validate_packet(data):
             return False
         pointer = 2  # discard frame marker
@@ -30,6 +31,7 @@ class FanProtocolParseMixin:
         high_byte_value = 0
         parameter = 1
         response_param_ids = set()
+        unsupported_param_ids = set()
         for p in payload:
             if parameter and p == 0xFF:
                 ext_function = 0xFF
@@ -48,7 +50,7 @@ class FanProtocolParseMixin:
                     value_counter = p
                     ext_function = 2
                 elif ext_function == 0xFD:
-                    response_param_ids.add((high_byte_value << 8) | p)
+                    unsupported_param_ids.add((high_byte_value << 8) | p)
                     ext_function = 0
                     response = bytearray()
                 else:
@@ -75,6 +77,7 @@ class FanProtocolParseMixin:
         )
         if valid:
             self._last_response_param_ids = response_param_ids
+            self._last_unsupported_param_ids = unsupported_param_ids
         return valid
 
     def _store_param(self, response):

--- a/custom_components/ecovent_v2/fan_speed_properties.py
+++ b/custom_components/ecovent_v2/fan_speed_properties.py
@@ -97,6 +97,8 @@ class FanSpeedPropertiesMixin:
     def preset_speed_percent(self, preset, *, fallback_to_manual=True):
         if self.uses_operating_mode_presets:
             return self.max_speed_setpoint
+        if preset == "manual":
+            return self.man_speed if fallback_to_manual else None
 
         preset_speeds = {
             "speed_1": (self.supply_speed_low, self.exhaust_speed_low),
@@ -110,12 +112,18 @@ class FanSpeedPropertiesMixin:
         }
         preset_speed = preset_speeds.get(preset)
         if preset_speed is None:
-            return self.man_speed if fallback_to_manual else None
+            return None
 
         supply_speed, exhaust_speed = preset_speed
-        if self.airflow == "air_supply" and supply_speed is not None:
+        airflow = self.airflow
+        if (
+            self.supports_parameter("airflow")
+            and airflow not in ("air_supply", "ventilation", "heat_recovery")
+        ):
+            return None
+        if airflow == "air_supply" and supply_speed is not None:
             return supply_speed
-        if self.airflow == "ventilation" and exhaust_speed is not None:
+        if airflow == "ventilation" and exhaust_speed is not None:
             return exhaust_speed
 
         available_speeds = [
@@ -123,7 +131,7 @@ class FanSpeedPropertiesMixin:
         ]
         if available_speeds:
             return int(sum(available_speeds) / len(available_speeds))
-        return self.man_speed if fallback_to_manual else None
+        return None
 
     @property
     def man_speed(self):

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.18",
+  "version": "1.2.19",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/protocol_metadata.py
+++ b/custom_components/ecovent_v2/protocol_metadata.py
@@ -109,7 +109,7 @@ class DeviceProfile:
     uses_operating_mode_presets: bool = False
     speed_percent_scale: str = "byte"
     supports_percentage_control: bool = True
-    optional_read_params: frozenset[int] = frozenset()
+    poll_required_params: frozenset[int] | None = None
 
 
 @dataclass(frozen=True)

--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -58,7 +58,8 @@ DEVICE_PROFILES = {
         params_name="breezy_params",
         write_params_name="breezy_write_params",
         quick_update_request=(
-            "0007000B001F00200021002200250027004A004B0081008300840129030B0320"
+            "000100020007000B001F002000210022002500270044004A004B008100830084"
+            "0129030B0320"
         ),
         preset_modes=("off", "low", "medium", "high", "speed_4", "speed_5", "manual"),
         boost_statuses_name="statuses",
@@ -85,14 +86,15 @@ DEVICE_PROFILES = {
         supports_oscillation=True,
         supports_preset_speed_settings=True,
         speed_percent_scale="percent",
-        optional_read_params=frozenset(
+        poll_required_params=frozenset(
             {
-                0x0011,
-                0x001A,
-                0x0027,
-                0x0315,
-                0x031F,
-                0x0320,
+                # Standard Freshpoint units have been reported to keep the
+                # fan/control rows alive while sensor and feature probes stay
+                # absent. Keep only the rows that prove the fan poll itself is
+                # healthy as fatal for coordinator availability.
+                0x0001,
+                0x0002,
+                0x0044,
             }
         ),
     ),

--- a/custom_components/ecovent_v2/sensor.py
+++ b/custom_components/ecovent_v2/sensor.py
@@ -423,16 +423,23 @@ class WeeklyScheduleSummarySensor(StableObjectIdMixin, CoordinatorEntity, Sensor
         )
 
     @property
-    def native_value(self) -> str:
+    def native_value(self) -> str | None:
         """Return a compact summary state for the schedule entity."""
-        return "Enabled" if self._fan.weekly_schedule_state == "on" else "Disabled"
+        state = self._fan.weekly_schedule_state
+        if state == "on":
+            return "Enabled"
+        if state == "off":
+            return "Disabled"
+        return None
 
     @property
     def extra_state_attributes(self) -> dict[str, object]:
         """Expose the full schedule summary for the custom editor."""
+        state = self._fan.weekly_schedule_state
+        enabled = state == "on" if state in ("on", "off") else None
         attrs: dict[str, object] = {
             "editor": "ecovent_schedule",
-            "weekly_schedule_enabled": self._fan.weekly_schedule_state == "on",
+            "weekly_schedule_enabled": enabled,
             "selected_day": self.coordinator.schedule_day_option,
             "day_options": list(SCHEDULE_DAY_OPTIONS),
             "speed_options": self._fan.available_schedule_speed_options(),

--- a/custom_components/ecovent_v2/switch.py
+++ b/custom_components/ecovent_v2/switch.py
@@ -370,7 +370,8 @@ class VentoSwitch(StableObjectIdMixin, CoordinatorEntity, SwitchEntity):
     @property
     def is_on(self) -> bool | None:
         """Is switch on."""
-        self._attr_is_on = self._method() == "on"
+        value = self._method()
+        self._attr_is_on = None if value is None else value == "on"
         # self._attr_is_on = (self._attribute == "on")  # do not work reliably, use method instead
         # _LOGGER.debug(f"Switch {self._attr_name}, val [{self._attribute2}] is_on: {self._attr_is_on}")
         _LOGGER.debug(f"Switch {self._attr_name} is_on: {self._attr_is_on}")

--- a/protocol.md
+++ b/protocol.md
@@ -225,14 +225,28 @@ The Freshpoint Smart Home guide limits each packet to 256 bytes. Full profile
 polls contain more registers than one response can safely carry on every
 firmware. A valid but incomplete response previously counted as success and
 could leave omitted fields stale. The implementation therefore sends at most 12
-read parameters per bulk request, records every returned or explicitly
-unsupported (`0xFD`) parameter, and retries only omitted parameters
-individually. The standard and Pro variants share one unit type, so missing
-CO2/VOC package probes do not fail the whole poll after their individual retry;
-humidity and the four documented temperature rows remain required. Quick
-polling includes those five required sensor rows. The response parser keeps the
-current `0xFF` high-byte page until another page marker changes it, as required
-by the guide's packet example.
+read parameters per bulk request, records returned parameters separately from
+explicitly unsupported (`0xFD`) parameters, and retries only omitted parameters
+individually. `0xFD` means the controller answered but did not provide fresh
+data for that row: unsupported required rows fail the read, and unsupported
+optional rows are cleared just like omitted optional rows.
+
+The standard and Pro variants share one unit type, and real Freshpoint 160-E
+reports before 1.2.17 showed the fan/control rows working while humidity,
+temperature, CO2, VOC, alarm, schedule, or airflow rows could stay absent. The
+Breezy/Freshpoint poll therefore treats only `0x0001` (`state`), `0x0002`
+(`speed`), and `0x0044` (`man_speed`) as fatal for coordinator availability.
+Quick polling includes those same control proof rows. Missing or unsupported
+non-critical rows are retried once, then put into a ten-poll retry backoff;
+their HA entities report `unknown`/`unavailable` instead of stale or false
+states. Automatic weekly-schedule cache loading waits until `0x0072`
+(`weekly_schedule_state`) reports `on` or `off`; if that row is unavailable,
+setup/reload avoids probing all 28 `0x0077` schedule records. Identity rows such
+as `0x00B9` (`unit_type`) are preserved on soft misses so the active profile is
+not lost during a degraded poll. Targeted reads remain all-required and bypass
+optional poll backoff. The response parser keeps the current `0xFF` high-byte
+page until another page marker changes it, as required by the guide's packet
+example.
 
 Documented unit type values from parameter `0x00B9`:
 

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -143,14 +143,43 @@ class PacketBuilderTest(unittest.TestCase):
 
         self.assertFalse(fan.update())
         self.assertEqual(calls, [("00010002", 3), ("0002", 1)])
+        self.assertEqual(fan.last_missing_required_params, {0x0002})
+        self.assertEqual(fan.last_missing_optional_params, set())
 
-    def test_freshpoint_update_allows_missing_variant_only_sensor_params(self):
+    def test_update_logs_missing_required_param_addresses(self):
+        fan = Fan("192.0.2.1", name="Freshpoint MBR")
+        fan.params = {
+            0x0001: ["state", fan.states],
+            0x0002: ["speed", fan.speeds],
+            0x0025: ["humidity", None],
+        }
+
+        def send_command(func, param, value="", retries=10):
+            if len(param) > 4:
+                fan._last_response_param_ids = {0x0001}
+                return True
+            return False
+
+        fan.send_command = send_command
+
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertFalse(fan.update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("missing required parameters: 0x0002, 0x0025", messages)
+        self.assertIn("Freshpoint MBR", messages)
+
+    def test_freshpoint_update_allows_missing_noncritical_poll_params(self):
         fan = Fan("192.0.2.1")
         fan.unit_type = "1100"
-        optional = fan.device_profile.optional_read_params
+        required = fan.device_profile.poll_required_params
         self.assertEqual(
-            optional,
-            {0x0011, 0x001A, 0x0027, 0x0315, 0x031F, 0x0320},
+            required,
+            {
+                0x0001,
+                0x0002,
+                0x0044,
+            },
         )
         calls = []
 
@@ -160,37 +189,344 @@ class PacketBuilderTest(unittest.TestCase):
                 int(param[i : i + 4], 16) for i in range(0, len(param), 4)
             }
             if len(param) > 4:
-                fan._last_response_param_ids = requested - optional
+                fan._last_response_param_ids = requested & required
                 return True
             param_id = int(param, 16)
-            if param_id not in optional:
+            if param_id in required:
                 fan._last_response_param_ids = {param_id}
                 return True
             return False
 
         fan.send_command = send_command
 
-        self.assertTrue(fan.update())
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.update())
         retried = {int(param, 16) for param, retries in calls if retries == 1}
+        for param_id in (0x001F, 0x0020, 0x0021, 0x0022, 0x0025):
+            self.assertIn(param_id, retried)
         self.assertIn(0x0027, retried)
+        self.assertIn(0x0084, retried)
+        self.assertIn(0x0129, retried)
+        self.assertIn(0x030B, retried)
         self.assertIn(0x0320, retried)
+        self.assertIn(0x0400, retried)
+        self.assertIn(0x0409, retried)
+        messages = "\n".join(logs.output)
+        self.assertIn("missing required parameters: none", messages)
+        self.assertIn("optional unavailable parameters:", messages)
+        self.assertIn("0x000F", messages)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertIn(0x0025, fan.last_missing_optional_params)
 
-    def test_freshpoint_update_still_fails_when_required_sensor_is_missing(self):
+        calls.clear()
+        self.assertTrue(fan.update())
+        self.assertEqual(
+            [param for param, retries in calls if retries == 1],
+            [],
+        )
+        self.assertIn(0x0025, fan.last_missing_optional_params)
+
+    def test_freshpoint_update_clears_optional_unsupported_param_without_retrying(self):
         fan = Fan("192.0.2.1")
         fan.unit_type = "1100"
-        optional = fan.device_profile.optional_read_params
+        fan.params = {
+            0x0001: ["state", fan.states],
+            0x0002: ["speed", fan.speeds],
+            0x0044: ["man_speed", None],
+            0x0025: ["humidity", None],
+        }
+        fan.humidity = "2a"
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            fan._last_response_param_ids = requested - {0x0025}
+            fan._last_unsupported_param_ids = requested & {0x0025}
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertEqual(calls, [("0001000200440025", 3)])
+        self.assertIsNone(fan.humidity)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertEqual(fan.last_missing_optional_params, {0x0025})
+        self.assertEqual(fan.last_unsupported_params, {0x0025})
+
+    def test_freshpoint_optional_param_recovers_from_bulk_read_during_backoff(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        fan.params = {
+            0x0001: ["state", fan.states],
+            0x0002: ["speed", fan.speeds],
+            0x0044: ["man_speed", None],
+            0x0025: ["humidity", None],
+        }
+        calls = []
+        recovered = False
+
+        def send_command(func, param, value="", retries=10):
+            nonlocal recovered
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if not recovered:
+                if len(param) > 4:
+                    fan._last_response_param_ids = requested - {0x0025}
+                    return True
+                return False
+
+            fan._last_response_param_ids = requested
+            if 0x0025 in requested:
+                fan.humidity = "37"
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertIsNone(fan.humidity)
+        self.assertIn(0x0025, fan.last_missing_optional_params)
+        calls.clear()
+
+        recovered = True
+        self.assertTrue(fan.update())
+        self.assertEqual(calls, [("0001000200440025", 3)])
+        self.assertEqual(fan.humidity, "55")
+        self.assertEqual(fan.last_missing_optional_params, set())
+
+    def test_freshpoint_optional_state_rows_clear_and_recover(self):
+        rows = {
+            0x0025: ("humidity", "2a", "37", "55"),
+            0x0083: ("alarm_status", "00", "01", "alarm"),
+            0x0072: ("weekly_schedule_state", "01", "00", "off"),
+            0x00B7: ("airflow", "02", "01", "heat_recovery"),
+        }
+        for param_id, (attr, old_value, recovered_value, expected) in rows.items():
+            with self.subTest(param=f"0x{param_id:04X}", attr=attr):
+                fan = Fan("192.0.2.1")
+                fan.unit_type = "1100"
+                fan.params = {
+                    0x0001: ["state", fan.states],
+                    0x0002: ["speed", fan.speeds],
+                    0x0044: ["man_speed", None],
+                    param_id: [attr, fan.params[param_id][1]],
+                }
+                setattr(fan, attr, old_value)
+                recovered = False
+
+                def send_command(func, param, value="", retries=10):
+                    requested = {
+                        int(param[i : i + 4], 16)
+                        for i in range(0, len(param), 4)
+                    }
+                    if not recovered:
+                        if len(param) > 4:
+                            fan._last_response_param_ids = requested - {param_id}
+                            return True
+                        return False
+
+                    fan._last_response_param_ids = requested
+                    if param_id in requested:
+                        setattr(fan, attr, recovered_value)
+                    return True
+
+                fan.send_command = send_command
+
+                self.assertTrue(fan.update())
+                self.assertIsNone(getattr(fan, attr))
+                self.assertEqual(fan.last_missing_optional_params, {param_id})
+
+                recovered = True
+                self.assertTrue(fan.update())
+                self.assertEqual(getattr(fan, attr), expected)
+                self.assertEqual(fan.last_missing_optional_params, set())
+
+    def test_targeted_read_bypasses_optional_poll_backoff(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        fan.params = {
+            0x0001: ["state", fan.states],
+            0x0002: ["speed", fan.speeds],
+            0x0044: ["man_speed", None],
+            0x0025: ["humidity", None],
+        }
+        calls = []
+        targeted = False
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if targeted:
+                fan._last_response_param_ids = requested
+                fan.humidity = "37"
+                return True
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - {0x0025}
+                return True
+            return False
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertIn(0x0025, fan.last_missing_optional_params)
+        calls.clear()
+
+        targeted = True
+        self.assertTrue(fan._read_params("0025"))
+        self.assertEqual(calls, [("0025", 3)])
+        self.assertEqual(fan.humidity, "55")
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertEqual(fan.last_missing_optional_params, set())
+
+    def test_freshpoint_full_and_quick_polls_fail_when_core_rows_are_absent(self):
+        for method_name in ("update", "quick_update"):
+            for missing_param in (0x0001, 0x0002, 0x0044):
+                with self.subTest(method=method_name, missing=f"0x{missing_param:04X}"):
+                    fan = Fan("192.0.2.1")
+                    fan.unit_type = "1100"
+
+                    def send_command(func, param, value="", retries=10):
+                        requested = {
+                            int(param[i : i + 4], 16)
+                            for i in range(0, len(param), 4)
+                        }
+                        if len(param) == 4 and missing_param in requested:
+                            return False
+                        fan._last_response_param_ids = requested - {missing_param}
+                        return True
+
+                    fan.send_command = send_command
+
+                    self.assertFalse(getattr(fan, method_name)())
+                    self.assertEqual(fan.last_missing_required_params, {missing_param})
+                    self.assertEqual(fan.last_unsupported_params, set())
+
+    def test_freshpoint_full_and_quick_polls_fail_when_core_rows_are_unsupported(self):
+        for method_name in ("update", "quick_update"):
+            for unsupported_param in (0x0001, 0x0002, 0x0044):
+                with self.subTest(
+                    method=method_name, unsupported=f"0x{unsupported_param:04X}"
+                ):
+                    fan = Fan("192.0.2.1")
+                    fan.unit_type = "1100"
+                    calls = []
+
+                    def send_command(func, param, value="", retries=10):
+                        calls.append((param, retries))
+                        requested = {
+                            int(param[i : i + 4], 16)
+                            for i in range(0, len(param), 4)
+                        }
+                        fan._last_response_param_ids = requested - {unsupported_param}
+                        fan._last_unsupported_param_ids = requested & {
+                            unsupported_param
+                        }
+                        return True
+
+                    fan.send_command = send_command
+
+                    self.assertFalse(getattr(fan, method_name)())
+                    self.assertEqual(
+                        fan.last_missing_required_params, {unsupported_param}
+                    )
+                    self.assertEqual(fan.last_unsupported_params, {unsupported_param})
+                    self.assertFalse(
+                        [
+                            param
+                            for param, retries in calls
+                            if retries == 1 and int(param, 16) == unsupported_param
+                        ]
+                    )
+
+    def test_freshpoint_update_still_fails_when_core_poll_param_is_missing(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
 
         def send_command(func, param, value="", retries=10):
             requested = {
                 int(param[i : i + 4], 16) for i in range(0, len(param), 4)
             }
-            returned = requested - optional - {0x0025}
+            returned = requested - {0x0002}
             fan._last_response_param_ids = returned
             return bool(returned) or len(param) > 4
 
         fan.send_command = send_command
 
-        self.assertFalse(fan.update())
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertFalse(fan.update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("missing required parameters: 0x0002", messages)
+        self.assertEqual(fan.last_missing_required_params, {0x0002})
+        self.assertNotIn(0x0002, fan.last_missing_optional_params)
+
+    def test_freshpoint_quick_update_allows_missing_issue63_sensor_rows(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        fan.humidity = "2a"
+        missing_issue63_sensors = {0x001F, 0x0020, 0x0021, 0x0022, 0x0025, 0x0027}
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            returned = requested - missing_issue63_sensors
+            fan._last_response_param_ids = returned
+            return bool(returned)
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.quick_update())
+        retried = {int(param, 16) for param, retries in calls if retries == 1}
+        self.assertLessEqual(missing_issue63_sensors, retried)
+        self.assertIsNone(fan.humidity)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertLessEqual(missing_issue63_sensors, fan.last_missing_optional_params)
+
+    def test_freshpoint_soft_missing_identity_rows_keep_active_profile(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+        unit_type = fan.unit_type
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            returned = requested & fan.device_profile.poll_required_params
+            fan._last_response_param_ids = returned
+            return bool(returned) or len(param) > 4
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.update())
+        self.assertEqual(fan.unit_type, unit_type)
+        self.assertEqual(fan.profile_key, "breezy")
+        self.assertIn(0x00B9, fan.last_missing_optional_params)
+
+    def test_freshpoint_quick_update_fails_when_core_poll_param_is_missing(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "1100"
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            returned = requested - {0x0044}
+            fan._last_response_param_ids = returned
+            return bool(returned) or len(param) > 4
+
+        fan.send_command = send_command
+
+        self.assertFalse(fan.quick_update())
+        self.assertEqual(fan.last_missing_required_params, {0x0044})
 
     def test_freshpoint_non_poll_read_still_requires_every_requested_param(self):
         fan = Fan("192.0.2.1")
@@ -232,7 +568,7 @@ class PacketBuilderTest(unittest.TestCase):
 
         self.assertTrue(fan.quick_update())
         requested = "".join(param for param, _ in calls)
-        for param in ("001f", "0020", "0021", "0022", "0025"):
+        for param in ("0001", "0002", "001f", "0020", "0021", "0022", "0025", "0044"):
             self.assertIn(param, requested.lower())
 
     def test_extract_fan_update_uses_profile_specific_parameters(self):

--- a/tests/test_ecovent_parsing.py
+++ b/tests/test_ecovent_parsing.py
@@ -102,9 +102,10 @@ class ParseRobustnessTest(unittest.TestCase):
         )
         self.assertEqual(fan.unknown_params, {})
         self.assertEqual(fan.state, "on")
-        self.assertEqual(fan._last_response_param_ids, {0x0065, 0x0001})
+        self.assertEqual(fan._last_response_param_ids, {0x0001})
+        self.assertEqual(fan._last_unsupported_param_ids, {0x0065})
 
-    def test_parse_response_records_present_and_unsupported_parameter_ids(self):
+    def test_parse_response_records_present_and_unsupported_parameter_ids_separately(self):
         fan = Fan("192.0.2.1")
 
         self.assertTrue(
@@ -112,7 +113,8 @@ class ParseRobustnessTest(unittest.TestCase):
         )
 
         self.assertEqual(fan.humidity, "50")
-        self.assertEqual(fan._last_response_param_ids, {0x0025, 0x0027})
+        self.assertEqual(fan._last_response_param_ids, {0x0025})
+        self.assertEqual(fan._last_unsupported_param_ids, {0x0027})
 
     def test_parse_response_applies_page_to_unsupported_parameter_id(self):
         fan = Fan("192.0.2.1")
@@ -123,7 +125,8 @@ class ParseRobustnessTest(unittest.TestCase):
             )
         )
 
-        self.assertEqual(fan._last_response_param_ids, {0x0101, 0x0104})
+        self.assertEqual(fan._last_response_param_ids, {0x0104})
+        self.assertEqual(fan._last_unsupported_param_ids, {0x0101})
 
     def test_parse_response_keeps_page_for_following_parameters(self):
         fan = Fan("192.0.2.1")

--- a/tests/test_issue16_regressions.py
+++ b/tests/test_issue16_regressions.py
@@ -31,10 +31,13 @@ class Issue16RegressionTest(unittest.TestCase):
             tree, "EcoVentCoordinator", "_should_refresh_schedule_week"
         )
         post_init = _class_method(tree, "EcoVentCoordinator", "_async_post_init_setup")
+        should_refresh_source = ast.get_source_segment(source, should_refresh)
 
-        self.assertIn("not self._weekly_schedule", source)
-        self.assertIn('weekly_schedule_state == "on"', source)
-        self.assertIn("self.updateCounter % 10 == 0", source)
+        self.assertIn("not self._weekly_schedule", should_refresh_source)
+        self.assertIn("state = self._fan.weekly_schedule_state", should_refresh_source)
+        self.assertIn('state not in ("on", "off")', should_refresh_source)
+        self.assertIn('state == "on"', should_refresh_source)
+        self.assertIn("self.updateCounter % 10 == 0", should_refresh_source)
         self.assertTrue(
             any(
                 isinstance(node, ast.Attribute)

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -333,6 +333,37 @@ class Issue35RegressionTest(unittest.TestCase):
         self.assertIn("hidden_by=None", init_source)
         self.assertNotIn('f"switch.{device_slug}_weekly_schedule"', init_source)
 
+    def test_switch_none_state_remains_unknown(self):
+        switch_source = SWITCH_PATH.read_text()
+        tree = _tree(SWITCH_PATH)
+        is_on = ast.get_source_segment(
+            switch_source, _class_method(tree, "VentoSwitch", "is_on")
+        )
+
+        self.assertIn("value = self._method()", is_on)
+        self.assertIn("None if value is None else value == \"on\"", is_on)
+
+    def test_weekly_schedule_summary_none_state_remains_unknown(self):
+        sensor_source = SENSOR_PATH.read_text()
+        tree = _tree(SENSOR_PATH)
+        native_value = ast.get_source_segment(
+            sensor_source,
+            _class_method(tree, "WeeklyScheduleSummarySensor", "native_value"),
+        )
+        attrs = ast.get_source_segment(
+            sensor_source,
+            _class_method(
+                tree, "WeeklyScheduleSummarySensor", "extra_state_attributes"
+            ),
+        )
+
+        self.assertIn("state = self._fan.weekly_schedule_state", native_value)
+        self.assertIn('if state == "on"', native_value)
+        self.assertIn('if state == "off"', native_value)
+        self.assertIn("return None", native_value)
+        self.assertIn("enabled = state == \"on\" if state in", attrs)
+        self.assertIn('"weekly_schedule_enabled": enabled', attrs)
+
     def test_reported_legacy_entity_migrations_are_listed(self):
         init_source = INIT_PATH.read_text()
 

--- a/tests/test_silent_fan_entity.py
+++ b/tests/test_silent_fan_entity.py
@@ -209,6 +209,33 @@ class SilentFanEntityTest(unittest.TestCase):
         self.assertIn("03b702", calls[0])
         self.assertNotIn("fe036f", calls[0])
 
+    def test_missing_airflow_reports_unknown_direction_and_oscillation(self):
+        entity, fan, _calls = _silent_entity(speed="low", man_speed=63)
+        fan._airflow = None
+
+        self.assertIsNone(entity.current_direction)
+        self.assertIsNone(entity.oscillating)
+
+    def test_unmapped_airflow_reports_unknown_direction_and_oscillation(self):
+        entity, fan, _calls = _silent_entity(speed="low", man_speed=63)
+        fan._airflow = "Unknown airflow 3"
+
+        self.assertIsNone(entity.current_direction)
+        self.assertIsNone(entity.oscillating)
+
+    def test_missing_preset_setpoints_do_not_report_manual_speed_percentage(self):
+        entity, fan, _calls = _silent_entity(speed="low", man_speed=63)
+        fan._airflow = "ventilation"
+        fan._supply_speed_low = None
+        fan._exhaust_speed_low = None
+
+        self.assertIsNone(entity.percentage)
+
+    def test_manual_mode_still_reports_manual_speed_percentage(self):
+        entity, _fan, _calls = _silent_entity(speed="manual", man_speed=63)
+
+        self.assertEqual(entity.percentage, 63)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- Restore Freshpoint 160-E setup/reload when optional sensor, feature, airflow, or schedule registers are omitted or explicitly returned as `0xFD` unsupported.
- Keep Breezy/Freshpoint polling strict for the core control proof rows (`0x0001` state, `0x0002` speed, `0x0044` manual speed), so unreachable devices still fail instead of hiding stale cycles.
- Clear missing optional values to `unknown`/`unavailable`, back off repeated individual retries, and skip automatic full weekly-schedule reads while `0x0072` schedule state is unavailable.
- Keep debug logging of missing required, optional unavailable, and unsupported register addresses; document the HACS downgrade caveat for migrated config entries.

## Context

Follow-up to https://github.com/gody01/ecovent_v2/pull/67#issuecomment-5007519851.

The reporter tested 1.2.18 on four Freshpoint 160-E units and every refresh still ended as incomplete, but the debug log did not identify the register addresses that made the completeness check fail.

The useful release boundary is https://github.com/gody01/ecovent_v2/issues/63: on 1.2.15, setup and fan controls worked while humidity/temperature/CO2/VOC were `unknown`. The stricter complete-read behavior added after that stopped accepting checksum-valid partial bulk replies, which fixed stale refresh cycles but made every omitted Breezy/Freshpoint row fatal.

This PR changes the Breezy/Freshpoint poll from "all requested rows prove liveness" to "only state, speed, and manual speed prove liveness." Targeted reads and non-poll reads remain all-required.

## Validation

- `python3 -m pytest -q tests/test_ecovent_packets.py tests/test_ecovent_parsing.py tests/test_issue16_regressions.py tests/test_issue35_regressions.py tests/test_silent_fan_entity.py` - 83 passed, 33 subtests passed
- `python3 -m pytest -q -p no:cacheprovider` - 181 passed, 148 subtests passed
- `ruff check .`
- `python3 -m compileall -q custom_components tests`
- JSON metadata and translation parse check
- `git diff --check`
- Current branch head: `e20cfc66966b2a3a59a4659d3c79397c20e06b87`
