### PR TITLE
Add EcoVent partial poll diagnostics

### DIFF
--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -297,6 +297,20 @@ class FanProtocolMixin:
         """Return whether encoded params contain exactly one 0x0044 write."""
         return len(encoded_params) == 4 and encoded_params[:2].lower() == "44"
 
+    def _protocol_context(self):
+        """Return non-secret device context for protocol diagnostics."""
+        return (
+            "name=%s host=%s profile=%s unit_type=%s unit_type_id=%s device_id=%s"
+            % (
+                self.name,
+                self.host,
+                self.device_profile.key,
+                self.unit_type,
+                f"0x{self._unit_type_id:04X}" if self._unit_type_id is not None else "unknown",
+                "known" if self.id and self.id != "DEFAULT_DEVICEID" else "default",
+            )
+        )
+
     def update(self):
         request = ""
         for param, definition in self.params.items():
@@ -308,6 +322,7 @@ class FanProtocolMixin:
         success = self._read_params(
             request,
             required_params=self.device_profile.poll_required_params,
+            read_name="full poll",
         )
         return success
 
@@ -325,6 +340,7 @@ class FanProtocolMixin:
         return self._read_params(
             self.device_profile.quick_update_request,
             required_params=self.device_profile.poll_required_params,
+            read_name="quick poll",
         )
 
     def update_preset_speed_settings(self):
@@ -332,7 +348,7 @@ class FanProtocolMixin:
             return True
 
         request = "003A003B003C003D003E003F"
-        return self._read_params(request)
+        return self._read_params(request, read_name="preset speed settings")
 
     def _mark_param_unavailable(self, param_id):
         """Clear a missing soft-poll value so Home Assistant does not keep stale data."""
@@ -371,7 +387,7 @@ class FanProtocolMixin:
             backoff.pop(param_id, None)
         return True
 
