### PR TITLE
Close poll profile reports and document A50 option rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,3 +524,10 @@ Version 1.2.21
 * Raise a Home Assistant Repairs warning for hardware/profile mismatches, with a
   prefilled GitHub issue link and config-entry diagnostics carrying the detected
   profile, unit type, firmware, and unsupported register details.
+
+Version 1.2.23
+* Add regression coverage and protocol notes for Blauberg Vento Expert A50-1 W
+  V.2 firmware `0.4` units that reject optional preset-speed and filter-timer
+  rows. The integration keeps the Vento/TwinFresh profile map, but unsupported
+  optional rows no longer imply that the fan poll is unavailable, and this
+  known A50 variant no longer opens a hardware/profile mismatch Repair.

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -35,6 +35,7 @@ except ImportError:
 from .const import CONF_AUTO_CLOCK_SYNC, CONF_SILENT_MODE, DOMAIN
 from .protocol_diagnostics import (
     hardware_profile_mismatch_issue_url,
+    reportable_hardware_profile_mismatch_param_ids,
     unsupported_optional_poll_parameter_summary,
 )
 
@@ -149,7 +150,7 @@ class EcoVentCoordinator(DataUpdateCoordinator):
 
     def _update_hardware_profile_mismatch_repair_issue(self) -> None:
         """Show a Repairs issue when this hardware omits profile-declared rows."""
-        unsupported = self._fan.unsupported_optional_poll_parameter_ids()
+        unsupported = reportable_hardware_profile_mismatch_param_ids(self._fan)
         if unsupported == self._reported_unsupported_optional_params:
             return
 
@@ -171,8 +172,10 @@ class EcoVentCoordinator(DataUpdateCoordinator):
             )
             return
 
