### PR TITLE
Fix Home Assistant 2026.9 compatibility

### DIFF
--- a/custom_components/ecovent_v2/config_flow.py
+++ b/custom_components/ecovent_v2/config_flow.py
@@ -70,7 +70,6 @@ def _bgcp_schema(defaults: dict[str, Any] | None = None) -> vol.Schema:
         ): vol.All(
             str,
             vol.Length(max=8),
-            vol.Match(r"^[0-9A-Za-z]{0,8}\Z"),
         ),
         **_common_schema(defaults),
         # Legacy initial form default=False; reconfigure uses the saved value.

--- a/custom_components/ecovent_v2/sensor_specs.py
+++ b/custom_components/ecovent_v2/sensor_specs.py
@@ -287,6 +287,7 @@ SENSOR_SPECS = (
         "_air_quality_status",
         "Air quality status",
         "air_quality_status",
+        device_class=SensorDeviceClass.ENUM,
         entity_category=EntityCategory.DIAGNOSTIC,
         icon="mdi:air-filter",
         required_capabilities=("arc_environment",),

--- a/tests/test_a21_config_flow.py
+++ b/tests/test_a21_config_flow.py
@@ -60,7 +60,7 @@ class A21ConfigFlowTest(unittest.TestCase):
             )
         )
 
-    def test_bgcp_schema_rejects_values_the_wire_format_cannot_represent(self):
+    def test_bgcp_schema_uses_serializable_form_validators(self):
         function = _module_function(ast.parse(CONFIG_FLOW.read_text()), "_bgcp_schema")
         calls = {
             node.func.attr: {
@@ -72,19 +72,19 @@ class A21ConfigFlowTest(unittest.TestCase):
             and isinstance(node.func, ast.Attribute)
             and isinstance(node.func.value, ast.Name)
             and node.func.value.id == "vol"
-            and node.func.attr in {"Range", "Length", "Match"}
+            and node.func.attr in {"Range", "Length"}
         }
 
         self.assertEqual(calls["Range"], {"min": 1, "max": 65535})
         self.assertEqual(calls["Length"], {"max": 8})
-        match_call = next(
-            node
-            for node in ast.walk(function)
-            if isinstance(node, ast.Call)
-            and isinstance(node.func, ast.Attribute)
-            and node.func.attr == "Match"
+        self.assertFalse(
+            any(
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "Match"
+                for node in ast.walk(function)
+            )
         )
-        self.assertEqual(ast.literal_eval(match_call.args[0]), r"^[0-9A-Za-z]{0,8}\Z")
 
     def test_all_translations_label_every_new_transport_form(self):
         expected_steps = {"user", "bgcp", "modbus_tcp", "modbus_rtu", "reconfigure"}

--- a/tests/test_ecovent_protocol_diagnostics.py
+++ b/tests/test_ecovent_protocol_diagnostics.py
@@ -110,7 +110,7 @@ class ProtocolDiagnosticsTest(unittest.TestCase):
 
         body = hardware_profile_mismatch_issue_body(fan)
         self.assertIn("Integration profile: `breezy`", body)
-        self.assertIn("EcoVent V2 integration version: `1.2.25`", body)
+        self.assertIn("EcoVent V2 integration version: `1.2.26`", body)
         self.assertIn("Firmware: `1.2.3`", body)
         self.assertIn("`0x0027` `co2`", body)
         self.assertIn("this one EcoVent config entry", body)

--- a/tests/test_issue35_regressions.py
+++ b/tests/test_issue35_regressions.py
@@ -1095,6 +1095,29 @@ class Issue35RegressionTest(unittest.TestCase):
             },
         )
 
+    def test_arc_air_quality_status_sensor_is_enum(self):
+        tree = _tree(SENSOR_SPECS_PATH)
+        matching_specs = []
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Call):
+                continue
+            if not isinstance(node.func, ast.Name) or node.func.id != "SensorSpec":
+                continue
+            if not node.args or not isinstance(node.args[0], ast.Constant):
+                continue
+            if node.args[0].value != "_air_quality_status":
+                continue
+            keywords = {keyword.arg: keyword.value for keyword in node.keywords}
+            capabilities = ast.literal_eval(keywords["required_capabilities"])
+            if capabilities == ("arc_environment",):
+                matching_specs.append(keywords)
+
+        self.assertEqual(len(matching_specs), 1)
+        self.assertEqual(
+            ast.unparse(matching_specs[0]["device_class"]),
+            "SensorDeviceClass.ENUM",
+        )
+
     def test_preset_translations_group_boost_modes(self):
         translation_paths = [STRINGS_PATH, *TRANSLATIONS_PATH.glob("*.json")]
 


### PR DESCRIPTION
## Summary

- Keep the BGCP setup and reconfigure forms renderable on Home Assistant
  2026.9 by removing the `vol.Match` validator that the form schema serializer
  cannot serialize. The existing eight-character limit remains in place.
- Mark the ARC environment air-quality status sensor as an enum so its options
  satisfy Home Assistant's sensor requirements.
- Update the protocol-diagnostics version assertion left behind by the 1.2.26
  version bump.

## Validation

- Verified both integration fixes on Home Assistant 2026.9.0 with EcoVent V2
  1.2.26.
- `uv run --with pytest pytest -q`
- 389 tests and 300 subtests passed.