-    def _read_params(self, request, *, required_params=None):
+    def _read_params(self, request, *, required_params=None, read_name="custom read"):
         """Read parameters without trusting a valid but incomplete bulk reply.
 
         The Smart Home protocol limits a packet to 256 bytes. Keep each request
@@ -393,6 +409,11 @@ class FanProtocolMixin:
         missing_required_params = set()
         missing_optional_params = set()
         unsupported_params = set()
+        received_params = set()
+        bulk_gap_params = set()
+        individual_retry_params = set()
+        no_response_params = set()
+        untracked_response_chunks = 0
         self._last_missing_required_params = frozenset()
         self._last_missing_optional_params = frozenset()
         self._last_unsupported_params = frozenset()
@@ -424,9 +445,11 @@ class FanProtocolMixin:
                     response_ids = self._last_response_param_ids
                     unsupported_ids = self._last_unsupported_param_ids
                     if response_ids is None and unsupported_ids is None:
+                        untracked_response_chunks += 1
                         continue
                     response_ids = set(response_ids or ()) & chunk_param_ids
                     unsupported_ids = set(unsupported_ids or ()) & chunk_param_ids
+                    received_params.update(response_ids)
                     for param_id in response_ids:
                         self._mark_param_available_for_retry(param_id)
                     for param_id in unsupported_ids:
@@ -438,12 +461,14 @@ class FanProtocolMixin:
                         if int(param, 16) not in response_ids | unsupported_ids
                     ]
                     if missing:
+                        bulk_gap_params.update(int(param, 16) for param in missing)
                         _LOGGER.debug(
-                            "Bulk read returned %d of %d requested parameters; "
-                            "retrying %d individually: %s",
+                            "EcoVent %s bulk read returned %d of %d requested "
+                            "parameters for %s; missing from bulk response: %s",
+                            read_name,
                             len(response_ids),
                             len(chunk) // 4,
-                            len(missing),
+                            self._protocol_context(),
                             _format_param_ids(
                                 int(param, 16) for param in missing
                             ),
@@ -470,6 +495,7 @@ class FanProtocolMixin:
 
                 self._last_response_param_ids = None
                 self._last_unsupported_param_ids = None
+                individual_retry_params.add(param_id)
                 param_complete = self.send_command(
                     self.func["read"], param, retries=1
                 )
@@ -482,28 +508,48 @@ class FanProtocolMixin:
                     continue
                 if param_complete and response_ids is not None:
                     param_complete = param_id in response_ids
+                if param_complete and response_ids is not None:
+                    received_params.update(set(response_ids) & {param_id})
                 if param_complete:
                     self._mark_param_available_for_retry(param_id)
                 if not param_complete:
+                    no_response_params.add(param_id)
                     mark_unavailable(param_id, delay_optional_retry=True)
                     if param_id not in required_param_ids:
                         _LOGGER.debug(
-                            "Optional parameter 0x%04X did not respond", param_id
+                            "EcoVent optional parameter 0x%04X did not respond "
+                            "during %s for %s",
+                            param_id,
+                            read_name,
+                            self._protocol_context(),
                         )
         self._last_missing_required_params = frozenset(missing_required_params)
         self._last_missing_optional_params = frozenset(missing_optional_params)
         self._last_unsupported_params = frozenset(unsupported_params)
         if missing_required_params or missing_optional_params or unsupported_params:
-            _LOGGER.debug(
-                "EcoVent protocol read incomplete for %s at %s using %s profile; "
+            log_level = logging.WARNING if missing_required_params else logging.DEBUG
+            _LOGGER.log(
+                log_level,
+                "EcoVent %s incomplete for %s; requested parameters: %s; "
+                "required availability parameters: %s; received parameters: %s; "
                 "missing required parameters: %s; optional unavailable parameters: %s; "
-                "unsupported parameters: %s",
-                self.name,
-                self.host,
-                self.device_profile.key,
+                "unsupported parameters: %s; missing from bulk response: %s; "
+                "individual retries attempted: %s; "
+                "no-response individual retries: %s; untracked valid bulk chunks: %d; "
+                "result: %s",
+                read_name,
+                self._protocol_context(),
+                _format_param_ids(requested_params),
+                _format_param_ids(required_param_ids),
+                _format_param_ids(received_params),
                 _format_param_ids(missing_required_params),
                 _format_param_ids(missing_optional_params),
                 _format_param_ids(unsupported_params),
+                _format_param_ids(bulk_gap_params),
+                _format_param_ids(individual_retry_params),
+                _format_param_ids(no_response_params),
+                untracked_response_chunks,
+                "available" if complete and received_response else "unavailable",
             )
         return complete and received_response
 

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -162,11 +162,17 @@ class PacketBuilderTest(unittest.TestCase):
 
         fan.send_command = send_command
 
-        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
-            self.assertFalse(fan._read_params("000100020025"))
+        with self.assertLogs("fan_protocol", level="WARNING") as logs:
+            self.assertFalse(fan._read_params("000100020025", read_name="setup poll"))
 
         messages = "\n".join(logs.output)
+        self.assertIn("EcoVent setup poll incomplete", messages)
+        self.assertIn("requested parameters: 0x0001, 0x0002, 0x0025", messages)
+        self.assertIn("required availability parameters: 0x0001, 0x0002, 0x0025", messages)
+        self.assertIn("received parameters: 0x0001", messages)
         self.assertIn("missing required parameters: 0x0002, 0x0025", messages)
+        self.assertIn("no-response individual retries: 0x0002, 0x0025", messages)
+        self.assertIn("result: unavailable", messages)
         self.assertIn("Freshpoint MBR", messages)
 
     def test_freshpoint_update_allows_missing_noncritical_poll_params(self):
@@ -612,11 +618,45 @@ class PacketBuilderTest(unittest.TestCase):
 
         fan.send_command = send_command
 
-        self.assertTrue(fan.quick_update())
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.quick_update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("EcoVent quick poll incomplete", messages)
+        self.assertIn("profile=vento", messages)
+        self.assertIn("required availability parameters: 0x0044", messages)
+        self.assertIn("optional unavailable parameters: 0x0006, 0x002D, 0x0304, 0x0305", messages)
+        self.assertIn("missing from bulk response: 0x0006, 0x002D, 0x0304, 0x0305", messages)
+        self.assertIn("individual retries attempted: 0x0006, 0x002D, 0x0304, 0x0305", messages)
+        self.assertIn("result: available", messages)
         retried = {int(param, 16) for param, retries in calls if retries == 1}
         self.assertLessEqual(missing_optional, retried)
         self.assertEqual(fan.last_missing_required_params, set())
         self.assertLessEqual(missing_optional, fan.last_missing_optional_params)
+
+    def test_vento_optional_backoff_diagnostics_do_not_claim_retry(self):
+        fan = Fan("192.0.2.1")
+        missing_optional = {0x0006}
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - missing_optional
+                return True
+            return False
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.quick_update())
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.quick_update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("missing from bulk response: 0x0006", messages)
+        self.assertIn("individual retries attempted: none", messages)
+        self.assertIn("Optional parameter 0x0006 still unavailable", messages)
 
     def test_vento_init_device_allows_missing_optional_poll_params(self):
         fan = Fan("192.0.2.1")


### PR DESCRIPTION
## Summary
- add non-secret protocol context to incomplete EcoVent poll diagnostics: read phase, device name/host, active profile, unit type, and whether the device id is still default or known
- report requested, required, received, missing-required, optional-unavailable, unsupported 0xFD, bulk-gap, actual individual-retry, no-response retry, and final availability result parameter sets
- keep fatal required-row gaps at WARNING while optional-only gaps stay DEBUG
- add regression coverage for fatal log details, optional Vento gaps, and optional retry backoff so diagnostics do not claim retries that were skipped

Follow-up to #70 / #69. #70 fixed the Vento availability policy and was merged before these extra diagnostics were added.

## Validation
- pytest -q tests/test_ecovent_packets.py (`43 passed, 23 subtests`)
- pytest -q (`188 passed, 155 subtests`)
- ruff check custom_components/ecovent_v2/fan_protocol.py tests/test_ecovent_packets.py
- python3 -m compileall -q custom_components/ecovent_v2 tests
- git diff --check upstream/main...HEAD
- codex review --base upstream/main (first pass found misleading retry wording; fixed with a backoff regression test; final pass found no correctness issues)
- live local HA deploy of this diagnostic build to homeassistant.local: `ha core check`, Core restart on HA 2026.7.2, `fan.living_room_vent` available, direct `init_device()` and `quick_update()` against 192.168.100.9 returned true with no missing/unsupported params, EcoVent system log hits were 0