### PR TITLE
Allow Freshbox polls without alarm list

### DIFF
--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -126,6 +126,16 @@ DEVICE_PROFILES = {
         ),
         speed_percent_scale="percent",
         supports_percentage_control=False,
+        poll_required_params=frozenset(
+            {
+                # VENTS Micra 100 WiFi units have been observed never
+                # answering alarm_list (0x007F), with occasional lossy drops
+                # of other rows. Keep only the rows that proved stable across
+                # the full and quick poll paths fatal for availability.
+                0x0002,
+                0x0006,
+            }
+        ),
     ),
     "arc": DeviceProfile(
         key="arc",

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -232,6 +232,108 @@ class PacketBuilderTest(unittest.TestCase):
         )
         self.assertIn(0x0025, fan.last_missing_optional_params)
 
+    def test_freshbox_update_allows_missing_alarm_list_param(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0200"
+        required = fan.device_profile.poll_required_params
+        self.assertEqual(
+            required,
+            {
+                0x0002,
+                0x0006,
+            },
+        )
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - {0x0001, 0x007F}
+                return True
+            if requested <= {0x0001, 0x007F}:
+                return False
+            fan._last_response_param_ids = requested
+            return True
+
+        fan.send_command = send_command
+
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.update())
+
+        retried = {int(param, 16) for param, retries in calls if retries == 1}
+        self.assertIn(0x007F, retried)
+        self.assertIn(0x0001, retried)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertEqual(fan.last_missing_optional_params, {0x0001, 0x007F})
+        messages = "\n".join(logs.output)
+        self.assertIn("profile=freshbox", messages)
+        self.assertIn("missing required parameters: none", messages)
+        self.assertIn("optional unavailable parameters: 0x0001, 0x007F", messages)
+        self.assertIn("result: available", messages)
+
+    def test_freshbox_init_device_allows_missing_noncritical_poll_params(self):
+        fan = Fan("192.0.2.1")
+        missing_optional = {0x0001, 0x007F}
+        calls = []
+
+        def send_command(func, param, value="", retries=10):
+            calls.append((param, retries))
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if requested == {0x007C}:
+                fan.device_search = "4d494352412d4944"
+                fan._last_response_param_ids = requested
+                return True
+            if requested == {0x00B9}:
+                fan.unit_type = "0200"
+                fan._last_response_param_ids = requested
+                return True
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - missing_optional
+                return True
+            if requested <= missing_optional:
+                return False
+            fan._last_response_param_ids = requested
+            return True
+
+        fan.send_command = send_command
+
+        self.assertTrue(fan.init_device())
+        self.assertEqual(fan.id, "MICRA-ID")
+        self.assertEqual(fan.profile_key, "freshbox")
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertEqual(fan.last_missing_optional_params, missing_optional)
+        self.assertEqual(calls[:2], [("007c", 10), ("00b9", 10)])
+
+    def test_freshbox_full_and_quick_polls_fail_when_core_rows_are_absent(self):
+        for method_name, missing_param in (
+            ("update", 0x0002),
+            ("update", 0x0006),
+            ("quick_update", 0x0006),
+        ):
+            with self.subTest(method=method_name, missing=f"0x{missing_param:04X}"):
+                fan = Fan("192.0.2.1")
+                fan.unit_type = "0200"
+
+                def send_command(func, param, value="", retries=10):
+                    requested = {
+                        int(param[i : i + 4], 16)
+                        for i in range(0, len(param), 4)
+                    }
+                    if len(param) == 4 and missing_param in requested:
+                        return False
+                    fan._last_response_param_ids = requested - {missing_param}
+                    return bool(fan._last_response_param_ids) or len(param) > 4
+
+                fan.send_command = send_command
+
+                self.assertFalse(getattr(fan, method_name)())
+                self.assertEqual(fan.last_missing_required_params, {missing_param})
+
     def test_freshpoint_update_clears_optional_unsupported_param_without_retrying(self):
         fan = Fan("192.0.2.1")
         fan.unit_type = "1100"


### PR DESCRIPTION
## Summary

Fixes the Freshbox/Micra startup failure reported in gody01/ecovent_v2#72 by making Freshbox poll availability depend on core fan rows instead of every mapped diagnostic/register row.

Freshbox now treats `0x0002` speed and `0x0006` boost status as the required availability proof. A Micra 100 that never answers `0x007F` (`alarm_list`) can still initialize when those stable rows are present; `0x007F` and other lossy non-proof rows such as `0x0001` state are retried, logged, and marked optional-unavailable instead of making the coordinator unavailable.

## Root Cause

Freshbox did not define `poll_required_params`, so the protocol reader treated every requested Freshbox register as required. On the affected VENTS Micra 100 WiFi trace, `0x007F` does not respond even when local BGCP communication is otherwise healthy, and a few non-proof rows still drop sporadically, so setup was rejected as incomplete.

## Tests

- `python -m pytest tests/test_ecovent_packets.py tests/test_ecovent_profiles.py tests/test_ecovent_metadata.py`
- `python -m pytest`
- `codex review --base upstream/main --title "Allow Freshbox polls without alarm list"`
