### PR TITLE
Fix Vento optional row reports

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,3 +524,14 @@ Version 1.2.21
 * Raise a Home Assistant Repairs warning for hardware/profile mismatches, with a
   prefilled GitHub issue link and config-entry diagnostics carrying the detected
   profile, unit type, firmware, and unsupported register details.
+
+Version 1.2.23
+* Add regression coverage and protocol notes for Blauberg Vento Expert A50-1 W
+  V.2 firmware `0.4` and Vento Expert DUO A30-1 S10 W V.2 firmware `0.7` units
+  that reject optional preset-speed and filter-timer rows. The integration
+  keeps the Vento/TwinFresh profile map, hides the unsupported generated
+  entities, and no longer opens a hardware/profile mismatch Repair when these
+  known unit-type variants reject only those optional rows.
+* Clarify hardware/profile mismatch Repairs and prefilled issue titles so mixed
+  installations report distinct model, firmware, and unsupported-register sets
+  separately instead of collapsing a device zoo into one ambiguous report.

--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -35,6 +35,7 @@ except ImportError:
 from .const import CONF_AUTO_CLOCK_SYNC, CONF_SILENT_MODE, DOMAIN
 from .protocol_diagnostics import (
     hardware_profile_mismatch_issue_url,
+    reportable_hardware_profile_mismatch_param_ids,
     unsupported_optional_poll_parameter_summary,
 )
 
@@ -149,7 +150,7 @@ class EcoVentCoordinator(DataUpdateCoordinator):
 
     def _update_hardware_profile_mismatch_repair_issue(self) -> None:
         """Show a Repairs issue when this hardware omits profile-declared rows."""
-        unsupported = self._fan.unsupported_optional_poll_parameter_ids()
+        unsupported = reportable_hardware_profile_mismatch_param_ids(self._fan)
         if unsupported == self._reported_unsupported_optional_params:
             return
 
@@ -171,8 +172,10 @@ class EcoVentCoordinator(DataUpdateCoordinator):
             )
             return
 
