### PR TITLE
test(ecovent): cover Vento firmware variant from issue 82

### DIFF
--- a/custom_components/ecovent_v2/protocol_diagnostics.py
+++ b/custom_components/ecovent_v2/protocol_diagnostics.py
@@ -6,9 +6,12 @@ from urllib.parse import urlencode
 
 GITHUB_NEW_ISSUE_URL = "https://github.com/gody01/ecovent_v2/issues/new"
 
-_VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS = frozenset(
-    {0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F, 0x0063}
+_VENTO_EXPERT_SPEED_OPTION_ROWS = frozenset(
+    {0x003A, 0x003B, 0x003C, 0x003D, 0x003E, 0x003F}
 )
+_VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS = _VENTO_EXPERT_SPEED_OPTION_ROWS | {
+    0x0063
+}
 
 _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS = {
     # Blauberg VENTO Expert A50-1 W V.2 firmware 0.4 and VENTO Expert DUO
@@ -16,8 +19,16 @@ _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS = {
     # preset-speed/filter-timer rows. Keep hiding the generated entities, but do
     # not ask users to file another mismatch report when these are the only
     # unsupported optional rows for the exact unit-type family.
-    ("vento", 0x0300): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
+    # Newer 0x0300 firmware can support the filter timer while still omitting
+    # the preset-speed rows; keep that row reportable unless the firmware is a
+    # known old variant that rejects the complete set.
+    ("vento", 0x0300): _VENTO_EXPERT_SPEED_OPTION_ROWS,
     ("vento", 0x0400): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
+}
+
+_KNOWN_VARIANT_FIRMWARE_UNSUPPORTED_OPTIONAL_PARAMS = {
+    ("vento", 0x0300, "0.4 2019-12-20"): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
+    ("vento", 0x0300, "0.7 2021-10-04"): _VENTO_EXPERT_SPEED_FILTER_OPTION_ROWS,
 }
 
 
@@ -29,8 +40,11 @@ def reportable_hardware_profile_mismatch_param_ids(fan) -> frozenset[int]:
     """Return unsupported optional rows that still need a hardware report."""
     unsupported = fan.unsupported_optional_poll_parameter_ids()
     unit_type_id = getattr(fan, "_unit_type_id", None)
-    known_variant = _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS.get(
-        (fan.profile_key, unit_type_id), frozenset()
+    known_variant = _KNOWN_VARIANT_FIRMWARE_UNSUPPORTED_OPTIONAL_PARAMS.get(
+        (fan.profile_key, unit_type_id, fan.firmware),
+        _KNOWN_VARIANT_UNSUPPORTED_OPTIONAL_PARAMS.get(
+            (fan.profile_key, unit_type_id), frozenset()
+        ),
     )
     return frozenset(unsupported - known_variant)
 

--- a/protocol.md
+++ b/protocol.md
@@ -42,6 +42,7 @@ reports and earlier compatibility fixes show these differences:
 | Issue #76 | `0x0300` | Blauberg VENTO Expert / VENTS TwinFresh Expert; reporter also noted original Vento 50 | `0.4 2019-12-20` on maintainer devices | Full polls can return valid rows including `0x0044` while `0x0001`/`0x0002` remain absent after retry; optional omissions must not make the fan unavailable. |
 | Issue #78 | `0x0300` | Blauberg Vento Expert A50-1 W V.2, no extra sensor modules | `0.4 2019-12-20` | Explicitly rejects optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
 | Issue #78 comment | `0x0300` | Blauberg VENTO Expert A50-1 S10 W V.2 | `0.8 2023-11-04`, `0.9 2024-07-08` | Reporter did not see the same hardware/profile mismatch, so the rows may still exist on newer A50 firmware. |
+| Issue #82 | `0x0300` | Blauberg VENTO Expert A50-1 S8 W V.3 with humidity sensor | `0.7 2021-10-04` | Explicitly rejects the same optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`; this is the same known Vento option-row variant as Issue #78. |
 | Issue #80 | `0x0400` | Blauberg VENTO Expert DUO A30-1 S10 W V.2 | `0.7 2021-10-04` | Explicitly rejects the same optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
 
 | Area | PDF / implementation expectation | Observed device behavior | Integration policy |

--- a/protocol.md
+++ b/protocol.md
@@ -43,6 +43,7 @@ reports and earlier compatibility fixes show these differences:
 | Issue #78 | `0x0300` | Blauberg Vento Expert A50-1 W V.2, no extra sensor modules | `0.4 2019-12-20` | Explicitly rejects optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
 | Issue #78 comment | `0x0300` | Blauberg VENTO Expert A50-1 S10 W V.2 | `0.8 2023-11-04`, `0.9 2024-07-08` | Reporter did not see the same hardware/profile mismatch, so the rows may still exist on newer A50 firmware. |
 | Issue #82 | `0x0300` | Blauberg VENTO Expert A50-1 S8 W V.3 with humidity sensor | `0.7 2021-10-04` | Explicitly rejects the same optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`; this is the same known Vento option-row variant as Issue #78. |
+| Issue #84 | `0x0300` | Blauberg VENTO Expert A50-1 S10 Pro / W V.2 | `0.7 2021-10-04`; another unit `0.9 2024-07-08` | Firmware `0.7` rejects preset-speed rows `0x003A`..`0x003F` and filter timer `0x0063`; firmware `0.9` rejects only the preset-speed rows and accepts `0x0063`. |
 | Issue #80 | `0x0400` | Blauberg VENTO Expert DUO A30-1 S10 W V.2 | `0.7 2021-10-04` | Explicitly rejects the same optional preset-speed rows `0x003A`..`0x003F` and filter-timer setpoint `0x0063`. |
 
 | Area | PDF / implementation expectation | Observed device behavior | Integration policy |

--- a/tests/test_ecovent_protocol_diagnostics.py
+++ b/tests/test_ecovent_protocol_diagnostics.py
@@ -59,6 +59,16 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
     def test_issue78_vento_a50_rows_do_not_request_mismatch_report(self):
         fan = Fan("192.0.2.1")
         fan.unit_type = "0300"
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
+        )
+
+    def test_issue82_vento_a50_humidity_variant_is_known(self):
+        """The reported 0x0300 firmware variant must not reopen a Repair."""
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0300"
+        fan._firmware = "0.7 2021-10-04"
         fan._unsupported_optional_poll_params = {
             0x003A,
             0x003B,

--- a/tests/test_ecovent_protocol_diagnostics.py
+++ b/tests/test_ecovent_protocol_diagnostics.py
@@ -83,6 +83,34 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
             reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
         )
 
+    def test_issue84_newer_vento_firmware_only_rejects_speed_rows(self):
+        """The newer reported firmware keeps the filter timer supported."""
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0300"
+        fan._firmware = "0.9 2024-07-08"
+        fan._unsupported_optional_poll_params = {
+            0x003A,
+            0x003B,
+            0x003C,
+            0x003D,
+            0x003E,
+            0x003F,
+        }
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset()
+        )
+
+    def test_unknown_filter_timer_rejection_still_requests_mismatch_report(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0300"
+        fan._firmware = "0.9 2024-07-08"
+        fan._unsupported_optional_poll_params = {0x0063}
+
+        self.assertEqual(
+            reportable_hardware_profile_mismatch_param_ids(fan), frozenset({0x0063})
+        )
+
     def test_issue80_vento_duo_a30_rows_do_not_request_mismatch_report(self):
         fan = Fan("192.0.2.1")
         fan.unit_type = "0400"


### PR DESCRIPTION
## Summary

- Add an explicit regression test for the `0x0300` Vento device reported in [gody01/ecovent_v2#82](https://github.com/gody01/ecovent_v2/issues/82) (firmware `0.7 2021-10-04`, humidity sensor, and rejected optional rows `0x003A`–`0x003F` plus `0x0063`).
- Cover [gody01/ecovent_v2#84](https://github.com/gody01/ecovent_v2/issues/84), including the firmware split where `0.9 2024-07-08` rejects the three-speed rows but accepts `0x0063`.
- Make the known Vento optional-row suppression firmware-aware so a filter-timer rejection on newer firmware still produces a useful mismatch report.
- Record the observed A50-1 S8 W V.3 and A50-1 S10 Pro / W V.2 variants in `protocol.md`.
- The runtime suppression for the already-known old variants is preserved from merged [gody01/ecovent_v2#81](https://github.com/gody01/ecovent_v2/pull/81); this follow-up makes both reports part of the maintained regression and protocol record.

## Validation

- `PYTHONPATH=tests pytest -q` — 206 passed, 156 subtests passed
- `ruff check custom_components/ecovent_v2 tests`
- `python3 -m compileall -q custom_components/ecovent_v2 tests`
- JSON parsing for manifest, strings, and English translations
- `git diff --check`

Current branch head: `9a79a9b1c6c446464320d9c0ff0e15df013a3a43`.

Closes gody01/ecovent_v2#82
Closes gody01/ecovent_v2#84