-        unsupported_params = unsupported_optional_poll_parameter_summary(self._fan)
-        issue_url = hardware_profile_mismatch_issue_url(self._fan)
+        unsupported_params = unsupported_optional_poll_parameter_summary(
+            self._fan, unsupported
+        )
+        issue_url = hardware_profile_mismatch_issue_url(self._fan, unsupported)
         ir.async_create_issue(
             self.hass,
             DOMAIN,

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -2,7 +2,7 @@
 
 import logging
 
-__version__ = "loc_1.2.20"
+__version__ = "loc_1.2.23"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.22",
+  "version": "1.2.23",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/protocol_diagnostics.py
+++ b/custom_components/ecovent_v2/protocol_diagnostics.py
@@ -6,32 +6,57 @@ from urllib.parse import urlencode
 
 GITHUB_NEW_ISSUE_URL = "https://github.com/gody01/ecovent_v2/issues/new"
 
+_KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS = {
+    # Some Blauberg Vento Expert A50-1 W V.2 firmware 0.4 devices explicitly
+    # reject these optional preset-speed/filter-timer rows. Keep hiding the
+    # generated entities, but do not ask users to file another mismatch report
+    # when these are the only unsupported optional Vento rows.
+    "vento": frozenset({0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F, 0x0063}),
+}
+
 
 def _format_param_id(param_id: int) -> str:
     return f"0x{param_id:04X}"
 
 
-def unsupported_optional_poll_parameter_details(fan) -> tuple[dict[str, str], ...]:
+def reportable_hardware_profile_mismatch_param_ids(fan) -> frozenset[int]:
+    """Return unsupported optional rows that still need a hardware report."""
+    unsupported = fan.unsupported_optional_poll_parameter_ids()
+    known_variant = _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS.get(
+        fan.profile_key, frozenset()
+    )
+    return frozenset(unsupported - known_variant)
+
+
+def unsupported_optional_poll_parameter_details(
+    fan, param_ids: frozenset[int] | None = None
+) -> tuple[dict[str, str], ...]:
     """Return public-safe details about hardware-rejected optional poll rows."""
     details = []
-    for param_id in sorted(fan.unsupported_optional_poll_parameter_ids()):
+    if param_ids is None:
+        param_ids = fan.unsupported_optional_poll_parameter_ids()
+    for param_id in sorted(param_ids):
         definition = fan.params.get(param_id)
         name = definition[0] if definition is not None else "unknown"
         details.append({"id": _format_param_id(param_id), "name": name})
     return tuple(details)
 
 
-def unsupported_optional_poll_parameter_summary(fan) -> str:
+def unsupported_optional_poll_parameter_summary(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Return a compact human-readable unsupported row summary."""
     return ", ".join(
         f"{detail['id']} ({detail['name']})"
-        for detail in unsupported_optional_poll_parameter_details(fan)
+        for detail in unsupported_optional_poll_parameter_details(fan, param_ids)
     )
 
 
-def hardware_profile_mismatch_issue_body(fan) -> str:
+def hardware_profile_mismatch_issue_body(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Build a prefilled GitHub issue body for live hardware/profile mismatches."""
-    unsupported = unsupported_optional_poll_parameter_details(fan)
+    unsupported = unsupported_optional_poll_parameter_details(fan, param_ids)
     unsupported_rows = "\n".join(
         f"- `{detail['id']}` `{detail['name']}`" for detail in unsupported
     )
@@ -72,10 +97,14 @@ def hardware_profile_mismatch_issue_body(fan) -> str:
     )
 
 
-def hardware_profile_mismatch_issue_url(fan) -> str:
+def hardware_profile_mismatch_issue_url(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Return a GitHub new-issue URL with detected mismatch details filled in."""
     title = f"Hardware profile mismatch for {fan.unit_type or fan.profile_key}"
     return (
         f"{GITHUB_NEW_ISSUE_URL}?"
-        + urlencode({"title": title, "body": hardware_profile_mismatch_issue_body(fan)})
+        + urlencode(
+            {"title": title, "body": hardware_profile_mismatch_issue_body(fan, param_ids)}
+        )
     )

--- a/docs/protocol-fix-howto.md
+++ b/docs/protocol-fix-howto.md
@@ -1,0 +1,83 @@
+# Protocol Fix How-To
+
+Use this guide when fixing EcoVent reports about incomplete protocol responses,
+unsupported registers, generated entities stuck as unavailable/unknown, noisy
+writes, or hardware/profile mismatch Repairs.
+
+## Triage
+
+- Start from the issue log and the reporter's exact hardware tuple: brand,
+  marketing name, unit type, firmware string, profile, host path, and the
+  requested/received/missing/unsupported register sets.
+- Check the last related PRs before editing. Regressions often sit around
+  `protocol_profiles.py`, `fan_protocol.py`, `fan_capabilities.py`,
+  `protocol_diagnostics.py`, `coordinator.py`, and the entity registry helpers.
+- Separate liveness proof from nice-to-have data. A reachable fan should not go
+  unavailable just because optional sensors, schedule rows, filter timers, or
+  Pro-only feature rows are absent.
+- Keep direct targeted reads strict. Optional-row tolerance is for automatic
+  poll availability, not for pretending an explicit requested value exists.
+- When a row is missing or returns `0xFD`, record whether it is required,
+  optional-unavailable, unsupported, retried, backed off, or skipped. Tests
+  should assert these sets, not just the final boolean.
+- After fixing availability for unsupported optional rows, check the second
+  user-facing surface: Repairs/diagnostics. Known firmware variants should not
+  keep suggesting a new hardware/profile mismatch report for rows that are now
+  documented as benign, while unknown extra unsupported rows should still keep
+  the prefilled report path.
+
+## Protocol And Documentation
+
+- Treat manufacturer PDFs as parameter-map evidence, not as complete firmware
+  contracts. Real devices in the Vento/TwinFresh, Breezy/Freshpoint, and
+  Freshbox/Micra families can omit or reject documented rows.
+- Before calling a PDF wrong, first check whether the issue is a variant split:
+  standard vs Pro sensor packages, firmware `0.4` behavior, A21 Modbus vs BGCP,
+  Vento-family rows shared across brands, or a row documented for one profile
+  but observed working on another.
+- Update `protocol.md` whenever a fix depends on this distinction. Capture the
+  PDF expectation, observed device behavior, and integration policy in the
+  "Spec and observed firmware differences" table.
+- Do not add a runtime map solely from a catalogue or relabel relationship.
+  Runtime mappings need either source documentation for that protocol or a
+  reporter/live-device observation.
+
+## Home Assistant Behavior
+
+- Startup, reload, and discovery should be read-only unless a user explicitly
+  calls a service or the code is batching into a write that would already happen.
+- Avoid surprise beeps. For RTC sync, silent/manual speed, presets, and airflow
+  mode changes, reread state first and skip unchanged or unsafe writes.
+- Preserve entity registry identity. Migrations should keep customized entity
+  IDs and names, migrate known legacy unique IDs, and hide unsupported generated
+  entities instead of deleting them.
+- Hiding unsupported entities is not the same as suppressing a Repair. When a
+  hardware report becomes a known variant, update `protocol_diagnostics.py` and
+  `coordinator.py` so the Repair is based only on still-reportable rows, and add
+  tests for both the no-Repair known set and a different unsupported row that
+  still asks for maintainer data.
+- Frontend assets must not block Home Assistant startup. File hashing or reads
+  that can touch disk during setup belong in executor work, and route changes
+  need a browser or HTTP smoke when practical.
+
+## PR Checklist
+
+- If the PR is meant to resolve bug reports, add explicit closing references
+  before publishing. Put each one on its own line as `Closes #NN` or
+  `Closes owner/repo#NN`, and do not wrap the reference in backticks. After
+  creating or editing the PR, read back GitHub's `closingIssuesReferences`;
+  issue text that merely says "Fixes ..." or `Refs ...` is not done until GitHub
+  shows the report under the PR's closing references.
+- Keep version markers aligned in the same commit: `manifest.json`,
+  `custom_components/ecovent_v2/ecoventv2.py`, and the README changelog section.
+- Prefer focused PRs. If one PR carries closure for already-merged follow-ups,
+  say that plainly in the PR body and keep the code delta limited to the missing
+  regression/docs/release bookkeeping.
+- Public PR text should distinguish validation that actually ran from validation
+  that still needs reporter hardware. Never claim a live smoke test from a fake
+  protocol test.
+- Standard validation for Python-only fixes:
+  `PYTHONPATH=tests pytest -q`, targeted regression tests, `ruff check
+  custom_components/ecovent_v2 tests`, `python3 -m compileall -q
+  custom_components/ecovent_v2 tests`, JSON parse checks for changed metadata or
+  translations, and `git diff --check`.

--- a/protocol.md
+++ b/protocol.md
@@ -16,6 +16,7 @@ Source PDFs:
 
 - [Connection to a "Smart Home" system - connection guide (B133-4-1EN-02)](https://blaubergventilatoren.net/download/vento-inhome-manual-14758.pdf)
 - [Smart Wi-Fi connection guide B168-1EN-01](https://blaubergventilatoren.net/download/smart-wi-fi-manual-8533.pdf)
+- [Vento Expert A50-1 W V.2 manual 7521](https://blaubergventilatoren.net/download/vento-expert-a50-1-s10-w-v2-manual-7521.pdf)
 - [TwinFresh Style Wi-Fi manual 19765](https://ventilation-system.com/download/twinfresh-style-wi-fi-manual-19765.pdf)
 - [TwinFresh Style Wi-Fi mini manual 19765](https://ventilation-system.com/download/twinfresh-style-wi-fi-mini-manual-19765.pdf)
 - [Breezy Eco manual 21433](https://ventilation-system.com/download/breezy-eco-manual-21433.pdf)
@@ -36,6 +37,7 @@ reports and earlier compatibility fixes show these differences:
 | Area | PDF / implementation expectation | Observed device behavior | Integration policy |
 | -- | -- | -- | -- |
 | Vento/TwinFresh availability rows | The Vento-family map documents `0x0001` (`state`), `0x0002` (`speed`), and, in the B133 Vento guide, `0x0044` (`man_speed`). | Issue #76 shows Vento Expert / TwinFresh Expert full polls returning many valid rows including `0x0044`, while `0x0001` and `0x0002` remain absent after individual retry. The maintainer also reported this on an original Vento 50 with firmware `0.4 2019-12-20`. | Treat `0x0044` as the full-poll Vento availability row, matching the existing quick-poll control proof. Missing `0x0001` / `0x0002` is logged and surfaced as unavailable data rather than making the coordinator fail. |
+| Vento Expert A50-1 W V.2 option rows | The Vento-family maps include preset-speed and filter-timer rows such as `0x003A` through `0x003F` and `0x0063`. | Issue #78 reports a Blauberg Vento Expert A50-1 W V.2 on firmware `0.4 2019-12-20` with no extra sensor modules where those rows are explicitly rejected. | Keep the rows in the Vento entity map because other Vento-family devices may support them, but treat their `0xFD` replies as unsupported optional data. Do not use those optional rows as proof that the device itself is unavailable. |
 | TwinFresh manual-speed row | The B133 Vento guide explicitly lists parameter `0x0044`; the TwinFresh Style PDFs reference manual speed mode `255` using parameter 68 but omit a separate `0x0044` table row. | TwinFresh-family devices and the Home Assistant silent manual-speed path use the manual-speed row successfully. | Keep `0x0044` in the shared `vento` profile because both document the manual-speed mode path, even though one PDF omits the row from its table. |
 | Breezy/Freshpoint standard sensor rows | Freshpoint product documents describe relative humidity and four built-in temperature sensors on standard and Pro units; only the Pro package adds tVOC/CO2eq air-quality sensing. | Issue #74 reports a Freshpoint 160 whose humidity, built-in temperature, CO2, VOC, recovery-efficiency, and schedule entities stay unknown while the fan still works. Earlier reports also showed optional rows omitted or explicitly rejected. | Keep `0x0001`, `0x0002`, and `0x0044` as Breezy/Freshpoint availability rows. Missing or unsupported non-critical sensor/feature rows are retried, backed off, cleared, and hidden when permanently unsupported instead of flickering the fan entity unavailable. |
 | Explicit `0xFD` unsupported markers | Source tables list readable rows, but the protocol can still answer an individual row with an unsupported marker. | Some firmware acknowledges a request with `0xFD` instead of returning fresh data. | Treat `0xFD` as "controller answered, but this row has no fresh value." Required rows still fail; optional rows become unavailable and may be removed from later automatic polls. |
@@ -52,6 +54,9 @@ controllers and firmware variants may omit, reject, or defer documented rows.
 The integration should therefore use documented maps for entity discovery and
 profile selection, but use observed stable control rows for coordinator
 availability.
+
+For practical maintainer steps when fixing these reports, see
+[`docs/protocol-fix-howto.md`](docs/protocol-fix-howto.md).
 
 Cross-brand and candidate OEM research sources:
 

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -925,6 +925,40 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertLessEqual(unsupported_optional, fan.last_missing_optional_params)
         self.assertLessEqual(unsupported_optional, fan.last_unsupported_params)
 
+    def test_vento_update_allows_issue78_unsupported_a50_optional_rows(self):
+        fan = Fan("192.0.2.1")
+        unsupported_optional = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        def send_command(func, param, value="", retries=10):
+            requested = {
+                int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+            }
+            fan._last_response_param_ids = requested - unsupported_optional
+            fan._last_unsupported_param_ids = requested & unsupported_optional
+            return True
+
+        fan.send_command = send_command
+
+        with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+            self.assertTrue(fan.update())
+
+        messages = "\n".join(logs.output)
+        self.assertIn("required availability parameters: 0x0044", messages)
+        self.assertIn("unsupported parameters: 0x003A", messages)
+        self.assertIn("missing required parameters: none", messages)
+        self.assertIn("result: available", messages)
+        self.assertEqual(fan.last_missing_required_params, set())
+        self.assertLessEqual(unsupported_optional, fan.last_missing_optional_params)
+        self.assertLessEqual(unsupported_optional, fan.last_unsupported_params)
+
     def test_vento_update_allows_issue76_missing_state_and_speed_rows(self):
         fan = Fan("192.0.2.1")
         missing_optional = {0x0001, 0x0002}

--- a/tests/test_ecovent_protocol_diagnostics.py
+++ b/tests/test_ecovent_protocol_diagnostics.py
@@ -8,6 +8,7 @@ from ecovent_test_helpers import Fan
 from protocol_diagnostics import (
     hardware_profile_mismatch_issue_body,
     hardware_profile_mismatch_issue_url,
+    reportable_hardware_profile_mismatch_param_ids,
     unsupported_optional_poll_parameter_details,
     unsupported_optional_poll_parameter_summary,
 )
@@ -51,3 +52,33 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
         self.assertEqual(parsed.path, "/gody01/ecovent_v2/issues/new")
         self.assertIn("Hardware profile mismatch", query["title"][0])
         self.assertIn("`0x0320` `voc`", query["body"][0])
+
+    def test_issue78_vento_a50_rows_do_not_request_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan._set_device_profile("vento")
+        fan._unsupported_optional_poll_params = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
+        )
+
+    def test_unknown_unsupported_rows_still_request_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan._set_device_profile("vento")
+        fan._unsupported_optional_poll_params = {0x003A, 0x0083}
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset({0x0083})
+        )
+        self.assertEqual(
+            unsupported_optional_poll_parameter_summary(fan, frozenset({0x0083})),
+            "0x0083 (alarm_status)",
+        )


### PR DESCRIPTION
## Summary

- Close the remaining open reports for the already-merged Breezy/Freshpoint and Vento/TwinFresh poll-profile fixes.
- Add regression coverage for Blauberg Vento Expert A50-1 W V.2 firmware `0.4` units that reject optional preset-speed and filter-timer rows while `0x0044` still proves the fan poll is available.
- Suppress the hardware/profile mismatch Repair for those now-known A50 option rows while keeping the report path for unknown unsupported rows.
- Record the A50 manual/report distinction in `protocol.md`, align the release markers to `1.2.23`, and add a developer how-to for future protocol fixes.

## Docs note

I do not see a standalone manual/PDF misread to undo here. The manuals remain useful parameter-map evidence, but the reports show firmware variants can omit or reject documented optional rows. The integration should keep the documented profile maps while basing availability on stable control rows and treating rejected optional rows as unavailable data.

Closes gody01/ecovent_v2#74
Closes gody01/ecovent_v2#76
Closes gody01/ecovent_v2#78

## Validation

- `PYTHONPATH=tests pytest -q`
- `PYTHONPATH=tests pytest -q tests/test_ecovent_packets.py`
- `ruff check custom_components/ecovent_v2 tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `python3 -m json.tool custom_components/ecovent_v2/manifest.json`
- `git diff --check`
- `codex review --base upstream/main`