-        unsupported_params = unsupported_optional_poll_parameter_summary(self._fan)
-        issue_url = hardware_profile_mismatch_issue_url(self._fan)
+        unsupported_params = unsupported_optional_poll_parameter_summary(
+            self._fan, unsupported
+        )
+        issue_url = hardware_profile_mismatch_issue_url(self._fan, unsupported)
         ir.async_create_issue(
             self.hass,
             DOMAIN,

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -2,7 +2,7 @@
 
 import logging
 
-__version__ = "loc_1.2.20"
+__version__ = "loc_1.2.23"
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/ecovent_v2/manifest.json
+++ b/custom_components/ecovent_v2/manifest.json
@@ -2,7 +2,7 @@
   "domain": "ecovent_v2",
   "name": "Vento Eco Vent v 2.1",
   "codeowners": ["@gody01","@AndyNew2"],
-  "version": "1.2.22",
+  "version": "1.2.23",
   "config_flow": true,
   "documentation": "https://www.home-assistant.io/integrations/ecovent_v2",
   "issue_tracker": "https://github.com/gody01/ecovent_v2/issues",

--- a/custom_components/ecovent_v2/protocol_diagnostics.py
+++ b/custom_components/ecovent_v2/protocol_diagnostics.py
@@ -6,32 +6,64 @@ from urllib.parse import urlencode
 
 GITHUB_NEW_ISSUE_URL = "https://github.com/gody01/ecovent_v2/issues/new"
 
+_VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS = frozenset(
+    {0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F, 0x0063}
+)
+
+_KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS = {
+    # Blauberg VENTO Expert A50-1 W V.2 firmware 0.4 and VENTO Expert DUO
+    # A30-1 S10 W V.2 firmware 0.7 devices explicitly reject these optional
+    # preset-speed/filter-timer rows. Keep hiding the generated entities, but do
+    # not ask users to file another mismatch report when these are the only
+    # unsupported optional rows for the exact unit-type family.
+    ("vento", 0x0300): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
+    ("vento", 0x0400): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
+}
+
 
 def _format_param_id(param_id: int) -> str:
     return f"0x{param_id:04X}"
 
 
-def unsupported_optional_poll_parameter_details(fan) -> tuple[dict[str, str], ...]:
+def reportable_hardware_profile_mismatch_param_ids(fan) -> frozenset[int]:
+    """Return unsupported optional rows that still need a hardware report."""
+    unsupported = fan.unsupported_optional_poll_parameter_ids()
+    unit_type_id = getattr(fan, "_unit_type_id", None)
+    known_variant = _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS.get(
+        (fan.profile_key, unit_type_id), frozenset()
+    )
+    return frozenset(unsupported - known_variant)
+
+
+def unsupported_optional_poll_parameter_details(
+    fan, param_ids: frozenset[int] | None = None
+) -> tuple[dict[str, str], ...]:
     """Return public-safe details about hardware-rejected optional poll rows."""
     details = []
-    for param_id in sorted(fan.unsupported_optional_poll_parameter_ids()):
+    if param_ids is None:
+        param_ids = fan.unsupported_optional_poll_parameter_ids()
+    for param_id in sorted(param_ids):
         definition = fan.params.get(param_id)
         name = definition[0] if definition is not None else "unknown"
         details.append({"id": _format_param_id(param_id), "name": name})
     return tuple(details)
 
 
-def unsupported_optional_poll_parameter_summary(fan) -> str:
+def unsupported_optional_poll_parameter_summary(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Return a compact human-readable unsupported row summary."""
     return ", ".join(
         f"{detail['id']} ({detail['name']})"
-        for detail in unsupported_optional_poll_parameter_details(fan)
+        for detail in unsupported_optional_poll_parameter_details(fan, param_ids)
     )
 
 
-def hardware_profile_mismatch_issue_body(fan) -> str:
+def hardware_profile_mismatch_issue_body(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Build a prefilled GitHub issue body for live hardware/profile mismatches."""
-    unsupported = unsupported_optional_poll_parameter_details(fan)
+    unsupported = unsupported_optional_poll_parameter_details(fan, param_ids)
     unsupported_rows = "\n".join(
         f"- `{detail['id']}` `{detail['name']}`" for detail in unsupported
     )
@@ -47,6 +79,12 @@ def hardware_profile_mismatch_issue_body(fan) -> str:
             "",
             "EcoVent V2 detected that this device explicitly rejects optional "
             "registers that the current profile expects.",
+            "",
+            "This report is for this one EcoVent config entry. If several "
+            "devices show the same Repair, please open one report for each "
+            "distinct model, firmware, and unsupported-register set. Identical "
+            "devices with identical firmware and rejected rows can share one "
+            "report; note the device count below.",
             "",
             "Please add the exact marketing model, photos of the label, firmware "
             "version, and any extra hardware options installed.",
@@ -72,10 +110,20 @@ def hardware_profile_mismatch_issue_body(fan) -> str:
     )
 
 
-def hardware_profile_mismatch_issue_url(fan) -> str:
+def hardware_profile_mismatch_issue_url(
+    fan, param_ids: frozenset[int] | None = None
+) -> str:
     """Return a GitHub new-issue URL with detected mismatch details filled in."""
-    title = f"Hardware profile mismatch for {fan.unit_type or fan.profile_key}"
+    unit_type_id = getattr(fan, "_unit_type_id", None)
+    unit_type_text = f"0x{unit_type_id:04X}" if unit_type_id is not None else "unknown"
+    firmware = fan.firmware or "unknown firmware"
+    title = (
+        f"Hardware profile mismatch for {fan.unit_type or fan.profile_key} "
+        f"{unit_type_text} firmware {firmware}"
+    )
     return (
         f"{GITHUB_NEW_ISSUE_URL}?"
-        + urlencode({"title": title, "body": hardware_profile_mismatch_issue_body(fan)})
+        + urlencode(
+            {"title": title, "body": hardware_profile_mismatch_issue_body(fan, param_ids)}
+        )
     )

--- a/custom_components/ecovent_v2/strings.json
+++ b/custom_components/ecovent_v2/strings.json
@@ -99,7 +99,7 @@
     "issues": {
         "hardware_profile_mismatch": {
             "title": "EcoVent hardware profile mismatch detected",
-            "description": "{name} reports itself as {unit_type} using the {profile} profile, but it explicitly rejected optional registers expected by that profile: {unsupported_params}. EcoVent V2 hid matching generated entities and will keep the fan available. Use the learn-more link to open a GitHub issue prefilled with these detected details, then add the exact marketing model, label photos, firmware, and installed hardware options."
+            "description": "{name} reports itself as {unit_type} using the {profile} profile, but it explicitly rejected optional registers expected by that profile: {unsupported_params}. EcoVent V2 hid matching generated entities and will keep the fan available. This Repair is for this one EcoVent config entry; if several devices show it, report each distinct model, firmware, and rejected-register set separately. Use the learn-more link to open a GitHub issue prefilled with these detected details, then add the exact marketing model, label photos, firmware, installed hardware options, and whether identical devices share the same result."
         }
     },
     "entity": {

--- a/custom_components/ecovent_v2/translations/en.json
+++ b/custom_components/ecovent_v2/translations/en.json
@@ -93,7 +93,7 @@
     "issues": {
         "hardware_profile_mismatch": {
             "title": "EcoVent hardware profile mismatch detected",
-            "description": "{name} reports itself as {unit_type} using the {profile} profile, but it explicitly rejected optional registers expected by that profile: {unsupported_params}. EcoVent V2 hid matching generated entities and will keep the fan available. Use the learn-more link to open a GitHub issue prefilled with these detected details, then add the exact marketing model, label photos, firmware, and installed hardware options."
+            "description": "{name} reports itself as {unit_type} using the {profile} profile, but it explicitly rejected optional registers expected by that profile: {unsupported_params}. EcoVent V2 hid matching generated entities and will keep the fan available. This Repair is for this one EcoVent config entry; if several devices show it, report each distinct model, firmware, and rejected-register set separately. Use the learn-more link to open a GitHub issue prefilled with these detected details, then add the exact marketing model, label photos, firmware, installed hardware options, and whether identical devices share the same result."
         }
     },
     "entity": {

--- a/docs/protocol-fix-howto.md
+++ b/docs/protocol-fix-howto.md
@@ -1,0 +1,93 @@
+# Protocol Fix How-To
+
+Use this guide when fixing EcoVent reports about incomplete protocol responses,
+unsupported registers, generated entities stuck as unavailable/unknown, noisy
+writes, or hardware/profile mismatch Repairs.
+
+## Triage
+
+- Start from the issue log and the reporter's exact hardware tuple: brand,
+  marketing name, unit type, firmware string, profile, host path, and the
+  requested/received/missing/unsupported register sets.
+- Check the last related PRs before editing. Regressions often sit around
+  `protocol_profiles.py`, `fan_protocol.py`, `fan_capabilities.py`,
+  `protocol_diagnostics.py`, `coordinator.py`, and the entity registry helpers.
+- Separate liveness proof from nice-to-have data. A reachable fan should not go
+  unavailable just because optional sensors, schedule rows, filter timers, or
+  Pro-only feature rows are absent.
+- Keep direct targeted reads strict. Optional-row tolerance is for automatic
+  poll availability, not for pretending an explicit requested value exists.
+- When a row is missing or returns `0xFD`, record whether it is required,
+  optional-unavailable, unsupported, retried, backed off, or skipped. Tests
+  should assert these sets, not just the final boolean.
+- After fixing availability for unsupported optional rows, check the second
+  user-facing surface: Repairs/diagnostics. Known firmware variants should not
+  keep suggesting a new hardware/profile mismatch report for rows that are now
+  documented as benign, while unknown extra unsupported rows should still keep
+  the prefilled report path.
+
+## Protocol And Documentation
+
+- Treat manufacturer PDFs as parameter-map evidence, not as complete firmware
+  contracts. Real devices in the Vento/TwinFresh, Breezy/Freshpoint, and
+  Freshbox/Micra families can omit or reject documented rows.
+- Before calling a PDF wrong, first check whether the issue is a variant split:
+  standard vs Pro sensor packages, firmware `0.4` behavior, A21 Modbus vs BGCP,
+  Vento-family rows shared across brands, or a row documented for one profile
+  but observed working on another.
+- Update `protocol.md` whenever a fix depends on this distinction. Capture the
+  PDF expectation, observed device behavior, and integration policy in the
+  "Spec and observed firmware differences" table.
+- Do not add a runtime map solely from a catalogue or relabel relationship.
+  Runtime mappings need either source documentation for that protocol or a
+  reporter/live-device observation.
+
+## Home Assistant Behavior
+
+- Startup, reload, and discovery should be read-only unless a user explicitly
+  calls a service or the code is batching into a write that would already happen.
+- Avoid surprise beeps. For RTC sync, silent/manual speed, presets, and airflow
+  mode changes, reread state first and skip unchanged or unsafe writes.
+- Preserve entity registry identity. Migrations should keep customized entity
+  IDs and names, migrate known legacy unique IDs, and hide unsupported generated
+  entities instead of deleting them.
+- Hiding unsupported entities is not the same as suppressing a Repair. When a
+  hardware report becomes a known variant, update `protocol_diagnostics.py` and
+  `coordinator.py` so the Repair is based only on still-reportable rows, and add
+  tests for both the no-Repair known set and a different unsupported row that
+  still asks for maintainer data.
+- Frontend assets must not block Home Assistant startup. File hashing or reads
+  that can touch disk during setup belong in executor work, and route changes
+  need a browser or HTTP smoke when practical.
+
+## PR Checklist
+
+- If the PR is meant to resolve bug reports, add explicit closing references
+  before publishing. Put each one on its own line as `Closes #NN` or
+  `Closes owner/repo#NN`, and do not wrap the reference in backticks. After
+  creating or editing the PR, read back GitHub's `closingIssuesReferences`;
+  issue text that merely says "Fixes ..." or `Refs ...` is not done until GitHub
+  shows the report under the PR's closing references.
+- Before opening another PR for a new report, search the current open PRs for
+  the same issue numbers, protocol family, and touched files. If an open PR
+  already carries the same fix surface, update that PR or explicitly mark the
+  older one as superseded; do not leave two mergeable PRs for the same
+  availability or Repair behavior.
+- When a mismatch Repair asks for hardware reports, make it clear whether the
+  report is per config entry or per distinct model/firmware/register set. In a
+  mixed installation, identical devices with identical firmware and rejected
+  rows can share one issue, but different tuples should not be merged into one
+  ambiguous hardware report.
+- Keep version markers aligned in the same commit: `manifest.json`,
+  `custom_components/ecovent_v2/ecoventv2.py`, and the README changelog section.
+- Prefer focused PRs. If one PR carries closure for already-merged follow-ups,
+  say that plainly in the PR body and keep the code delta limited to the missing
+  regression/docs/release bookkeeping.
+- Public PR text should distinguish validation that actually ran from validation
+  that still needs reporter hardware. Never claim a live smoke test from a fake
+  protocol test.
+- Standard validation for Python-only fixes:
+  `PYTHONPATH=tests pytest -q`, targeted regression tests, `ruff check
+  custom_components/ecovent_v2 tests`, `python3 -m compileall -q
+  custom_components/ecovent_v2 tests`, JSON parse checks for changed metadata or
+  translations, and `git diff --check`.

--- a/protocol.md
+++ b/protocol.md
@@ -16,6 +16,8 @@ Source PDFs:
 
 - [Connection to a "Smart Home" system - connection guide (B133-4-1EN-02)](https://blaubergventilatoren.net/download/vento-inhome-manual-14758.pdf)
 - [Smart Wi-Fi connection guide B168-1EN-01](https://blaubergventilatoren.net/download/smart-wi-fi-manual-8533.pdf)
+- [Vento Expert A50-1 S10 W V.2 manual 7521](https://blaubergventilatoren.net/download/vento-expert-a50-1-s10-w-v2-manual-7521.pdf)
+- [Vento Expert DUO A30-1 S10 W V.2 manual 14758](https://blaubergventilatoren.net/download/vento-expert-duo-a30-1-s10-w-v2-manual-14758.pdf)
 - [TwinFresh Style Wi-Fi manual 19765](https://ventilation-system.com/download/twinfresh-style-wi-fi-manual-19765.pdf)
 - [TwinFresh Style Wi-Fi mini manual 19765](https://ventilation-system.com/download/twinfresh-style-wi-fi-mini-manual-19765.pdf)
 - [Breezy Eco manual 21433](https://ventilation-system.com/download/breezy-eco-manual-21433.pdf)
@@ -33,9 +35,19 @@ The manufacturer PDFs are treated as parameter-map evidence, not as a guarantee
 that every firmware answers every documented row in every poll. Current issue
 reports and earlier compatibility fixes show these differences:
 
+### Observed device behavior
+
+| Source | Unit type | Marketing model / family | Firmware | Observed behavior |
+| -- | -- | -- | -- | -- |
+| Issue #76 | `0x0300` | Blauberg VENTO Expert / VENTS TwinFresh Expert; reporter also noted original Vento 50 | `0.4 2019-12-20` on maintainer devices | Full polls can return valid rows including `0x0044` while `0x0001`/`0x0002` remain absent after retry; optional omissions must not make the fan unavailable. |
+| Issue #78 | `0x0300` | Blauberg Vento Expert A50-1 W V.2, no extra sensor modules | `0.4 2019-12-20` | Explicitly rejects optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
+| Issue #78 comment | `0x0300` | Blauberg VENTO Expert A50-1 S10 W V.2 | `0.8 2023-11-04`, `0.9 2024-07-08` | Reporter did not see the same hardware/profile mismatch, so the rows may still exist on newer A50 firmware. |
+| Issue #80 | `0x0400` | Blauberg VENTO Expert DUO A30-1 S10 W V.2 | `0.7 2021-10-04` | Explicitly rejects the same optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
+
 | Area | PDF / implementation expectation | Observed device behavior | Integration policy |
 | -- | -- | -- | -- |
 | Vento/TwinFresh availability rows | The Vento-family map documents `0x0001` (`state`), `0x0002` (`speed`), and, in the B133 Vento guide, `0x0044` (`man_speed`). | Issue #76 shows Vento Expert / TwinFresh Expert full polls returning many valid rows including `0x0044`, while `0x0001` and `0x0002` remain absent after individual retry. The maintainer also reported this on an original Vento 50 with firmware `0.4 2019-12-20`. | Treat `0x0044` as the full-poll Vento availability row, matching the existing quick-poll control proof. Missing `0x0001` / `0x0002` is logged and surfaced as unavailable data rather than making the coordinator fail. |
+| Vento Expert A50-1 / DUO A30 option rows | The Vento-family maps include preset-speed and filter-timer rows such as `0x003A` through `0x003F` and `0x0063`. | The observation table above shows the same rejected-row set on old A50 and DUO A30 firmware, but not on newer A50 firmware. | Keep the rows in the Vento entity map because other Vento-family devices and newer firmware may support them, but treat their `0xFD` replies as unsupported optional data for the known `0x0300`/`0x0400` variants. Do not use those optional rows as proof that the device itself is unavailable or as a repeated hardware/profile report by themselves. |
 | TwinFresh manual-speed row | The B133 Vento guide explicitly lists parameter `0x0044`; the TwinFresh Style PDFs reference manual speed mode `255` using parameter 68 but omit a separate `0x0044` table row. | TwinFresh-family devices and the Home Assistant silent manual-speed path use the manual-speed row successfully. | Keep `0x0044` in the shared `vento` profile because both document the manual-speed mode path, even though one PDF omits the row from its table. |
 | Breezy/Freshpoint standard sensor rows | Freshpoint product documents describe relative humidity and four built-in temperature sensors on standard and Pro units; only the Pro package adds tVOC/CO2eq air-quality sensing. | Issue #74 reports a Freshpoint 160 whose humidity, built-in temperature, CO2, VOC, recovery-efficiency, and schedule entities stay unknown while the fan still works. Earlier reports also showed optional rows omitted or explicitly rejected. | Keep `0x0001`, `0x0002`, and `0x0044` as Breezy/Freshpoint availability rows. Missing or unsupported non-critical sensor/feature rows are retried, backed off, cleared, and hidden when permanently unsupported instead of flickering the fan entity unavailable. |
 | Explicit `0xFD` unsupported markers | Source tables list readable rows, but the protocol can still answer an individual row with an unsupported marker. | Some firmware acknowledges a request with `0xFD` instead of returning fresh data. | Treat `0xFD` as "controller answered, but this row has no fresh value." Required rows still fail; optional rows become unavailable and may be removed from later automatic polls. |
@@ -52,6 +64,9 @@ controllers and firmware variants may omit, reject, or defer documented rows.
 The integration should therefore use documented maps for entity discovery and
 profile selection, but use observed stable control rows for coordinator
 availability.
+
+For practical maintainer steps when fixing these reports, see
+[`docs/protocol-fix-howto.md`](docs/protocol-fix-howto.md).
 
 Cross-brand and candidate OEM research sources:
 

--- a/tests/test_ecovent_metadata.py
+++ b/tests/test_ecovent_metadata.py
@@ -130,6 +130,10 @@ class ParseResponseTest(unittest.TestCase):
             Fan.device_models[0x0E00].name,
             "VENTS TwinFresh Style Wi-Fi",
         )
+        self.assertEqual(Fan.device_models[0x0300].profile_key, "vento")
+        self.assertEqual(Fan.device_models[0x0300].parser_key, 0x0300)
+        self.assertEqual(Fan.device_models[0x0400].profile_key, "vento")
+        self.assertEqual(Fan.device_models[0x0400].parser_key, 0x0400)
         style_names = {
             marketing.model for marketing in Fan.device_models[0x0E00].official_names
         }

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -925,6 +925,46 @@ class PacketBuilderTest(unittest.TestCase):
         self.assertLessEqual(unsupported_optional, fan.last_missing_optional_params)
         self.assertLessEqual(unsupported_optional, fan.last_unsupported_params)
 
+    def test_vento_update_allows_issue78_and_issue80_optional_rows(self):
+        unsupported_optional = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        for unit_type in ("0300", "0400"):
+            with self.subTest(unit_type=unit_type):
+                fan = Fan("192.0.2.1")
+                fan.unit_type = unit_type
+
+                def send_command(func, param, value="", retries=10):
+                    requested = {
+                        int(param[i : i + 4], 16) for i in range(0, len(param), 4)
+                    }
+                    fan._last_response_param_ids = requested - unsupported_optional
+                    fan._last_unsupported_param_ids = requested & unsupported_optional
+                    return True
+
+                fan.send_command = send_command
+
+                with self.assertLogs("fan_protocol", level="DEBUG") as logs:
+                    self.assertTrue(fan.update())
+
+                messages = "\n".join(logs.output)
+                self.assertIn("required availability parameters: 0x0044", messages)
+                self.assertIn("unsupported parameters: 0x003A", messages)
+                self.assertIn("missing required parameters: none", messages)
+                self.assertIn("result: available", messages)
+                self.assertEqual(fan.last_missing_required_params, set())
+                self.assertLessEqual(
+                    unsupported_optional, fan.last_missing_optional_params
+                )
+                self.assertLessEqual(unsupported_optional, fan.last_unsupported_params)
+
     def test_vento_update_allows_issue76_missing_state_and_speed_rows(self):
         fan = Fan("192.0.2.1")
         missing_optional = {0x0001, 0x0002}

--- a/tests/test_ecovent_protocol_diagnostics.py
+++ b/tests/test_ecovent_protocol_diagnostics.py
@@ -8,6 +8,7 @@ from ecovent_test_helpers import Fan
 from protocol_diagnostics import (
     hardware_profile_mismatch_issue_body,
     hardware_profile_mismatch_issue_url,
+    reportable_hardware_profile_mismatch_param_ids,
     unsupported_optional_poll_parameter_details,
     unsupported_optional_poll_parameter_summary,
 )
@@ -39,6 +40,8 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
         self.assertIn("Integration profile: `breezy`", body)
         self.assertIn("Firmware: `1.2.3`", body)
         self.assertIn("`0x0027` `co2`", body)
+        self.assertIn("this one EcoVent config entry", body)
+        self.assertIn("distinct model, firmware, and unsupported-register set", body)
         self.assertIn("Device id: `known`", body)
         self.assertNotIn("secret", body)
         self.assertNotIn("192.0.2.1", body)
@@ -50,4 +53,70 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
         self.assertEqual(parsed.netloc, "github.com")
         self.assertEqual(parsed.path, "/gody01/ecovent_v2/issues/new")
         self.assertIn("Hardware profile mismatch", query["title"][0])
+        self.assertIn("0x1400 firmware 1.2.3", query["title"][0])
         self.assertIn("`0x0320` `voc`", query["body"][0])
+
+    def test_issue78_vento_a50_rows_do_not_request_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0300"
+        fan._unsupported_optional_poll_params = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
+        )
+
+    def test_issue80_vento_duo_a30_rows_do_not_request_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0400"
+        fan._unsupported_optional_poll_params = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
+        )
+
+    def test_unknown_unit_type_still_requests_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan._set_device_profile("vento")
+        fan._unsupported_optional_poll_params = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+            0x0063,
+        }
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan),
+            frozenset({0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F, 0x0063}),
+        )
+
+    def test_unknown_extra_unsupported_rows_still_request_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0300"
+        fan._unsupported_optional_poll_params = {0x003A, 0x0083}
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset({0x0083})
+        )
+        self.assertEqual(
+            unsupported_optional_poll_parameter_summary(fan, frozenset({0x0083})),
+            "0x0083 (alarm_status)",
+        )


### PR DESCRIPTION
## Summary

- Keep Vento/TwinFresh `0x0300` and VENTO Expert DUO `0x0400` on the shared `vento` profile, because the reported devices still match that protocol family.
- Treat `0x0044` as the Vento full-poll availability row so missing `state`/`speed` rows do not make the fan unavailable.
- Hide generated entities for optional rows that the device explicitly rejects, while keeping the fan available.
- Suppress repeated hardware/profile mismatch Repairs only for known `0x0300`/`0x0400` variants rejecting `0x003A`..`0x003F` and `0x0063`; unknown unit types or extra unsupported rows still ask for a hardware report.
- Clarify mismatch Repairs and prefilled issue titles so mixed installations report each distinct model, firmware, and unsupported-register set separately.
- Document observed behavior for A50 firmware `0.4`, A50 firmware `0.8`/`0.9`, and DUO A30 firmware `0.7`.

## Device Notes

The reports show a firmware/device variant split, not a new protocol profile:

- Blauberg Vento Expert A50-1 W V.2 firmware `0.4 2019-12-20` rejects optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`.
- Blauberg VENTO Expert DUO A30-1 S10 W V.2 firmware `0.7 2021-10-04` rejects the same optional rows.
- Newer Blauberg VENTO Expert A50-1 S10 W V.2 firmware `0.8 2023-11-04` and `0.9 2024-07-08` did not show the same mismatch in the reporter's installation.

The integration therefore keeps the documented Vento-family rows for devices and firmware that support them, but treats these rejected rows as unsupported optional data for the known affected unit types.

## Validation

- `PYTHONPATH=tests pytest -q`
- `PYTHONPATH=tests pytest -q tests/test_ecovent_protocol_diagnostics.py tests/test_ecovent_packets.py tests/test_ecovent_metadata.py`
- `ruff check custom_components/ecovent_v2 tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- `python3 -m json.tool custom_components/ecovent_v2/manifest.json`
- `python3 -m json.tool custom_components/ecovent_v2/strings.json`
- `python3 -m json.tool custom_components/ecovent_v2/translations/en.json`
- `git diff --check`

Closes gody01/ecovent_v2#76
Closes gody01/ecovent_v2#78
Closes gody01/ecovent_v2#80
