### PR TITLE
Fix TwinFresh filter countdown recovery and schedule retry loop

### DIFF
--- a/custom_components/ecovent_v2/coordinator.py
+++ b/custom_components/ecovent_v2/coordinator.py
@@ -249,9 +249,11 @@ class EcoVentCoordinator(DataUpdateCoordinator):
         if not self._fan.supports_parameter("weekly_schedule_setup"):
             return self.updateCounter % 10 == 0
 
-        return not self._weekly_schedule or (
-            state == "on" and self.updateCounter % 10 == 0
+        complete_week = all(
+            set(self._weekly_schedule.get(day, ())) == {1, 2, 3, 4}
+            for day in range(1, 8)
         )
+        return self.updateCounter % 10 == 0 and (not complete_week or state == "on")
 
     def _load_schedule_week(self) -> None:
         """Read and cache the full weekly schedule from the device."""
@@ -264,8 +266,8 @@ class EcoVentCoordinator(DataUpdateCoordinator):
             try:
                 records = self._fan.read_weekly_schedule_day(day)
             except OSError as err:
-                _LOGGER.warning(
-                    "EcoVentCoordinator: preserving cached schedule for %s day %s "
+                _LOGGER.debug(
+                    "EcoVentCoordinator: schedule read failed for %s day %s "
                     "after a read error: %s",
                     self._fan.name,
                     day,
@@ -273,19 +275,28 @@ class EcoVentCoordinator(DataUpdateCoordinator):
                 )
                 continue
             if not records or set(records) != {1, 2, 3, 4}:
-                _LOGGER.warning(
-                    "EcoVentCoordinator: preserving cached schedule for %s day %s "
-                    "after an incomplete read (%s/4 periods)",
+                received_periods = sorted(records or {})
+                missing_periods = sorted(set(range(1, 5)) - set(received_periods))
+                cache_action = (
+                    "preserving cached schedule"
+                    if day in self._weekly_schedule
+                    else "leaving schedule unavailable"
+                )
+                _LOGGER.debug(
+                    "EcoVentCoordinator: %s for %s day %s after an incomplete "
+                    "read; received periods %s, missing periods %s",
+                    cache_action,
                     self._fan.name,
                     day,
-                    len(records or {}),
+                    received_periods or "none",
+                    missing_periods,
                 )
                 continue
             try:
                 validate_schedule_day([records[period] for period in range(1, 5)])
             except ValueError as err:
-                _LOGGER.warning(
-                    "EcoVentCoordinator: preserving cached schedule for %s day %s "
+                _LOGGER.debug(
+                    "EcoVentCoordinator: invalid schedule readback for %s day %s "
                     "after invalid readback: %s",
                     self._fan.name,
                     day,

--- a/custom_components/ecovent_v2/ecoventv2.py
+++ b/custom_components/ecovent_v2/ecoventv2.py
@@ -315,6 +315,7 @@ class Fan(
         self._bulk_read_reprobe_countdown = 0
         self._last_response_param_ids = None
         self._last_raw_response_param_ids = None
+        self._last_invalid_response_param_ids = None
         self._last_response_device_id = None
         self._unsupported_optional_poll_params = set()
         self.audible_write_command_count = 0

--- a/custom_components/ecovent_v2/fan_protocol.py
+++ b/custom_components/ecovent_v2/fan_protocol.py
@@ -17,6 +17,7 @@ BULK_READ_REPROBE_READS = 10
 VENTO_SOFT_MISS_CONTROL_PARAMS = frozenset({0x0001, 0x0002, 0x0044})
 PRESERVE_ON_SOFT_MISS_PARAMS = frozenset(
     {
+        0x0064,  # filter_timer_countdown
         0x007C,  # device_search
         0x0086,  # firmware
         0x009C,  # wifi_assigned_ip
@@ -429,6 +430,7 @@ class FanProtocolMixin:
             i = i + 1
             self._last_response_param_ids = None
             self._last_raw_response_param_ids = None
+            self._last_invalid_response_param_ids = None
             self._last_response_param_values = None
             self._last_unsupported_param_ids = None
             if self.send(data):
@@ -457,14 +459,26 @@ class FanProtocolMixin:
                         decoded_read_ids = self._store_staged_response_params(
                             requested_read_ids, record_unknown=False
                         )
-                        # An answered but undecodable control row is not silence.
+                        # An answered but undecodable row is not silence. Keep this
+                        # transaction fact for both direct and bulk-read callers.
                         invalid_read_ids = (
                             requested_read_ids
                             & set(self._last_raw_response_param_ids or ())
                         ) - decoded_read_ids
+                        self._last_invalid_response_param_ids = frozenset(
+                            invalid_read_ids
+                        )
                         for param_id in invalid_read_ids:
-                            if self._is_vento_soft_miss_control(param_id):
-                                self._mark_param_unavailable(param_id, invalid=True)
+                            # Preserve rows need an affirmative clear because a
+                            # soft omission normally keeps their cached value.
+                            # Other rows retain their established read handling.
+                            if (
+                                param_id in PRESERVE_ON_SOFT_MISS_PARAMS
+                                or self._is_vento_soft_miss_control(param_id)
+                            ):
+                                self._mark_param_unavailable(
+                                    param_id, invalid=True
+                                )
                         read_confirmed = bool(
                             requested_read_ids
                             & (decoded_read_ids | set(unsupported_ids))
@@ -611,7 +625,7 @@ class FanProtocolMixin:
 
     def _mark_param_unavailable(self, param_id, *, unsupported=False, invalid=False):
         """Retain soft-missing controls/identity, but clear explicitly rejected data."""
-        if param_id in PRESERVE_ON_SOFT_MISS_PARAMS:
+        if param_id in PRESERVE_ON_SOFT_MISS_PARAMS and not (unsupported or invalid):
             return
         if not (unsupported or invalid) and self._is_vento_soft_miss_control(param_id):
             definition = self.params[param_id]
@@ -738,17 +752,21 @@ class FanProtocolMixin:
             )
             try_bulk_read = self._bulk_read_reprobe_countdown == 0
 
-        def mark_unavailable(param_id, *, unsupported=False):
+        def mark_unavailable(param_id, *, unsupported=False, invalid=False):
             nonlocal complete
             if param_id in required_param_ids:
                 if unsupported or self._is_vento_soft_miss_control(param_id):
-                    self._mark_param_unavailable(param_id, unsupported=unsupported)
+                    self._mark_param_unavailable(
+                        param_id, unsupported=unsupported, invalid=invalid
+                    )
                 complete = False
                 missing_required_params.add(param_id)
                 return
 
             missing_optional_params.add(param_id)
-            self._mark_param_unavailable(param_id, unsupported=unsupported)
+            self._mark_param_unavailable(
+                param_id, unsupported=unsupported, invalid=invalid
+            )
             if unsupported or not self._is_vento_soft_miss_control(param_id):
                 self._delay_optional_param_retry(param_id)
 
@@ -760,6 +778,7 @@ class FanProtocolMixin:
             if try_bulk_read:
                 self._last_response_param_ids = None
                 self._last_unsupported_param_ids = None
+                self._last_invalid_response_param_ids = None
                 if self.send_command(self.func["read"], chunk, retries=3):
                     received_response = True
                     self._bulk_read_supported = True
@@ -771,6 +790,9 @@ class FanProtocolMixin:
                         continue
                     response_ids = set(response_ids or ()) & chunk_param_ids
                     unsupported_ids = set(unsupported_ids or ()) & chunk_param_ids
+                    invalid_ids = set(
+                        self._last_invalid_response_param_ids or ()
+                    ) & chunk_param_ids
                     received_params.update(response_ids)
                     for param_id in response_ids:
                         self._mark_param_available_for_retry(param_id)
@@ -779,10 +801,13 @@ class FanProtocolMixin:
                         if param_id not in required_param_ids:
                             self._unsupported_optional_poll_param_ids().add(param_id)
                         mark_unavailable(param_id, unsupported=True)
+                    for param_id in invalid_ids:
+                        mark_unavailable(param_id, invalid=True)
                     missing = [
                         param
                         for param in missing
-                        if int(param, 16) not in response_ids | unsupported_ids
+                        if int(param, 16)
+                        not in response_ids | unsupported_ids | invalid_ids
                     ]
                     if missing:
                         bulk_gap_params.update(int(param, 16) for param in missing)
@@ -821,12 +846,16 @@ class FanProtocolMixin:
 
                 self._last_response_param_ids = None
                 self._last_unsupported_param_ids = None
+                self._last_invalid_response_param_ids = None
                 individual_retry_params.add(param_id)
                 param_complete = self.send_command(
                     self.func["read"], param, retries=1
                 )
                 response_ids = self._last_response_param_ids
                 unsupported_ids = set(self._last_unsupported_param_ids or ())
+                invalid_response = param_id in set(
+                    self._last_invalid_response_param_ids or ()
+                )
                 received_response = param_complete or received_response
                 if param_complete and param_id in unsupported_ids:
                     unsupported_params.add(param_id)
@@ -844,7 +873,7 @@ class FanProtocolMixin:
                     no_response_params.add(param_id)
                     # Vento can transiently omit its control rows. Keep their
                     # values and retry next poll; other probes retain backoff.
-                    mark_unavailable(param_id)
+                    mark_unavailable(param_id, invalid=invalid_response)
                     if param_id not in required_param_ids:
                         _LOGGER.debug(
                             "EcoVent optional parameter 0x%04X did not respond "

--- a/custom_components/ecovent_v2/fan_speed_properties.py
+++ b/custom_components/ecovent_v2/fan_speed_properties.py
@@ -255,12 +255,10 @@ class FanSpeedPropertiesMixin:
             "breezy": 4,
             "freshbox": 4,
         }.get(self.profile_key)
-        # Captured TwinFresh Style 0x0E00 / 0.3 (2021-10-04) reports a
-        # four-byte minute/hour/u16-day value, unlike three-byte Vento timers.
-        if (
-            getattr(self, "_unit_type_id", None) == 0x0E00
-            and self.firmware == "0.3 2021-10-04"
-        ):
+        # TwinFresh Style 0x0E00 uses a four-byte minute/hour/u16-day value,
+        # unlike three-byte Vento timers. Extend the captured 0.3 format to
+        # this model's newer firmware; see protocol.md for the evidence limit.
+        if getattr(self, "_unit_type_id", None) == 0x0E00:
             expected_size = 4
         if (
             getattr(self, "_unit_type_id", None) is not None

--- a/protocol.md
+++ b/protocol.md
@@ -336,21 +336,40 @@ accounting and transport commands share the lock so concurrent writes cannot
 replace a poll response before its parameter IDs are consumed.
 
 A captured TwinFresh Style Wi-Fi (`0x0E00`, firmware `0.3 2021-10-04`) returns
-a four-byte `0x0064`: minute, hour, then little-endian 16-bit days. This exact
-variant uses the existing four-byte decoder with minute/hour bounds and a
-365-day limit; other Vento variants retain their three-byte requirement.
+a four-byte `0x0064`: minute, hour, then little-endian 16-bit days. Issue #101
+reports the same model's firmware `0.5 2024-07-10` responding with that row;
+until its raw capture arrives, accepting it is an evidence-backed format
+inference rather than a second physical capture. This model variant uses the
+four-byte decoder with minute/hour bounds and a 365-day limit; other Vento
+variants retain their three-byte requirement. A soft omission preserves a
+previously decoded filter countdown, but an explicit unsupported or malformed
+row clears it.
 Initialization reads firmware before the first full poll. The captured full/quick
 cycle is replayed by `tests/test_twinfresh_capture.py`; identity/IP values are
 redacted, and operational payload bytes are preserved.
-For the HA-visible regression, run `python tests/ha_issue100_smoke.py` in an
-environment with Home Assistant installed (validated with `2026.6.0.dev0`).
-The harness uses real coordinator updates, entity listeners, and the HA state
-machine with captured values and controlled omissions. Each of the three control
-rows is checked across 26 accelerated cycles with bulk and individual recovery.
-It also checks failed command confirmation, offline recovery, empty/unrelated
-replies, wrong device IDs, invalid checksums, malformed controls, and explicit
-rejections. No network traffic is sent. Schedule and Repairs side effects are
-excluded from this focused test.
+
+Schedule cache reads use the documented day/period selector for all four slots.
+Only a complete, validated day replaces its cache entry. An incomplete day keeps
+the prior complete entry (or remains unavailable when none exists) and retries on
+the normal ten-update cadence, including when the weekly schedule is off.
+For HA-visible regressions, run `python tests/ha_issue100_smoke.py` and
+`python tests/ha_issues101_102_smoke.py` in an environment with Home Assistant
+installed (validated with `2026.6.0.dev0`). The latter replays the captured
+four-byte countdown under the reported 0.5 identity through production polling
+and HA entities. It checks cold-start recovery, twelve consecutive soft-missing
+full polls, bounded individual retries, and malformed/unsupported invalidation.
+Each schedule slot is omitted in turn: an empty cache retries only at updates
+10 and 20, recovers all seven days, and retains complete days through later
+partial reads. Neither harness sends network traffic. The latter accepts
+`--source-root /path/to/checkout --case firmware|filter|schedule` for full-source
+baseline comparisons; all three cases fail against unmodified `495ccd0`.
+The issue #100 harness uses real coordinator updates, entity listeners, and the
+HA state machine with captured values and controlled omissions. Each of the three
+control rows is checked across 26 accelerated cycles with bulk and individual
+recovery. It also checks failed command confirmation, offline recovery,
+empty/unrelated replies, wrong device IDs, invalid checksums, malformed controls,
+and explicit rejections. Schedule and Repairs side effects are excluded from this
+focused test.
 
 `python tests/ha_issue100_smoke.py --baseline b72970a` substitutes the old polling
 handlers for comparison. With state/speed absent from bulk replies, the old

--- a/tests/ha_issues101_102_smoke.py
+++ b/tests/ha_issues101_102_smoke.py
@@ -1,0 +1,307 @@
+"""Replay filter and schedule failures through production polling and HA states.
+
+Run with Home Assistant installed:
+    python tests/ha_issues101_102_smoke.py
+    python tests/ha_issues101_102_smoke.py --source-root /path/to/baseline --case schedule
+
+The 0.5 identity is applied to the captured 0.3 TwinFresh frame format, not a
+second physical capture. Only the wire is simulated; production encoding,
+parsing, retries, coordinator updates, entity listeners and HA serialization
+remain active. Cycles are accelerated, not a wall-clock soak. No sockets or
+device writes are allowed. Repairs are outside this focused test.
+"""
+
+import argparse
+import asyncio
+import importlib
+import json
+import logging
+from pathlib import Path
+import sys
+import tempfile
+import types
+
+from ecovent_test_helpers import packet_with_payload
+from ha_issue100_smoke import Wire
+from homeassistant.const import __version__
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers import device_registry, entity_registry
+from homeassistant.helpers.entity_component import EntityComponent
+
+
+class ScheduleWire(Wire):
+    """Extend the captured poll fixture with selector-addressed schedule rows."""
+
+    def __init__(self, fan):
+        super().__init__(fan)
+        self.values[0x0072] = b"\x00"
+        self.missing_period = None
+        self.schedule_calls = []
+        self.first_end_hour = 6
+
+    def send(self, data):
+        assert data[:2] == self.fan.func["read"], "unexpected device write"
+        raw = bytes.fromhex(data[2:])
+        page, size, pos = 0, 1, 0
+        ids, payload = [], bytearray()
+        while pos < len(raw):
+            code = raw[pos]
+            pos += 1
+            if code == 0xFF:
+                page = raw[pos]
+                pos += 1
+                continue
+            if code == 0xFE:
+                size = raw[pos]
+                pos += 1
+                continue
+            pid = page * 256 + code
+            ids.append(pid)
+            if pid == 0x0077:
+                assert size == 2
+                day, period = raw[pos : pos + size]
+                pos += size
+                self.schedule_calls.append((day, period))
+                value = bytes(
+                    [
+                        day,
+                        period,
+                        1,
+                        15,
+                        0,
+                        {1: self.first_end_hour, 2: 9, 3: 19, 4: 0}[period],
+                    ]
+                )
+                if period == self.missing_period:
+                    size = 1
+                    continue
+            else:
+                assert size == 1, "unexpected read selector"
+                value = self.values.get(pid)
+            size = 1
+            if pid in self.omit or (len(raw) > 1 and pid in self.bulk_omit):
+                continue
+            if pid in self.reject:
+                payload.extend([0xFF, page, 0xFD, code])
+            elif value is not None:
+                payload.extend([0xFF, page])
+                if len(value) > 1:
+                    payload.extend([0xFE, len(value)])
+                payload.append(code)
+                payload.extend(value)
+        self.calls.append(ids)
+        self.pending = (
+            packet_with_payload(payload, device_id=self.fan.id.encode())
+            if payload
+            else False
+        )
+        return not self.offline
+
+
+def sensor_for_method(module, hass, entry, method):
+    spec = next(spec for spec in module.SENSOR_SPECS if spec.method == method)
+    return module.VentoSensor(
+        hass,
+        entry,
+        spec.key,
+        spec.name,
+        spec.method,
+        spec.native_unit_of_measurement,
+        spec.device_class,
+        spec.state_class,
+        spec.entity_category,
+        spec.enable_by_default,
+        spec.icon,
+        translation_key=spec.translation_key,
+        suggested_display_precision=spec.suggested_display_precision,
+    )
+
+
+async def run_case(source_root, case, missing_period=None, cold_filter=False):
+    package = types.ModuleType("issues101_102_ecovent")
+    package.__path__ = [str(source_root / "custom_components/ecovent_v2")]
+    sys.modules[package.__name__] = package
+    coordinator_type = importlib.import_module(
+        package.__name__ + ".coordinator"
+    ).EcoVentCoordinator
+    sensors = importlib.import_module(package.__name__ + ".sensor")
+
+    with tempfile.TemporaryDirectory(prefix="ecovent-ha-101-102-") as tmp:
+        hass = HomeAssistant(tmp)
+        entry = types.SimpleNamespace(
+            data={
+                "ip_address": "192.0.2.1",
+                "password": "1111",
+                "name": "Issue 101/102 audit",
+                "auto_clock_sync": False,
+            },
+            unique_id=None,
+            entry_id="issues101_102",
+            async_on_unload=lambda _: None,
+            pref_disable_polling=True,
+        )
+        device_registry.async_setup(hass)
+        await device_registry.async_load(hass)
+        await entity_registry.async_load(hass)
+        co = coordinator_type(hass, entry)
+        fan = co._fan
+        wire = ScheduleWire(fan)
+        fan.send, fan.receive = wire.send, wire.receive
+        co._update_hardware_profile_mismatch_repair_issue = lambda: None
+        if case == "firmware":
+            wire.values[0x0086] = bytes.fromhex("00050a07e807")
+        if case == "schedule":
+            wire.missing_period = missing_period
+        if cold_filter:
+            wire.omit.add(0x0064)
+        await co.async_refresh()
+        assert co.last_update_success, co.last_exception
+        hass.data["ecovent_v2"] = {entry.entry_id: co}
+        countdown = sensor_for_method(sensors, hass, entry, "filter_timer_countdown")
+        remaining = sensor_for_method(sensors, hass, entry, "filter_remaining")
+        schedule = sensors.WeeklyScheduleSummarySensor(hass, entry)
+        component = EntityComponent(logging.getLogger(__name__), "sensor", hass)
+        await component.async_add_entities([countdown, remaining, schedule])
+        await hass.async_block_till_done()
+
+        def state(entity):
+            return hass.states.get(entity.entity_id).state
+
+        async def refresh(full=False):
+            if full:
+                co.updateCounter = 3
+            wire.calls.clear()
+            wire.schedule_calls.clear()
+            await co.async_refresh()
+            await hass.async_block_till_done()
+            assert co.last_update_success, co.last_exception
+
+        async def targeted_filter():
+            await hass.async_add_executor_job(fan.get_param, "filter_timer_countdown")
+            co.async_update_listeners()
+            await hass.async_block_till_done()
+
+        if case == "schedule":
+            assert not co._weekly_schedule
+            schedule_refreshes = []
+            for counter in range(2, 22):
+                if counter == 11:
+                    wire.missing_period = None
+                await refresh()
+                assert co.updateCounter == counter
+                if wire.schedule_calls:
+                    schedule_refreshes.append(counter)
+                assert bool(wire.schedule_calls) == (counter in (10, 20)), (
+                    "unbounded or missing schedule retry",
+                    counter,
+                    wire.schedule_calls,
+                )
+                lengths = [
+                    len(day["periods"])
+                    for day in hass.states.get(schedule.entity_id).attributes["days"]
+                ]
+                assert lengths == ([0] * 7 if counter < 20 else [4] * 7), lengths
+            assert state(schedule) == "Disabled"
+            cached = hass.states.get(schedule.entity_id).attributes["days"]
+            wire.missing_period = missing_period
+            wire.values[0x0072] = b"\x01"
+            wire.first_end_hour = 7
+            co.updateCounter = 29
+            await refresh()
+            assert wire.schedule_calls
+            assert hass.states.get(schedule.entity_id).attributes["days"] == cached
+            wire.missing_period = None
+            co.updateCounter = 39
+            await refresh()
+            assert hass.states.get(schedule.entity_id).attributes["days"] != cached
+            assert len(co._weekly_schedule) == 7
+            result = {
+                "missing_period": missing_period,
+                "cold_retry_cycles": schedule_refreshes,
+                "recovered_days": len(co._weekly_schedule),
+            }
+        else:
+            if cold_filter:
+                assert state(countdown) == state(remaining) == "unknown"
+                wire.omit.clear()
+                for _ in range(12):
+                    await refresh(full=True)
+                    if state(countdown) != "unknown":
+                        break
+            initial = state(countdown), state(remaining)
+            assert all(value not in ("unknown", "unavailable") for value in initial), (
+                initial
+            )
+            assert (
+                hass.states.get(remaining.entity_id).attributes["unit_of_measurement"]
+                == "%"
+            )
+            wire.omit.add(0x0064)
+            wire.bulk_omit.add(0x0064)
+            retry_cycles = []
+            for cycle in range(12):
+                await refresh(full=True)
+                assert (state(countdown), state(remaining)) == initial
+                if [0x0064] in wire.calls:
+                    retry_cycles.append(cycle)
+            assert 1 <= len(retry_cycles) <= 2, retry_cycles
+            wire.omit.clear()
+            wire.values[0x0064] = bytes.fromhex("00009600")
+            for recovery_cycle in range(12):
+                await refresh(full=True)
+                if state(countdown) != initial[0]:
+                    break
+            assert state(countdown) not in (initial[0], "unknown", "unavailable")
+            wire.bulk_omit.clear()
+            wire.values[0x0064] = b"\x01\x02"
+            await refresh(full=True)
+            assert state(countdown) == state(remaining) == "unknown"
+            wire.values[0x0064] = bytes.fromhex("00009600")
+            await targeted_filter()
+            assert state(countdown) not in ("unknown", "unavailable")
+            wire.values[0x0064] = b"\x01\x02"
+            await targeted_filter()
+            assert state(countdown) == state(remaining) == "unknown"
+            wire.values[0x0064] = bytes.fromhex("00009600")
+            await targeted_filter()
+            wire.reject.add(0x0064)
+            await refresh(full=True)
+            assert state(countdown) == state(remaining) == "unknown"
+            assert 0x0064 in fan.unsupported_optional_poll_parameter_ids()
+            result = {
+                "cold_start": cold_filter,
+                "initial": initial,
+                "omission_cycles": 12,
+                "targeted_retry_cycles": retry_cycles,
+                "recovery_cycle": recovery_cycle,
+            }
+
+        assert fan.audible_write_command_count == 0
+        print(
+            json.dumps({"ha": __version__, "case": case, **result, "device_writes": 0})
+        )
+        await co.async_shutdown()
+        await hass.async_stop()
+
+
+async def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--source-root", type=Path, default=Path(__file__).resolve().parents[1]
+    )
+    parser.add_argument(
+        "--case", choices=("all", "firmware", "filter", "schedule"), default="all"
+    )
+    args = parser.parse_args()
+    if args.case in ("all", "firmware"):
+        await run_case(args.source_root, "firmware")
+    if args.case in ("all", "filter"):
+        for cold in (False, True):
+            await run_case(args.source_root, "filter", cold_filter=cold)
+    if args.case in ("all", "schedule"):
+        for period in range(1, 5):
+            await run_case(args.source_root, "schedule", missing_period=period)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_ecovent_packets.py
+++ b/tests/test_ecovent_packets.py
@@ -76,7 +76,6 @@ class PacketBuilderTest(unittest.TestCase):
     def test_soft_miss_preservation_is_limited_to_vento_controls(self):
         for unit_type, param_id, attr in (
             ("0e00", 0x0025, "humidity"),
-            ("0e00", 0x0064, "filter_timer_countdown"),
             ("0200", 0x0001, "state"),
         ):
             with self.subTest(unit_type=unit_type, param=param_id):
@@ -100,6 +99,101 @@ class PacketBuilderTest(unittest.TestCase):
                 calls.clear()
                 self.assertTrue(fan._read_params(request, required_params=frozenset()))
                 self.assertEqual(calls, [request])
+
+    def test_filter_countdown_soft_miss_retains_only_a_known_valid_value(self):
+        recovered = False
+
+        def configure_soft_omission(fan, calls):
+            def send_command(func, param, value="", retries=10):
+                calls.append(param)
+                if len(param) > 4:
+                    if recovered:
+                        fan._filter_timer_countdown = "9d 0h 0m "
+                        fan._last_response_param_ids = {0x0002, 0x0064}
+                        return True
+                    fan._last_response_param_ids = {0x0002}
+                    return True
+                return False
+
+            fan.send_command = send_command
+
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0e00"
+        fan.filter_timer_countdown = "00000a00"
+        calls = []
+        configure_soft_omission(fan, calls)
+        self.assertTrue(fan._read_params("00640002", required_params=frozenset()))
+        self.assertEqual(fan.filter_timer_countdown, "10d 0h 0m ")
+        self.assertEqual(fan.last_missing_optional_params, {0x0064})
+
+        recovered = True
+        self.assertTrue(fan._read_params("00640002", required_params=frozenset()))
+        self.assertEqual(fan.filter_timer_countdown, "9d 0h 0m ")
+        self.assertFalse(fan.last_missing_optional_params)
+
+        recovered = False
+        absent = Fan("192.0.2.1")
+        absent.unit_type = "0e00"
+        configure_soft_omission(absent, [])
+        self.assertTrue(absent._read_params("00640002", required_params=frozenset()))
+        self.assertIsNone(absent.filter_timer_countdown)
+
+    def test_filter_countdown_explicit_invalid_or_unsupported_rows_clear_stale_value(self):
+        for payload in (
+            [0xFE, 0x04, 0x64, 0x00, 0x00, 0x6E, 0x01],
+            [0xFD, 0x64],
+        ):
+            with self.subTest(payload=payload):
+                fan = Fan("192.0.2.1")
+                fan.unit_type = "0e00"
+                fan.filter_timer_countdown = "00000a00"
+                fan.send = lambda _data: True
+                fan.receive = lambda payload=payload: packet_with_payload(payload)
+
+                self.assertFalse(fan._read_params("0064", required_params=frozenset()))
+                self.assertIsNone(fan.filter_timer_countdown)
+
+    def test_filter_countdown_cold_start_stays_unknown_and_recovers_after_backoff(self):
+        missing = packet_with_payload([0x02, 1])
+        recovered = packet_with_payload([0xFE, 4, 0x64, 0, 0, 9, 0])
+
+        cold = Fan("192.0.2.1")
+        cold.unit_type = "0e00"
+        cold.send = lambda _data: True
+        cold_responses = iter((missing, missing))
+        cold.receive = lambda: next(cold_responses)
+        self.assertTrue(cold._read_params("00640002", required_params=frozenset()))
+        self.assertIsNone(cold.filter_timer_countdown)
+
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0e00"
+        fan.filter_timer_countdown = "00000a00"
+        fan.send = lambda _data: True
+        responses = iter((missing, missing, *(missing for _ in range(10)), missing, recovered))
+        fan.receive = lambda: next(responses)
+
+        self.assertTrue(fan._read_params("00640002", required_params=frozenset()))
+        self.assertEqual(fan.filter_timer_countdown, "10d 0h 0m ")
+        self.assertEqual(fan._optional_read_backoff[0x0064], 10)
+        for remaining in range(9, -1, -1):
+            self.assertTrue(
+                fan._read_params("00640002", required_params=frozenset())
+            )
+            self.assertEqual(fan._optional_read_backoff.get(0x0064, 0), remaining)
+
+        self.assertTrue(fan._read_params("00640002", required_params=frozenset()))
+        self.assertEqual(fan.filter_timer_countdown, "9d 0h 0m ")
+        self.assertFalse(fan.last_missing_optional_params)
+
+    def test_targeted_invalid_filter_countdown_clears_stale_value(self):
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0e00"
+        fan.filter_timer_countdown = "00000a00"
+        fan.send = lambda _data: True
+        fan.receive = lambda: packet_with_payload([0xFE, 4, 0x64, 0, 0, 0x6E, 1])
+
+        self.assertFalse(fan.get_param("filter_timer_countdown"))
+        self.assertIsNone(fan.filter_timer_countdown)
 
     def test_targeted_rejection_clears_retained_controls(self):
         fan = Fan("192.0.2.1")
@@ -281,6 +375,35 @@ class PacketBuilderTest(unittest.TestCase):
         record = fan.read_weekly_schedule_record(1, 1)
         self.assertIsNotNone(record)
         self.assertEqual((record.day, record.period), (1, 1))
+
+    def test_schedule_day_reads_each_documented_period_selector(self):
+        fan = Fan("192.0.2.1")
+        sent = []
+        responses = iter(
+            [
+                packet_with_payload(
+                    [0xFE, 0x06, 0x77, 0x01, period, 0x01, 0x00, 0x00, end]
+                )
+                for period, end in ((1, 6), (2, 12), (3, 18), (4, 0))
+            ]
+        )
+        fan.send = lambda data: sent.append(data) or True
+        fan.receive = lambda: next(responses)
+
+        records = fan.read_weekly_schedule_day(1)
+
+        self.assertEqual(set(records), {1, 2, 3, 4})
+        self.assertEqual(
+            sent,
+            [
+                fan.func["read"] + fan.encode_params("0077", f"01{period:02x}")
+                for period in range(1, 5)
+            ],
+        )
+        self.assertEqual(
+            [(record.day, record.period) for record in records.values()],
+            [(1, period) for period in range(1, 5)],
+        )
 
     def test_schedule_read_learns_only_explicit_unsupported_response(self):
         fan = Fan("192.0.2.1")

--- a/tests/test_ecovent_parsing.py
+++ b/tests/test_ecovent_parsing.py
@@ -318,10 +318,10 @@ class ParseRobustnessTest(unittest.TestCase):
         )
         self.assertEqual(fan.filter_timer_countdown, "72d 8h 17m ")
 
-    def test_twinfresh_style_captured_filter_timer_variant(self):
+    def test_twinfresh_style_filter_timer_variant_is_firmware_independent(self):
         for unit, firmware, valid in (
             ("0e00", "0003040ae507", True),
-            ("0e00", "0004040ae507", False),
+            ("0e00", "0005040ae507", True),
             ("0500", "0003040ae507", False),
         ):
             with self.subTest(unit=unit, firmware=firmware):

--- a/tests/test_ecovent_sensor_helpers.py
+++ b/tests/test_ecovent_sensor_helpers.py
@@ -1,9 +1,36 @@
 """Regression tests for Home Assistant sensor helper behavior."""
 
+import ast
+import re
 import unittest
+import types
 
 from ecovent_test_helpers import COMPONENT_PATH  # noqa: F401  Ensures sys.path setup.
 from sensor_helpers import enum_options_with_value
+
+
+SENSOR_PATH = COMPONENT_PATH / "sensor.py"
+
+
+def _function(tree, name):
+    return next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
+
+
+def _class_method(tree, name):
+    sensor_class = next(
+        node
+        for node in tree.body
+        if isinstance(node, ast.ClassDef) and node.name == "VentoSensor"
+    )
+    return next(
+        node
+        for node in sensor_class.body
+        if isinstance(node, ast.FunctionDef) and node.name == name
+    )
 
 
 class SensorEnumOptionsTest(unittest.TestCase):
@@ -21,6 +48,36 @@ class SensorEnumOptionsTest(unittest.TestCase):
 
     def test_preserves_non_enum_without_options(self):
         self.assertIsNone(enum_options_with_value(None, "Unknown beeper 3"))
+
+    def test_filter_remaining_uses_the_decoded_filter_countdown(self):
+        tree = ast.parse(SENSOR_PATH.read_text())
+        nodes = [
+            _function(tree, "_parse_hours"),
+            _function(tree, "_parse_days"),
+            _class_method(tree, "filter_timer_countdown"),
+            _class_method(tree, "filter_remaining"),
+        ]
+        namespace = {"re": re}
+        exec(
+            compile(
+                ast.fix_missing_locations(ast.Module(body=nodes, type_ignores=[])),
+                str(SENSOR_PATH),
+                "exec",
+            ),
+            namespace,
+        )
+        sensor_instance = types.SimpleNamespace(
+            _fan=types.SimpleNamespace(
+                filter_timer_countdown="90d 0h 0m ",
+                filter_timer_setpoint="180 d",
+            )
+        )
+        sensor_instance.filter_timer_countdown = types.MethodType(
+            namespace["filter_timer_countdown"], sensor_instance
+        )
+
+        self.assertEqual(sensor_instance.filter_timer_countdown(), 2160.0)
+        self.assertEqual(namespace["filter_remaining"](sensor_instance), 50)
 
 
 if __name__ == "__main__":

--- a/tests/test_issue16_regressions.py
+++ b/tests/test_issue16_regressions.py
@@ -29,21 +29,68 @@ def _class_method(tree, class_name, method_name):
 
 
 class Issue16RegressionTest(unittest.TestCase):
-    def test_weekly_schedule_polling_keeps_editor_cache_warm_when_disabled(self):
+    def test_schedule_refresh_is_bounded_for_empty_or_partial_off_cache(self):
         source = COORDINATOR_PATH.read_text()
         tree = ast.parse(source)
         should_refresh = _class_method(
             tree, "EcoVentCoordinator", "_should_refresh_schedule_week"
         )
         post_init = _class_method(tree, "EcoVentCoordinator", "_async_post_init_setup")
-        should_refresh_source = ast.get_source_segment(source, should_refresh)
+        namespace = {
+            "_LOGGER": logging.getLogger(__name__),
+            "SCHEDULE_DAY_LABELS": {day: str(day) for day in range(1, 8)},
+        }
+        exec(
+            compile(
+                ast.fix_missing_locations(
+                    ast.Module(body=[should_refresh], type_ignores=[])
+                ),
+                str(COORDINATOR_PATH),
+                "exec",
+            ),
+            namespace,
+        )
 
-        self.assertIn("not self._weekly_schedule", should_refresh_source)
-        self.assertIn("state = self._fan.weekly_schedule_state", should_refresh_source)
-        self.assertIn('state not in ("on", "off")', should_refresh_source)
-        self.assertIn('state == "on"', should_refresh_source)
-        self.assertIn("self.updateCounter % 10 == 0", should_refresh_source)
-        self.assertIn("profile_supports_parameter", should_refresh_source)
+        class Fan:
+            weekly_schedule_state = "off"
+
+            def profile_supports_parameter(self, _name):
+                return True
+
+            supports_parameter = profile_supports_parameter
+
+        coordinator = types.SimpleNamespace(
+            _fan=Fan(), _weekly_schedule={}, updateCounter=0
+        )
+        should_refresh_week = namespace["_should_refresh_schedule_week"]
+
+        self.assertTrue(should_refresh_week(coordinator))
+        coordinator.updateCounter = 1
+        self.assertFalse(should_refresh_week(coordinator))
+        coordinator.updateCounter = 10
+        self.assertTrue(should_refresh_week(coordinator))
+
+        coordinator._weekly_schedule = {
+            1: {period: object() for period in range(1, 5)}
+        }
+        coordinator.updateCounter = 1
+        self.assertFalse(should_refresh_week(coordinator))
+        coordinator.updateCounter = 10
+        self.assertTrue(should_refresh_week(coordinator))
+
+        coordinator._weekly_schedule = {
+            day: {period: object() for period in range(1, 5)}
+            for day in range(1, 8)
+        }
+        coordinator._weekly_schedule[1].pop(4)
+        coordinator.updateCounter = 10
+        self.assertTrue(should_refresh_week(coordinator))
+
+        coordinator._weekly_schedule[1][4] = object()
+        self.assertFalse(should_refresh_week(coordinator))
+        coordinator._fan.weekly_schedule_state = "on"
+        self.assertTrue(should_refresh_week(coordinator))
+
         self.assertTrue(
             any(
                 isinstance(node, ast.Attribute)
@@ -139,7 +186,7 @@ class Issue16RegressionTest(unittest.TestCase):
             "_load_schedule_days",
         )
         namespace = {
-            "_LOGGER": types.SimpleNamespace(warning=lambda *_args: None),
+            "_LOGGER": types.SimpleNamespace(debug=lambda *_args: None),
             "validate_schedule_day": lambda _records: None,
         }
         exec(

--- a/tests/test_twinfresh_capture.py
+++ b/tests/test_twinfresh_capture.py
@@ -13,6 +13,29 @@ from ecovent_test_helpers import Fan, packet_with_payload
 
 
 class TwinFreshCaptureTest(unittest.TestCase):
+    def test_reported_firmware_05_accepts_the_captured_filter_frame(self):
+        """Apply the #101 identity to the physical 0.3 frame format replay."""
+        capture = json.loads(
+            (Path(__file__).parent / "fixtures/twinfresh_style_wifi_poll_capture.json").read_text()
+        )
+        filter_transaction = next(
+            transaction
+            for transaction in capture["polls"][0]["transactions"]
+            if transaction["request"] == "0064"
+        )
+        frame = filter_transaction["frames"][0]
+
+        fan = Fan("192.0.2.1")
+        fan.unit_type = "0e00"
+        fan.firmware = "00050a07e807"
+        fan.send = lambda _data: True
+        fan.receive = lambda: packet_with_payload(bytes.fromhex(frame["payload"]))
+
+        self.assertTrue(fan._read_params("0064", required_params=frozenset()))
+        self.assertEqual(fan.filter_timer_countdown, "151d 11h 36m ")
+        self.assertFalse(fan.last_missing_optional_params)
+        self.assertNotIn(0x0064, fan._optional_param_backoff())
+
     def test_full_and_quick_polls_match_recorded_hardware(self):
         capture = json.loads(
             (Path(__file__).parent / "fixtures/twinfresh_style_wifi_poll_capture.json").read_text()


### PR DESCRIPTION
## Summary

Fixes the permanently unknown TwinFresh filter countdown and the repeated incomplete-schedule warnings introduced in 1.2.28.

Closes gody01/ecovent_v2#101
Closes gody01/ecovent_v2#102

### Filter readings

- The four-byte `0x0064` decoder was restricted to `0x0E00` firmware `0.3 2021-10-04`. Apply it to the TwinFresh Style model instead of that one firmware string; other Vento variants retain their three-byte validation.
- Preserve a previously decoded countdown through soft omissions, with bounded individual retries. Initial missing values stay unknown, and malformed or explicitly unsupported replies clear the old reading, including targeted reads.
- Carry the transaction's invalid-row result into the polling path so an answered-but-invalid row cannot be treated as a harmless omission.

### Weekly schedules

- Retry an empty or incomplete week every ten coordinator updates, including while the schedule is disabled. An empty cache no longer triggers a full weekly read on every poll.
- Keep a previously complete day when a refresh is partial or invalid. Do not invent a missing period or expose a partial day as a complete editable schedule.
- Log tolerated failures at DEBUG with the actual received/missing slot numbers and accurate wording for an empty cache.

## Validation

- `PYTHONPATH=custom_components/ecovent_v2:tests pytest -q`: 434 tests and 335 subtests passed.
- Ruff, compileall and `git diff --check` passed.
- `tests/ha_issues101_102_smoke.py` uses production encoding, parsing, retries, coordinator updates, entities and HA states with a simulated wire. It covers the reported firmware identity, cold-start recovery, twelve consecutive soft-missing full polls, bounded retries, malformed/unsupported rows, omission of each of the four schedule slots, cold-cache recovery and warm-cache preservation.
- The same harness against the complete unmodified `495ccd0` source fails all three separate firmware, filter-retention and schedule-retry cases. The existing `tests/ha_issue100_smoke.py` also passes all six recovery cases across 156 accelerated coordinator cycles, including its negative controls.
- Deployed the complete candidate on Home Assistant 2026.9.1 and tested a physical TwinFresh Style Wi-Fi (`0x0E00`, firmware `0.3 2021-10-04`). Both filter registers and all 28 schedule slots returned and decoded; HA exposes numeric filter sensors and the complete disabled weekly schedule. The direct device probes issued only read commands. A six-minute settled-state observation (25 samples at 15-second intervals) kept numeric filters, all 28 schedule periods and unchanged fan settings.

## Evidence Limits

The firmware-0.5 raw response offered in gody01/ecovent_v2#101 is not available yet. Its regression test applies the reported identity to the captured 0.3 frame format; model-level format compatibility is an inference, not a second physical capture.

The physical device returned all four periods during these reads. The three-period response in gody01/ecovent_v2#102 is tested with controlled omissions of each slot, not claimed as a naturally reproduced packet loss pattern. Raw data is still needed to explain why the reporter consistently loses one slot; this patch fixes the retry/logging loop without guessing its contents.
