### PR TITLE
Fix Vento state/speed poll gaps

### DIFF
--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -412,6 +412,8 @@ class FanProtocolMixin:
             ignored_optional_params = set()
         else:
             required_param_ids = requested_params & set(required_params)
+            if not required_param_ids:
+                required_param_ids = requested_params
             ignored_optional_params = (
                 (requested_params - required_param_ids)
                 & self._unsupported_optional_poll_param_ids()

--- a/custom_components/ecovent_v2/protocol_profiles.py
+++ b/custom_components/ecovent_v2/protocol_profiles.py
@@ -35,11 +35,10 @@ DEVICE_PROFILES = {
         supports_preset_speed_settings=True,
         poll_required_params=frozenset(
             {
-                # Some Vento Expert units omit optional diagnostics from normal
-                # polls. Treat the core fan/control rows as the availability
-                # signal so missing sensors do not block setup.
-                0x0001,
-                0x0002,
+                # Some Vento Expert units intermittently omit the state/speed
+                # rows from otherwise healthy full polls. The quick poll has
+                # always used the manual-speed row as its availability signal,
+                # so keep the same stable control row for full polls too.
                 0x0044,
             }
         ),

--- a/protocol.md
+++ b/protocol.md
@@ -27,6 +27,32 @@ Source PDFs:
 - [Arc Smart Smart House CO2 connection guide](https://ventilation-system.com/download/arc-smart-manual-21863.pdf)
 - [O2 Supreme Smart Home connection guide B255-1EN-01](https://blaubergventilatoren.net/download/o2-supreme-manual-15274.pdf)
 
+### Spec and observed firmware differences
+
+The manufacturer PDFs are treated as parameter-map evidence, not as a guarantee
+that every firmware answers every documented row in every poll. Current issue
+reports and earlier compatibility fixes show these differences:
+
+| Area | PDF / implementation expectation | Observed device behavior | Integration policy |
+| -- | -- | -- | -- |
+| Vento/TwinFresh availability rows | The Vento-family map documents `0x0001` (`state`), `0x0002` (`speed`), and, in the B133 Vento guide, `0x0044` (`man_speed`). | Issue #76 shows Vento Expert / TwinFresh Expert full polls returning many valid rows including `0x0044`, while `0x0001` and `0x0002` remain absent after individual retry. The maintainer also reported this on an original Vento 50 with firmware `0.4 2019-12-20`. | Treat `0x0044` as the full-poll Vento availability row, matching the existing quick-poll control proof. Missing `0x0001` / `0x0002` is logged and surfaced as unavailable data rather than making the coordinator fail. |
+| TwinFresh manual-speed row | The B133 Vento guide explicitly lists parameter `0x0044`; the TwinFresh Style PDFs reference manual speed mode `255` using parameter 68 but omit a separate `0x0044` table row. | TwinFresh-family devices and the Home Assistant silent manual-speed path use the manual-speed row successfully. | Keep `0x0044` in the shared `vento` profile because both document the manual-speed mode path, even though one PDF omits the row from its table. |
+| Breezy/Freshpoint standard sensor rows | Freshpoint product documents describe relative humidity and four built-in temperature sensors on standard and Pro units; only the Pro package adds tVOC/CO2eq air-quality sensing. | Issue #74 reports a Freshpoint 160 whose humidity, built-in temperature, CO2, VOC, recovery-efficiency, and schedule entities stay unknown while the fan still works. Earlier reports also showed optional rows omitted or explicitly rejected. | Keep `0x0001`, `0x0002`, and `0x0044` as Breezy/Freshpoint availability rows. Missing or unsupported non-critical sensor/feature rows are retried, backed off, cleared, and hidden when permanently unsupported instead of flickering the fan entity unavailable. |
+| Explicit `0xFD` unsupported markers | Source tables list readable rows, but the protocol can still answer an individual row with an unsupported marker. | Some firmware acknowledges a request with `0xFD` instead of returning fresh data. | Treat `0xFD` as "controller answered, but this row has no fresh value." Required rows still fail; optional rows become unavailable and may be removed from later automatic polls. |
+| Weekly schedule rows | Vento/TwinFresh and Breezy/Freshpoint tables document `0x0072` (`weekly_schedule_state`) and `0x0077` (`weekly_schedule_setup`). | Some variants do not answer schedule rows during setup/reload, and probing all schedule records can cause delays. | Load the full schedule cache only after `0x0072` reports a known `on`/`off` state. If `0x0072` is unavailable, keep the fan available and leave schedule entities unavailable. |
+| Packet completeness | The guides impose a 256-byte packet limit, while older integration versions could accept a valid but partial response as a complete refresh. | Firmware can return a valid response that omits requested rows without using `0xFD`. | Split full polls into protocol-safe chunks, verify returned parameter ids, retry omitted rows individually, and distinguish required rows from optional rows. |
+| Shared parameter numbers across families | Several manuals reuse the same parameter ids for different device families. | `0x0002`, `0x0014`, `0x0068`, `0x0401`, and other rows do not always have the same semantics between Vento, extract-fan, Breezy/Freshpoint, Freshbox, and Arc profiles. | Keep profile-specific parameter maps instead of treating one PDF as a universal superset. |
+| A21 / Modbus controllers | VENTS A21 documents Modbus TCP/RTU and a controller identity at input register `37`. | A21 does not publish a BGCP `0x00B9` unit type and does not use the UDP BGCP parameter map. | Implement A21 as a separate Modbus transport. Do not infer BGCP compatibility from physical/OEM similarity alone. |
+| Unit-type parsing | The PDFs list unit-type values read from BGCP parameter `0x00B9`. | This parser stores those two response bytes as parser keys such as `0x0300`, and no reviewed PDF documents device type `7` / parser key `0x0700`. | Keep the byte-swapped parser keys documented next to the PDF values. Rows such as `0x0007` are parameters, not unit-type values. |
+| Vento-family `0x0306` | The Vento/TwinFresh schedule table uses schedule speed values. | A response such as `0x0306=03` can be confused with an unrelated beeper/status row if the wrong family table is applied. | Treat `0x0306` as `schedule_speed` for the Vento-family profile; Breezy/Freshpoint has its own beeper row at `0x0401`. |
+
+These differences do not currently prove that the PDFs are being read upside
+down. They show that the PDFs describe the broad protocol surface, while real
+controllers and firmware variants may omit, reject, or defer documented rows.
+The integration should therefore use documented maps for entity discovery and
+profile selection, but use observed stable control rows for coordinator
+availability.
+
 Cross-brand and candidate OEM research sources:
 
 - [ECONOPRIME DF 270 Connect product page](https://www.econology.fr/df-270-connect-econoprime-vmc-double-flux.html)

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -781,8 +781,6 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertEqual(
             required,
             {
-                0x0001,
-                0x0002,
                 0x0044,
             },
         )
@@ -927,8 +925,38 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertLessEqual(unsupported_optional, fan.last_missing_optional_params)
         self.assertLessEqual(unsupported_optional, fan.last_unsupported_params)
 
-    def test_vento_update_fails_when_core_poll_param_is_unsupported(self):
-        for unsupported_param in (0x0001, 0x0002, 0x0044):
+    def test_vento_update_allows_issue76_missing_state_and_speed_rows(self):
+        fan = Fan("192.0.2.1")
+        missing_optional = {0x0001, 0x0002}
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            if len(param) > 4:
+                fan._last_response_param_ids = requested - missing_optional
+                return True
+            param_id = int(param, 16)
+            if param_id in missing_optional:
+                return False
+            fan._last_response_param_ids = {param_id}
+            return True
+
+        fan.send_command = send_command
+
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("required availability parameters: 0x0044", messages)
+        self.assertIn("optional unavailable parameters: 0x0001, 0x0002", messages)
+        self.assertIn("missing required parameters: none", messages)
+        self.assertIn("result: available", messages)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertLessEqual(missing_optional, fan.last_missing_optional_params)
+
+    def test_vento_update_fails_when_required_poll_param_is_unsupported(self):
+        for unsupported_param in (0x0044,):
             with self.subTest(unsupported=f"0x{unsupported_param:04X}"):
                 fan = Fan("192.0.2.1")
 
@@ -947,10 +975,8 @@ class PacketBuilderTest(unittest.TestCase):
                 self.assertEqual(fan.last_missing_required_params, {unsupported_param})
                 self.assertEqual(fan.last_unsupported_params, {unsupported_param})
 
-    def test_vento_full_and_quick_polls_fail_when_core_rows_are_absent(self):
+    def test_vento_full_and_quick_polls_fail_when_required_rows_are_absent(self):
         for method_name, missing_param in (
-            ("update", 0x0001),
-            ("update", 0x0002),
             ("update", 0x0044),
             ("quick_update", 0x0044),
         ):


### PR DESCRIPTION
## What changed

- Treat `0x0044` (`man_speed`) as the Vento/TwinFresh full-poll availability row.
- Stop requiring `0x0001` (`state`) and `0x0002` (`speed`) for Vento/TwinFresh coordinator availability when the device otherwise answers a healthy profile poll.
- Keep the existing Breezy/Freshpoint behavior from merged `gody01/ecovent_v2#75` for `gody01/ecovent_v2#74`: core fan rows remain required, while unsupported optional rows are backed off/cleared instead of making the fan unavailable.
- Document the current differences between the PDF parameter maps and observed firmware behavior in `protocol.md`.

## Why

`gody01/ecovent_v2#76` shows Vento/TwinFresh devices returning valid full-poll rows, including `0x0044`, while omitting `0x0001` and `0x0002`. The previous profile treated those omitted rows as fatal, so the coordinator reported incomplete responses even though the quick-poll/control path already works through `0x0044`.

The spec notes are not treating the PDFs as wrong. They record that the PDFs are useful parameter-map evidence, but real controller and firmware variants may omit or reject documented rows. Availability should therefore be based on stable observed control rows for each profile, not on every row that appears in a family PDF.

Fixes `gody01/ecovent_v2#76`.
Refs `gody01/ecovent_v2#74`.

## Validation

- `python3 -m pytest -q` -> `198 passed, 154 subtests passed`
- `python3 -m pytest -q tests/test_ecovent_packets.py tests/test_ecovent_profiles.py` -> `69 passed, 22 subtests passed`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `ruff check custom_components/ecovent_v2 tests`
- `git diff --check`
- Hardware protocol smoke against a VENTS TwinFresh Style Wi-Fi firmware `0.3`: `init_device`, `quick_update`, and full `update` returned true with no missing required, missing optional, or unsupported parameter rows.
- Runtime Home Assistant validation on the same VENTS TwinFresh Style Wi-Fi firmware `0.3`: after updating the config entry to the device's active LAN address, `fan.living_room_vent` loaded as `on`, the IP sensor reported the active address, airflow reported `air_supply`, humidity reported `72%`, filter remaining reported `50%`, and the recent EcoVent log tail was clean.
